### PR TITLE
Add a "create a pattern" flow

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/settings/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/settings/index.js
@@ -8,6 +8,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import PublishHeader from './publish-header';
 import SaveButton from './save-button';
 import usePostMeta from '../../store/hooks/use-post-meta';
 import usePostTaxonomy from '../../store/hooks/use-post-taxonomy';
@@ -26,10 +27,14 @@ export default function Settings( { closeSidebar } ) {
 	// Double-destructured because the terms default to an array, but we will only have one category.
 	// Note: This slug should be the "REST base", not the taxonomy slug.
 	const [ [ term ], setTerms ] = usePostTaxonomy( 'pattern-categories' );
-	const post = useSelect( ( select ) => {
-		const { getEditingBlockPatternId, getEditedBlockPattern } = select( MODULE_KEY );
+	// Get the post as is currently saved (not edited).
+	const { hasEdits, post } = useSelect( ( select ) => {
+		const { getEditingBlockPatternId, getEditedBlockPattern, hasEditsBlockPattern } = select( MODULE_KEY );
 		const patternId = getEditingBlockPatternId();
-		return getEditedBlockPattern( patternId );
+		return {
+			hasEdits: hasEditsBlockPattern( patternId ),
+			post: getEditedBlockPattern( patternId ),
+		};
 	} );
 	const { editBlockPattern } = useDispatch( MODULE_KEY );
 	// @todo Maybe change these statii depending on any custom statuses in the process.
@@ -45,22 +50,7 @@ export default function Settings( { closeSidebar } ) {
 				</Button>
 			</div>
 			<div className="block-pattern-creator__settings-details">
-				{ isUnpublished ? (
-					<>
-						<h2>{ __( 'Are you ready to publish?', 'wporg-patterns' ) }</h2>
-						<p>
-							{ __(
-								'Name your pattern and write a short description before submitting.',
-								'wporg-patterns'
-							) }
-						</p>
-					</>
-				) : (
-					<>
-						<h2>{ __( 'Update your published pattern.', 'wporg-patterns' ) }</h2>
-						<p>{ __( 'Change your pattern details [copy tbd].', 'wporg-patterns' ) }</p>
-					</>
-				) }
+				<PublishHeader hasEdits={ hasEdits } />
 			</div>
 			<PanelBody title={ __( 'Details', 'wporg-patterns' ) } initialOpen>
 				<TextControl

--- a/public_html/wp-content/plugins/pattern-creator/src/components/settings/publish-header.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/settings/publish-header.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { MODULE_KEY } from '../../store/utils';
+
+export default function PublishHeader( { hasEdits } ) {
+	const isUnpublished = useSelect( ( select ) => {
+		const { getEditingBlockPatternId, getBlockPattern } = select( MODULE_KEY );
+		const post = getBlockPattern( getEditingBlockPatternId() );
+		return [ 'publish', 'private' ].indexOf( post.status ) === -1;
+	} );
+
+	if ( isUnpublished ) {
+		return (
+			<>
+				<h2>{ __( 'Are you ready to publish?', 'wporg-patterns' ) }</h2>
+				<p>
+					{ __(
+						'Name your pattern and write a short description before submitting.',
+						'wporg-patterns'
+					) }
+				</p>
+			</>
+		);
+	} else if ( hasEdits ) {
+		return (
+			<>
+				<h2>{ __( 'Update your published pattern.', 'wporg-patterns' ) }</h2>
+				<p>{ __( 'Change your pattern details [copy tbd].', 'wporg-patterns' ) }</p>
+			</>
+		);
+	}
+	return (
+		<>
+			<h2>{ __( 'Pattern Updated!', 'wporg-patterns' ) }</h2>
+			<p>{ __( 'Find your pattern on wp.org…', 'wporg-patterns' ) }</p>
+		</>
+	);
+}

--- a/public_html/wp-content/plugins/pattern-creator/view/editor.php
+++ b/public_html/wp-content/plugins/pattern-creator/view/editor.php
@@ -10,7 +10,7 @@ get_header();
 
 // @todo Permissions TBD, see https://github.com/WordPress/pattern-directory/issues/30.
 
-$post_type = get_post_type_object( POST_TYPE );
+$post_type_obj = get_post_type_object( POST_TYPE );
 
 if ( is_singular( POST_TYPE ) ) {
 	$page_title   = __( 'Update a Block Pattern', 'wporg-patterns' );
@@ -27,7 +27,7 @@ if ( is_singular( POST_TYPE ) ) {
 
 	<main id="main" class="site-main col-12" role="main">
 
-		<?php if ( ( is_singular( POST_TYPE ) && current_user_can( 'edit_post', get_the_ID() ) ) || current_user_can( $post_type->cap->create_posts ) ) : ?>
+		<?php if ( ( is_singular( POST_TYPE ) && current_user_can( 'edit_post', get_the_ID() ) ) || current_user_can( $post_type_obj->cap->create_posts ) ) : ?>
 			<div id="block-pattern-creator"></div>
 		<?php else : ?>
 			<section class="no-results not-found">

--- a/public_html/wp-content/plugins/pattern-creator/view/editor.php
+++ b/public_html/wp-content/plugins/pattern-creator/view/editor.php
@@ -3,12 +3,46 @@
  * Pattern Creator template.
  */
 
+namespace WordPressdotorg\Pattern_Creator;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+
 get_header();
+
+// @todo Permissions TBD, see https://github.com/WordPress/pattern-directory/issues/30.
+
+$post_type = get_post_type_object( POST_TYPE );
+
+if ( is_singular( POST_TYPE ) ) {
+	$page_title   = __( 'Update a Block Pattern', 'wporg-patterns' );
+	if ( ! is_user_logged_in() ) {
+		$page_content = __( 'You need to be logged in to edit this block pattern.', 'wporg-patterns' );
+	} else {
+		$page_content = __( "You need to be the pattern's author to edit this pattern.", 'wporg-patterns' );
+	}
+} else {
+	$page_title   = __( 'Submit a Block Pattern', 'wporg-patterns' );
+	$page_content = __( 'You need to be logged in to create a block pattern.', 'wporg-patterns' );
+}
 ?>
 
 	<main id="main" class="site-main col-12" role="main">
 
-		<div id="block-pattern-creator"></div>
+		<?php if ( ( is_singular( POST_TYPE ) && current_user_can( 'edit_post', get_the_ID() ) ) || current_user_can( $post_type->cap->create_posts ) ) : ?>
+			<div id="block-pattern-creator"></div>
+		<?php else : ?>
+			<section class="no-results not-found">
+				<header class="page-header">
+					<h1 class="page-title"><?php echo esc_html( $page_title ); ?></h1>
+				</header><!-- .page-header -->
+
+				<div class="page-content">
+					<p>
+						<?php echo esc_html( $page_content ); ?>
+						<a href="<?php echo esc_url( wp_login_url( get_permalink() ) ); ?>" rel="nofollow"><?php esc_html_e( 'Log in to WordPress.org.', 'wporg-patterns' ); ?></a>
+					</p>
+				</div>
+			</section>
+		<?php endif; ?>
 
 	</main><!-- #main -->
 


### PR DESCRIPTION
This is a very bare-bones attempt at a flow to create a new block pattern. It will let you create a new draft pattern, which you can edit and save.

**To test**

- Create a page with the slug `new-pattern` — this was the most straightforward way to set this up locally, but we could also use a page template
- Go to that page, you should have a page with an empty editor
- Enter some content, hit submit and publish
- View the patterns in wp-admin, your new pattern should show up
- Try as a logged out user, it should not let you create a pattern

⚠️  Things to follow up on (in new PRs)
- It only creates drafts - we need a validation step somewhere in here
- The Settings panel should be converted to use something like the PrePublish/PostPublish components, maybe? Something to give more feedback that the pattern was saved and is either being validated or is now available on wp.org.
