### PR TITLE
Pattern Creator: Hook up pattern meta UI

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -64,8 +64,15 @@ function enqueue_assets() {
 		sprintf(
 			'var wporgBlockPattern = JSON.parse( decodeURIComponent( \'%s\' ) );',
 			rawurlencode( wp_json_encode( array(
-				'settings' => $settings,
-				'postId'   => get_the_ID(),
+				'settings'   => $settings,
+				'postId'     => get_the_ID(),
+				'categories' => get_terms(
+					'wporg-pattern-category',
+					array(
+						'hide_empty' => false,
+						'fields' => 'id=>name',
+					)
+				),
 			) ) )
 		),
 		'before'

--- a/public_html/wp-content/plugins/pattern-creator/src/components/inspector/settings.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/inspector/settings.js
@@ -3,13 +3,16 @@
  */
 import { PanelBody, PanelRow, SelectControl, TextControl, TextareaControl } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import usePostMeta from '../../store/hooks/use-post-meta';
+
 export default function Settings() {
 	const title = '';
-	const description = '';
-	const categories = '';
-	// const keywords = '';
-	// const viewportWidth = '';
 	const onChange = () => {};
+	const [ description, setDescription ] = usePostMeta( 'wpop_description', '' );
+	const [ viewportWidth, setViewportWidth ] = usePostMeta( 'wpop_viewport_width', '' );
 
 	return (
 		<>
@@ -22,10 +25,13 @@ export default function Settings() {
 					<TextControl label="Pattern Name" value={ title } onChange={ onChange } />
 				</PanelRow>
 				<PanelRow>
-					<TextareaControl label="Description" value={ description } onChange={ onChange } />
+					<TextareaControl label="Description" value={ description } onChange={ setDescription } />
 				</PanelRow>
 				<PanelRow>
-					<SelectControl label="Categories" value={ categories } onChange={ onChange } />
+					<SelectControl label="Categories" value={ '' } onChange={ onChange } />
+				</PanelRow>
+				<PanelRow>
+					<SelectControl label="Preview width" value={ viewportWidth } onChange={ setViewportWidth } />
 				</PanelRow>
 			</PanelBody>
 		</>

--- a/public_html/wp-content/plugins/pattern-creator/src/components/inspector/settings.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/inspector/settings.js
@@ -39,7 +39,16 @@ export default function Settings() {
 					options={ termList }
 					onChange={ setTerms }
 				/>
-				<SelectControl label="Preview width" value={ viewportWidth } onChange={ setViewportWidth } />
+				<SelectControl
+					label="Preview Width"
+					value={ viewportWidth }
+					onChange={ setViewportWidth }
+					options={ [
+						{ value: 800, label: 'Normal' },
+						{ value: 1100, label: 'Wide' },
+						{ value: 1400, label: 'Extra Wide' },
+					] }
+				/>
 			</PanelBody>
 		</>
 	);

--- a/public_html/wp-content/plugins/pattern-creator/src/components/inspector/settings.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/inspector/settings.js
@@ -7,12 +7,22 @@ import { PanelBody, PanelRow, SelectControl, TextControl, TextareaControl } from
  * Internal dependencies
  */
 import usePostMeta from '../../store/hooks/use-post-meta';
+import usePostTaxonomy from '../../store/hooks/use-post-taxonomy';
+
+// Map the terms from WordPress into options supported by SelectControl.
+const termList = Object.entries( wporgBlockPattern.categories ).map( ( [ value, label ] ) => ( {
+	value: Number( value ),
+	label: label,
+} ) );
 
 export default function Settings() {
 	const title = '';
 	const onChange = () => {};
 	const [ description, setDescription ] = usePostMeta( 'wpop_description', '' );
 	const [ viewportWidth, setViewportWidth ] = usePostMeta( 'wpop_viewport_width', '' );
+	// Double-destructured because the terms default to an array, but we will only have one category.
+	// Note: This slug should be the "REST base", not the taxonomy slug.
+	const [ [ term ], setTerms ] = usePostTaxonomy( 'pattern-categories' );
 
 	return (
 		<>
@@ -28,7 +38,12 @@ export default function Settings() {
 					<TextareaControl label="Description" value={ description } onChange={ setDescription } />
 				</PanelRow>
 				<PanelRow>
-					<SelectControl label="Categories" value={ '' } onChange={ onChange } />
+					<SelectControl
+						label="Pattern Categories"
+						value={ term }
+						options={ termList }
+						onChange={ setTerms }
+					/>
 				</PanelRow>
 				<PanelRow>
 					<SelectControl label="Preview width" value={ viewportWidth } onChange={ setViewportWidth } />

--- a/public_html/wp-content/plugins/pattern-creator/src/components/inspector/settings.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/inspector/settings.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { PanelBody, PanelRow, SelectControl, TextControl, TextareaControl } from '@wordpress/components';
+import { PanelBody, SelectControl, TextControl, TextareaControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -31,23 +31,15 @@ export default function Settings() {
 				<span>Info about saving a block pattern.</span>
 			</div>
 			<PanelBody title="My Block Settings" initialOpen={ true }>
-				<PanelRow>
-					<TextControl label="Pattern Name" value={ title } onChange={ onChange } />
-				</PanelRow>
-				<PanelRow>
-					<TextareaControl label="Description" value={ description } onChange={ setDescription } />
-				</PanelRow>
-				<PanelRow>
-					<SelectControl
-						label="Pattern Categories"
-						value={ term }
-						options={ termList }
-						onChange={ setTerms }
-					/>
-				</PanelRow>
-				<PanelRow>
-					<SelectControl label="Preview width" value={ viewportWidth } onChange={ setViewportWidth } />
-				</PanelRow>
+				<TextControl label="Pattern Name" value={ title } onChange={ onChange } />
+				<TextareaControl label="Description" value={ description } onChange={ setDescription } />
+				<SelectControl
+					label="Pattern Categories"
+					value={ term }
+					options={ termList }
+					onChange={ setTerms }
+				/>
+				<SelectControl label="Preview width" value={ viewportWidth } onChange={ setViewportWidth } />
 			</PanelBody>
 		</>
 	);

--- a/public_html/wp-content/plugins/pattern-creator/src/components/provider/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/provider/index.js
@@ -14,9 +14,9 @@ import { POST_TYPE } from '../../store/utils';
 
 export default function Provider( { blockEditorSettings, patternId, ...props } ) {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor( 'postType', POST_TYPE, { id: patternId } );
-	const { editBlockPattern } = useDispatch( 'wporg/block-pattern-creator' );
+	const { editBlockPatternId } = useDispatch( 'wporg/block-pattern-creator' );
 	useEffect( () => {
-		editBlockPattern( patternId );
+		editBlockPatternId( patternId );
 	}, [ patternId ] );
 
 	return (

--- a/public_html/wp-content/plugins/pattern-creator/src/store/actions.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { dispatch, select } from '@wordpress/data-controls';
+import { dispatch, select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -16,8 +16,8 @@ export function editBlockPattern( patternId ) {
  * Save a block pattern.
  */
 export function* saveBlockPattern() {
-	const patternId = yield select( MODULE_KEY, 'getEditingBlockPatternId' );
+	const patternId = yield select( MODULE_KEY ).getEditingBlockPatternId();
 
 	// @todo maybe check for errors?
-	yield dispatch( 'core', 'saveEditedEntityRecord', KIND, POST_TYPE, patternId );
+	yield dispatch( 'core' ).saveEditedEntityRecord( KIND, POST_TYPE, patternId );
 }

--- a/public_html/wp-content/plugins/pattern-creator/src/store/actions.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/actions.js
@@ -8,12 +8,20 @@ import { dispatch, select } from '@wordpress/data';
  */
 import { KIND, MODULE_KEY, POST_TYPE } from './utils';
 
-export function editBlockPattern( patternId ) {
+/**
+ * Set the ID of the block pattern which is being edited.
+ *
+ * @param {number} patternId
+ * @return {Object} Action object
+ */
+export function editBlockPatternId( patternId ) {
 	return { type: 'EDIT_BLOCK_PATTERN', value: patternId };
 }
 
 /**
  * Save a block pattern.
+ *
+ * @yield {Object} Action object
  */
 export function* saveBlockPattern() {
 	const patternId = yield select( MODULE_KEY ).getEditingBlockPatternId();

--- a/public_html/wp-content/plugins/pattern-creator/src/store/actions.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/actions.js
@@ -19,6 +19,21 @@ export function editBlockPatternId( patternId ) {
 }
 
 /**
+ * Set the ID of the block pattern which is being edited.
+ * Helper layer over `editEntityRecord`.
+ *
+ * @param {Object} edits   The edits.
+ * @param {Object} options Options for the edit.
+ * @param {boolean} options.undoIgnore Whether to ignore the edit in undo history or not.
+ * @yield {Object} Action object
+ */
+export function* editBlockPattern( edits, options = {} ) {
+	const patternId = yield select( MODULE_KEY ).getEditingBlockPatternId();
+
+	yield dispatch( 'core' ).editEntityRecord( KIND, POST_TYPE, patternId, edits, options );
+}
+
+/**
  * Save a block pattern.
  *
  * @yield {Object} Action object

--- a/public_html/wp-content/plugins/pattern-creator/src/store/hooks/use-post-meta.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/hooks/use-post-meta.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { KIND, MODULE_KEY, POST_TYPE } from '../utils';
+
+/**
+ * A hook to get and set a post meta value.
+ *
+ * @param {string} key          Meta key.
+ * @param {?*}     defaultValue A default value, if the key is not set.
+ *
+ * @return {Array<*,Function>} A pair of values: the current meta value and a callback to update this meta value.
+ */
+export default function usePostMeta( key, defaultValue = '' ) {
+	const patternId = useSelect( ( select ) => select( MODULE_KEY ).getEditingBlockPatternId() );
+
+	const metaValue = useSelect( ( select ) => {
+		const { meta = {} } = select( 'core' ).getEditedEntityRecord( KIND, POST_TYPE, patternId );
+		if ( ! meta ) {
+			return defaultValue;
+		}
+		return meta[ key ] || defaultValue;
+	} );
+
+	const { editEntityRecord } = useDispatch( 'core' );
+	const setMetaValue = ( value ) => {
+		editEntityRecord( KIND, POST_TYPE, patternId, {
+			meta: {
+				[ key ]: value,
+			},
+		} );
+	};
+
+	return [ metaValue, setMetaValue ];
+}

--- a/public_html/wp-content/plugins/pattern-creator/src/store/hooks/use-post-meta.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/hooks/use-post-meta.js
@@ -6,7 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { KIND, MODULE_KEY, POST_TYPE } from '../utils';
+import { MODULE_KEY } from '../utils';
 
 /**
  * A hook to get and set a post meta value.
@@ -20,16 +20,16 @@ export default function usePostMeta( key, defaultValue = '' ) {
 	const patternId = useSelect( ( select ) => select( MODULE_KEY ).getEditingBlockPatternId() );
 
 	const metaValue = useSelect( ( select ) => {
-		const { meta = {} } = select( 'core' ).getEditedEntityRecord( KIND, POST_TYPE, patternId );
+		const { meta = {} } = select( MODULE_KEY ).getEditedBlockPattern( patternId );
 		if ( ! meta ) {
 			return defaultValue;
 		}
 		return meta[ key ] || defaultValue;
 	} );
 
-	const { editEntityRecord } = useDispatch( 'core' );
+	const { editBlockPattern } = useDispatch( MODULE_KEY );
 	const setMetaValue = ( value ) => {
-		editEntityRecord( KIND, POST_TYPE, patternId, {
+		editBlockPattern( {
 			meta: {
 				[ key ]: value,
 			},

--- a/public_html/wp-content/plugins/pattern-creator/src/store/hooks/use-post-taxonomy.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/hooks/use-post-taxonomy.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { MODULE_KEY } from '../utils';
+
+/**
+ * A hook to get and set a post taxonomy value.
+ *
+ * @param {string} taxonomy Identifier for taxonomy to use. Should be the "REST base" name, not the tax slug.
+ *
+ * @return {Array<*,Function>} A pair of values: the current meta value and a callback to update this meta value.
+ */
+export default function usePostTaxonomy( taxonomy ) {
+	const patternId = useSelect( ( select ) => select( MODULE_KEY ).getEditingBlockPatternId() );
+
+	const taxValue = useSelect( ( select ) => {
+		const post = select( MODULE_KEY ).getEditedBlockPattern( patternId );
+		return post[ taxonomy ] || [];
+	} );
+
+	const { editBlockPattern } = useDispatch( MODULE_KEY );
+	const setTaxValue = ( value ) => {
+		if ( ! Array.isArray( value ) ) {
+			value = [ value ];
+		}
+		editBlockPattern( {
+			[ taxonomy ]: value.map( Number ),
+		} );
+	};
+
+	return [ taxValue, setTaxValue ];
+}

--- a/public_html/wp-content/plugins/pattern-creator/src/store/selectors.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/selectors.js
@@ -12,6 +12,10 @@ export function getEditingBlockPatternId( state ) {
 	return state.currentPatternId;
 }
 
+export const getEditedBlockPattern = createRegistrySelector( ( select ) => ( state, patternId ) => {
+	return select( 'core' ).getEditedEntityRecord( KIND, POST_TYPE, patternId );
+} );
+
 export const hasEditsBlockPattern = createRegistrySelector( ( select ) => ( state, patternId ) => {
 	return select( 'core' ).hasEditsForEntityRecord( KIND, POST_TYPE, patternId );
 } );

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -32,7 +32,7 @@ function register_post_type_data() {
 			'public'        => true,
 			'hierarchical'  => true,
 			'show_in_rest'  => true,
-			'rest_base'     => 'category',
+			'rest_base'     => 'pattern-categories',
 		)
 	);
 


### PR DESCRIPTION
See #9 

The current pattern creator UI has some fields for description, viewport width, etc. This PR hooks those fields up with the backend meta, so they can be saved. This is still using the proof-of-concept UI, in a future PR we'll implement the design in https://github.com/WordPress/pattern-directory/issues/14

This hooks up the description & viewport to post meta, and the pattern category to the right taxonomy.

![Screen Shot 2020-11-10 at 6 14 47 PM](https://user-images.githubusercontent.com/541093/98747918-85a98000-2386-11eb-9621-0935b1362aca.png)

To test

- Run `yarn workspace wporg-pattern-creator run build`
- Create some pattern categories, ex Header, Buttons, Columns.
- If needed, create some Block Patterns in wp-admin, `/wp-admin/post-new.php?post_type=wporg-pattern`.
- View a published pattern, if you're logged in you should see the pattern editor.
- Play around & save your pattern, it should save.
- Change some meta (title isn't hooked up, everything else should work)
- Reload the page, view it in wp-admin, or the API — the meta should save.
