### PR TITLE
Pattern CPT: Add validation for the pattern metadata

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -108,7 +108,12 @@ function register_post_type_data() {
 			'default'           => '',
 			'sanitize_callback' => 'sanitize_text_field',
 			'auth_callback'     => __NAMESPACE__ . '\can_edit_this_pattern',
-			'show_in_rest'      => true,
+			'show_in_rest'      => array(
+				'schema' => array(
+					'maxLength' => 360,
+					'required'  => true,
+				),
+			),
 		)
 	);
 
@@ -119,10 +124,15 @@ function register_post_type_data() {
 			'type'              => 'number',
 			'description'       => 'The width of the pattern in the block inserter.',
 			'single'            => true,
-			'default'           => 0,
+			'default'           => 1200,
 			'sanitize_callback' => 'absint',
 			'auth_callback'     => __NAMESPACE__ . '\can_edit_this_pattern',
-			'show_in_rest'      => true,
+			'show_in_rest'      => array(
+				'schema' => array(
+					'minimum' => 400,
+					'maximum' => 2000,
+				),
+			),
 		)
 	);
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -10,6 +10,10 @@ add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_title', 1
  * Validate the pattern content.
  */
 function validate_content( $prepared_post, $request ) {
+	if ( is_wp_error( $prepared_post ) ) {
+		return $prepared_post;
+	}
+
 	$content = $prepared_post->post_content;
 	if ( ! $content ) {
 		return new \WP_Error(

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Test Block Pattern validation.
+ */
+
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+
+/**
+ * Test pattern validation.
+ */
+class Pattern_Title_Validation_Test extends WP_UnitTestCase {
+	protected static $pattern_id;
+	protected static $user;
+
+	/**
+	 * Setup fixtures that are shared across all tests.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$pattern_id = $factory->post->create(
+			array( 'post_type' => POST_TYPE )
+		);
+		self::$user = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Helper function to handle REST requests to save the pattern.
+	 */
+	protected function save_block( $args = array() ) {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request_args = wp_parse_args( $args, array(
+			'status' => 'publish',
+			'content' => "<!-- wp:paragraph -->\n<p>This is a block.</p>\n<!-- /wp:paragraph -->",
+		) );
+		$request->set_body( json_encode( $request_args ) );
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * Test valid pattern title: Add a new title.
+	 */
+	public function test_valid_create_title() {
+		wp_set_current_user( self::$user );
+		$response = $this->save_block( array( 'title' => 'Default Paragraph' ) );
+		$this->assertFalse( $response->is_error() );
+	}
+
+	/**
+	 * Test valid pattern title: empty title for a draft pattern.
+	 */
+	public function test_valid_empty_title_draft() {
+		wp_set_current_user( self::$user );
+		$response = $this->save_block( array(
+			'title' => '',
+			'status' => 'draft',
+		) );
+		$this->assertFalse( $response->is_error() );
+	}
+
+	/**
+	 * Test valid pattern title: the existing pattern already has a title.
+	 */
+	public function test_valid_title_already_set() {
+		wp_set_current_user( self::$user );
+		wp_update_post( array(
+			'ID' => self::$pattern_id,
+			'post_title' => 'Test Title',
+		) );
+		$response = $this->save_block();
+		$this->assertFalse( $response->is_error() );
+	}
+
+	/**
+	 * Test invalid pattern title: Published pattern, setting empty title.
+	 */
+	public function test_invalid_empty_new_title() {
+		wp_set_current_user( self::$user );
+		$response = $this->save_block( array(
+			'status' => 'publish',
+			'title' => '',
+		) );
+		$this->assertTrue( $response->is_error() );
+		$data = $response->get_data();
+		$this->assertSame( 'rest_pattern_empty_title', $data['code'] );
+	}
+
+	/**
+	 * Test invalid pattern title: Published pattern, has empty title with no new title.
+	 */
+	public function test_invalid_empty_existing_title() {
+		wp_set_current_user( self::$user );
+		wp_update_post( array(
+			'ID' => self::$pattern_id,
+			'post_title' => '',
+		) );
+		$response = $this->save_block();
+		$this->assertTrue( $response->is_error() );
+		$data = $response->get_data();
+		$this->assertSame( 'rest_pattern_empty_title', $data['code'] );
+	}
+}
+


### PR DESCRIPTION
This adds checks for the viewport, description, and pattern title.

See #22.

A pattern needs a title, but a draft can stay untitled, so the check for a title only applies if the pattern is or will be published. The viewport value should be between 800 - 2000 (this is arbitrary - the default is 1200 and probably shouldn't change for most patterns). The description has a max length of 360 characters. There's no minimum, since the default is an empty string, and nothing will break if there isn't a description.

**To test:**

Automated tests on this PR should pass.

- Edit a published pattern
- Try saving with an empty title
- It should error
- Add a title, and put too much content in the description
- It should error (new error)

You can also test by sending requests to `/wp-json/wp/v2/wporg-pattern/<ID>`
