### PR TITLE
PostCSS: Read custom property definitions from CSS file

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/postcss.config.js
+++ b/public_html/wp-content/plugins/pattern-creator/postcss.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	ident: 'postcss',
+	plugins: [
+		require( 'autoprefixer' )( { grid: true } ),
+		require( 'postcss-custom-properties' )( {
+			importFrom: './src/style.css',
+		} ),
+	],
+};

--- a/public_html/wp-content/plugins/pattern-creator/src/style.css
+++ b/public_html/wp-content/plugins/pattern-creator/src/style.css
@@ -1,5 +1,6 @@
 :root {
 	--default-font: sans-serif;
+	--default-line-height: 1.4;
 	--editor-font: sans-serif;
 	--default-font-size: 14px;
 	--editor-font-size: 18px;


### PR DESCRIPTION
Fixes #7 

The files as read by webpack/`MiniCSSExtractPlugin` don't share custom property definitions, so even though they're set as `:root` in the built CSS, the PostCSS process can't correctly add the fallbacks. To fix this, we tell PostCSS where to look for these properties, by adding a custom PostCSS config. I also swapped the order of PostCSS plugins so that the autoprefixer will run first, then the custom properties fallbacks will be added. Otherwise the IE11 grid rules were not getting the custom property fallbacks.

To test:

- Run `yarn workspace wporg-pattern-creator run start` or `build`
- Check the built files to see that any instance of a `var(--thing)` has a fallback above it, ex:

```
.block-pattern-creator__header {
	padding: 16px;
	padding: var(--grid-unit);
}
```
