### PR TITLE
Theme: Add live pattern preview to single pattern page

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -20,6 +20,7 @@
 @import "../../../wporg/css/components/widget-area";
 @import "../../../wporg/css/components/wporg-footer";
 @import "../../../wporg/css/components/wporg-header";
+@import "pattern-preview";
 @import "pattern";
 @import "search-form";
 @import "section-heading";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -20,7 +20,7 @@
 @import "../../../wporg/css/components/widget-area";
 @import "../../../wporg/css/components/wporg-footer";
 @import "../../../wporg/css/components/wporg-header";
-@import "pattern-creator";
+@import "pattern";
 @import "search-form";
 @import "section-heading";
 @import "site-title";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
@@ -1,11 +1,11 @@
 #wporg-pattern-container {
-	padding: 2rem 0;
+	padding: 2rem 0 0;
 	background: $color-gray-light-200;
 }
 
 .pattern-preview__viewport {
 	position: relative;
-	margin: 0 auto 2rem;
+	margin: 0 auto;
 	padding: 0 20px;
 	max-width: 100vw;
 	min-width: 320px;
@@ -59,17 +59,5 @@
 
 	&:focus {
 		box-shadow: 0 1px 0 #0073aa, 0 0 2px 1px #33b3db;
-	}
-}
-
-.pattern-preview__meta {
-	max-width: $size__site-main;
-	margin-left: auto;
-	margin-right: auto;
-	display: flex;
-	justify-content: space-between;
-
-	.pattern-preview__report {
-		text-align: right;
 	}
 }

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
@@ -16,6 +16,23 @@
 		vertical-align: middle;
 		max-width: 100vw;
 	}
+
+	&:focus-within .pattern-preview__resize-help {
+		clip: initial;
+		clip-path: initial;
+		height: initial;
+		margin: initial;
+		overflow: initial;
+		width: initial;
+		bottom: -1rem;
+		left: 20px;
+		right: 20px;
+		padding: 8px 16px;
+		background: $color-white;
+		border-radius: 2px;
+		border: 1px solid $color-gray-light-600;
+		text-align: center;
+	}
 }
 
 .pattern-preview__drag-handle {

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
@@ -62,8 +62,14 @@
 	}
 }
 
-.pattern-preview__categories {
+.pattern-preview__meta {
 	max-width: $size__site-main;
 	margin-left: auto;
 	margin-right: auto;
+	display: flex;
+	justify-content: space-between;
+
+	.pattern-preview__report {
+		text-align: right;
+	}
 }

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
@@ -1,4 +1,4 @@
-#wporg-pattern-container {
+.pattern-preview__container {
 	padding: 2rem 0 0;
 	background: $color-gray-light-200;
 }

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
@@ -1,0 +1,69 @@
+#wporg-pattern-container {
+	padding: 2rem 0;
+	background: $color-gray-light-200;
+}
+
+.pattern-preview__viewport {
+	position: relative;
+	margin: 0 auto 2rem;
+	padding: 0 20px;
+	max-width: 100vw;
+	min-width: 320px;
+
+	.pattern-preview__viewport-iframe {
+		background: $color-white;
+		border: 1px solid $color-gray-light-400;
+		vertical-align: middle;
+		max-width: 100vw;
+	}
+}
+
+.pattern-preview__drag-handle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 20px;
+}
+
+.pattern-preview__drag-handle.is-left {
+	left: 0;
+}
+
+.pattern-preview__drag-handle.is-right {
+	right: 0;
+}
+
+.pattern-preview__drag-handle-button {
+	$height: 100px;
+	position: absolute;
+	top: calc(50% - #{$height/2});
+	left: 6px;
+	padding: 0;
+	width: 8px;
+	height: $height;
+	appearance: none;
+	cursor: grab;
+	outline: none;
+	background: $color-gray-200;
+	border-radius: 99999px;
+	border: none;
+
+	&:hover {
+		background: $color-gray-300;
+	}
+
+	&:active {
+		cursor: grabbing;
+		background: $color-gray-400;
+	}
+
+	&:focus {
+		box-shadow: 0 1px 0 #0073aa, 0 0 2px 1px #33b3db;
+	}
+}
+
+.pattern-preview__categories {
+	max-width: $size__site-main;
+	margin-left: auto;
+	margin-right: auto;
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -37,18 +37,3 @@ body.single-wporg-pattern {
 		margin-right: auto;
 	}
 }
-
-#wporg-pattern-container {
-	position: relative;
-
-	&::before {
-		content: "";
-		background: $color-gray-light-200; //$color-white;
-		position: absolute;
-		z-index: -1;
-		top: 0;
-		bottom: 0;
-		left: calc(50% - 50vw);
-		width: 100vw;
-	}
-}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -36,4 +36,22 @@ body.single-wporg-pattern {
 		margin-left: auto;
 		margin-right: auto;
 	}
+
+	.pattern__meta {
+		padding: 2rem 0;
+		background: $color-gray-light-200;
+
+		> div {
+			max-width: $size__site-main;
+			margin-left: auto;
+			margin-right: auto;
+			display: flex;
+			justify-content: space-between;
+		}
+
+		.pattern-preview__report {
+			text-align: right;
+		}
+	}
+
 }

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -21,4 +21,34 @@ body.single-wporg-pattern {
 			line-height: 1.2;
 		}
 	}
+
+	.pattern-actions {
+		display: flex;
+		align-items: stretch;
+
+		button + button {
+			margin-left: 2em;
+		}
+	}
+
+	.entry-content {
+		max-width: $size__site-main;
+		margin-left: auto;
+		margin-right: auto;
+	}
+}
+
+#wporg-pattern-container {
+	position: relative;
+
+	&::before {
+		content: "";
+		background: $color-gray-light-200; //$color-white;
+		position: absolute;
+		z-index: -1;
+		top: 0;
+		bottom: 0;
+		left: calc(50% - 50vw);
+		width: 100vw;
+	}
 }

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -10,7 +10,15 @@ body.single-wporg-pattern {
 		padding: 0;
 	}
 
-	.site-main {
-		max-width: $size__wide-width;
+	.entry-header {
+		max-width: $size__site-main;
+		padding: 2rem 0;
+		margin-left: auto;
+		margin-right: auto;
+
+		.entry-title {
+			margin-top: 0;
+			line-height: 1.2;
+		}
 	}
 }

--- a/public_html/wp-content/themes/pattern-directory/css/settings/_colors.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/settings/_colors.scss
@@ -32,6 +32,9 @@ $color-gray-light-100: lighten($color-base-gray, 77%);
 $color-error-red: #c92c2c;
 $color-alert-red: #d94f4f;
 
+$color-black: #000;
+$color-white: #fff;
+
 $color-accent-blue-shade4: #006899;
 $color-accent-green-shade1: #399648;
 

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -48,6 +48,8 @@ function enqueue_assets() {
 			true
 		);
 
+		wp_enqueue_style( 'wp-components' );
+
 		wp_set_script_translations( 'wporg-pattern-script', 'wporg-patterns' );
 	}
 }

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -6,6 +6,7 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+add_action( 'wp_head', __NAMESPACE__ . '\generate_block_editor_styles_html' );
 
 /**
  * Sets up theme defaults and registers support for various WordPress features.
@@ -49,4 +50,50 @@ function enqueue_assets() {
 
 		wp_set_script_translations( 'wporg-pattern-script', 'wporg-patterns' );
 	}
+}
+
+/**
+ * Generate styles used in the block pattern preview iframe.
+ * See https://github.com/WordPress/gutenberg/blob/6ad2a433769a4514fc52083e97aa47a0bc9edf07/lib/client-assets.php#L710
+ */
+function generate_block_editor_styles_html() {
+	if ( ! is_singular( POST_TYPE ) ) {
+		return;
+	}
+
+	$handles = array(
+		'wp-block-editor',
+		'wp-block-library',
+		'wp-edit-blocks',
+	);
+
+	$block_registry = \WP_Block_Type_Registry::get_instance();
+
+	foreach ( $block_registry->get_all_registered() as $block_type ) {
+		if ( ! empty( $block_type->style ) ) {
+			$handles[] = $block_type->style;
+		}
+
+		if ( ! empty( $block_type->editor_style ) ) {
+			$handles[] = $block_type->editor_style;
+		}
+	}
+
+	$handles = array_unique( $handles );
+	$done    = wp_styles()->done;
+
+	ob_start();
+
+	wp_styles()->done = array();
+	wp_styles()->do_items( $handles );
+	wp_styles()->done = $done;
+
+	wp_add_inline_script(
+		'wporg-pattern-script',
+		sprintf(
+			'window.__editorStyles = JSON.parse( decodeURIComponent( \'%s\' ) );',
+			rawurlencode( wp_json_encode( array( 'html' => ob_get_clean() ) ) )
+		),
+		'before'
+	);
 }

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -27,6 +27,7 @@
 	"devDependencies": {
 		"@wordpress/block-editor": "5.3.0",
 		"@wordpress/browserslist-config": "3.0.1",
+		"@wordpress/components": "13.0.0",
 		"@wordpress/element": "2.20.0",
 		"@wordpress/scripts": "14.0.1",
 		"autoprefixer": "9.8.6",

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -38,8 +38,9 @@
 		"grunt-sass": "3.1.0",
 		"grunt-sass-globbing": "1.5.1",
 		"grunt-webpack": "4.0.2",
-		"sass": "1.32.8",
-		"pixrem": "5.0.0"
+		"pixrem": "5.0.0",
+		"react-use-gesture": "9.1.3",
+		"sass": "1.32.8"
 	},
 	"eslintConfig": {
 		"extends": "../../../../.eslintrc.js",

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -29,6 +29,8 @@
 		"@wordpress/browserslist-config": "3.0.1",
 		"@wordpress/components": "13.0.0",
 		"@wordpress/element": "2.20.0",
+		"@wordpress/i18n": "3.19.0",
+		"@wordpress/keycodes": "2.19.0",
 		"@wordpress/scripts": "14.0.1",
 		"autoprefixer": "9.8.6",
 		"cssnano": "4.1.10",

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -28,6 +28,7 @@
 		"@wordpress/block-editor": "5.3.0",
 		"@wordpress/browserslist-config": "3.0.1",
 		"@wordpress/components": "13.0.0",
+		"@wordpress/compose": "3.25.0",
 		"@wordpress/element": "2.20.0",
 		"@wordpress/i18n": "3.19.0",
 		"@wordpress/keycodes": "2.19.0",

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -25,7 +25,9 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"devDependencies": {
+		"@wordpress/block-editor": "5.3.0",
 		"@wordpress/browserslist-config": "3.0.1",
+		"@wordpress/element": "2.20.0",
 		"@wordpress/scripts": "14.0.1",
 		"autoprefixer": "9.8.6",
 		"cssnano": "4.1.10",

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -29,10 +29,11 @@ get_header();
 					</div>
 				</header><!-- .entry-header -->
 
+				<div id="wporg-pattern-container" hidden>
+					<?php echo rawurlencode( wp_json_encode( get_the_content() ) ); ?>
+				</div>
+
 				<div class="entry-content">
-					<div id="wporg-pattern-container" hidden>
-						<?php echo rawurlencode( wp_json_encode( get_the_content() ) ); ?>
-					</div>
 					<h2>More from this designer</h2>
 					<div class="pattern-grid">
 						<ul>

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -33,6 +33,23 @@ get_header();
 					<?php echo rawurlencode( wp_json_encode( get_the_content() ) ); ?>
 				</div>
 
+				<div class="pattern__meta">
+					<div>
+						<div class="pattern__categories">
+							<?php
+							$categories_list = get_the_term_list( get_the_ID(), 'wporg-pattern-category', '', ', ' );
+							if ( $categories_list ) {
+								/* translators: 1: list of pattern categories. */
+								printf( esc_html__( 'Categories: %1$s', 'wporg-patterns' ), $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							}
+							?>
+						</div>
+						<div class="pattern__report">
+							<button class="button">Report this pattern</button>
+						</div>
+					</div>
+				</div>
+
 				<div class="entry-content">
 					<h2>More from this designer</h2>
 					<div class="pattern-grid">

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * The template for displaying all single posts.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
+ *
+ * @package WordPressdotorg\Theme
+ */
+
+namespace WordPressdotorg\Theme;
+
+get_header();
+?>
+
+	<main id="main" class="site-main col-12" role="main">
+
+		<?php
+		while ( have_posts() ) :
+			the_post();
+			?>
+
+			<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+				<header class="entry-header">
+					<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+					<p>A large hero section with an example background image and a heading in the center.</p>
+					<div class="pattern-actions">
+						<button class="button button-primary">Copy Pattern</button>
+						<button class="button">Add to favorites</button>
+					</div>
+				</header><!-- .entry-header -->
+
+				<div class="entry-content">
+					<div id="wporg-pattern-container" hidden>
+						<?php echo rawurlencode( wp_json_encode( get_the_content() ) ); ?>
+					</div>
+					<h2>More from this designer</h2>
+					<div class="pattern-grid">
+						<ul>
+							<li>Pattern A</li>
+							<li>Pattern B</li>
+							<li>Pattern C</li>
+						</ul>
+					</div>
+				</div><!-- .entry-content -->
+			</article><!-- #post-## -->
+
+		<?php endwhile; ?>
+
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -29,7 +29,7 @@ get_header();
 					</div>
 				</header><!-- .entry-header -->
 
-				<div id="wporg-pattern-container" hidden>
+				<div class="pattern-preview__container" hidden>
 					<?php echo rawurlencode( wp_json_encode( get_the_content() ) ); ?>
 				</div>
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	/* eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- Experimental is OK. */
+	__unstableIframe as Iframe,
+} from '@wordpress/block-editor';
+
+function Canvas( { html } ) {
+	const style = {
+		width: '100%',
+		height: '50vh',
+		minHeight: '200px',
+		overflowY: 'auto',
+	};
+	const iframeBodyStyle =
+		'<style>body{display: flex;align-items: center;justify-content: center;min-height: 100vh;}</style>';
+
+	return (
+		<Iframe style={ style } headHTML={ window.__editorStyles.html + iframeBodyStyle }>
+			<div
+				dangerouslySetInnerHTML={ {
+					__html: html,
+				} }
+			/>
+		</Iframe>
+	);
+}
+
+export default Canvas;

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
@@ -5,26 +5,25 @@ import {
 	/* eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- Experimental is OK. */
 	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
-import { Disabled } from '@wordpress/components';
 
 function Canvas( { html } ) {
 	const style = {
 		width: '100%',
 		height: '50vh',
-		minHeight: '200px',
+		minHeight: '600px',
 		overflowY: 'auto',
 	};
-	const iframeBodyStyle =
+	const extraIframeStyles =
 		// @todo - Should we keep the TT1 style? Load css from a local file?
-		'<link rel="stylesheet" id="twenty-twenty-one-style-css" href="https://wp-themes.com/wp-content/themes/twentytwentyone/style.css?ver=1.2" media="all" />' +
-		'<style>body{display: flex;align-items: center;justify-content: center;min-height: 100vh;}</style>';
+		'<link rel="stylesheet" id="twenty-twenty-one-style-css"  href="https://wp-themes.com/wp-content/themes/twentytwentyone/style.css?ver=1.2" media="all" />' +
+		'<style>body{pointer-events:none;display: flex;align-items: center;justify-content: center;min-height: 100vh;} body > div {width: 100%}</style>';
 
 	return (
-		<Disabled>
+		<div>
 			<Iframe
 				className="pattern-preview__viewport-iframe"
 				style={ style }
-				headHTML={ window.__editorStyles.html + iframeBodyStyle }
+				headHTML={ window.__editorStyles.html + extraIframeStyles }
 			>
 				<div
 					dangerouslySetInnerHTML={ {
@@ -32,7 +31,7 @@ function Canvas( { html } ) {
 					} }
 				/>
 			</Iframe>
-		</Disabled>
+		</div>
 	);
 }
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
@@ -5,6 +5,7 @@ import {
 	/* eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- Experimental is OK. */
 	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
+import { Disabled } from '@wordpress/components';
 
 function Canvas( { html } ) {
 	const style = {
@@ -17,13 +18,19 @@ function Canvas( { html } ) {
 		'<style>body{display: flex;align-items: center;justify-content: center;min-height: 100vh;}</style>';
 
 	return (
-		<Iframe style={ style } headHTML={ window.__editorStyles.html + iframeBodyStyle }>
-			<div
-				dangerouslySetInnerHTML={ {
-					__html: html,
-				} }
-			/>
-		</Iframe>
+		<Disabled>
+			<Iframe
+				className="pattern-preview__viewport-iframe"
+				style={ style }
+				headHTML={ window.__editorStyles.html + iframeBodyStyle }
+			>
+				<div
+					dangerouslySetInnerHTML={ {
+						__html: html,
+					} }
+				/>
+			</Iframe>
+		</Disabled>
 	);
 }
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
@@ -15,6 +15,8 @@ function Canvas( { html } ) {
 		overflowY: 'auto',
 	};
 	const iframeBodyStyle =
+		// @todo - Should we keep the TT1 style? Load css from a local file?
+		'<link rel="stylesheet" id="twenty-twenty-one-style-css" href="https://wp-themes.com/wp-content/themes/twentytwentyone/style.css?ver=1.2" media="all" />' +
 		'<style>body{display: flex;align-items: center;justify-content: center;min-height: 100vh;}</style>';
 
 	return (

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/drag-handle.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/drag-handle.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useState } from '@wordpress/element';
+/* eslint-disable-next-line -- @wordpress/no-unsafe-wp-apis -- Experimental is OK. */
+import { __experimentalUseDragging as useDragging } from '@wordpress/compose';
+
+function DragHandle( { label, className, onDragChange } ) {
+	const [ position, setPosition ] = useState( null );
+
+	const changePosition = useCallback(
+		( event ) => {
+			if ( null !== position ) {
+				const delta = position - event.clientX;
+				onDragChange( delta );
+			}
+
+			if ( event.clientX >= 1 && event.clientX <= window.innerWidth ) {
+				setPosition( event.clientX );
+			}
+		},
+		[ onDragChange, position, setPosition ]
+	);
+
+	const { startDrag } = useDragging( {
+		onDragStart: useCallback( ( event ) => setPosition( event.clientX ), [ setPosition ] ),
+		onDragMove: changePosition,
+		onDragEnd: useCallback( () => setPosition( null ), [ setPosition ] ),
+	} );
+
+	return (
+		<div className={ `pattern-preview__drag-handle ${ className }` }>
+			<button
+				className="pattern-preview__drag-handle-button"
+				aria-label={ label }
+				onMouseDown={ startDrag }
+			/>
+		</div>
+	);
+}
+
+export default DragHandle;

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/drag-handle.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/drag-handle.js
@@ -1,31 +1,14 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
-import { useCallback, useState } from '@wordpress/element';
-/* eslint-disable-next-line -- @wordpress/no-unsafe-wp-apis -- Experimental is OK. */
-import { __experimentalUseDragging as useDragging } from '@wordpress/compose';
+import { useDrag } from 'react-use-gesture';
 
-function DragHandle( { label, className, onDragChange } ) {
-	const [ position, setPosition ] = useState( null );
-
-	const changePosition = useCallback(
-		( event ) => {
-			if ( null !== position ) {
-				const delta = position - event.clientX;
-				onDragChange( delta );
-			}
-
-			if ( event.clientX >= 1 && event.clientX <= window.innerWidth ) {
-				setPosition( event.clientX );
-			}
-		},
-		[ onDragChange, position, setPosition ]
-	);
-
-	const { startDrag } = useDragging( {
-		onDragStart: useCallback( ( event ) => setPosition( event.clientX ), [ setPosition ] ),
-		onDragMove: changePosition,
-		onDragEnd: useCallback( () => setPosition( null ), [ setPosition ] ),
+function DragHandle( { label, className, onDragChange, direction = 'left' } ) {
+	const dragGestures = useDrag( ( { delta, dragging } ) => {
+		const multiplier = direction === 'left' ? 2 : -2;
+		if ( dragging ) {
+			onDragChange( delta[ 0 ] * multiplier );
+		}
 	} );
 
 	return (
@@ -33,7 +16,7 @@ function DragHandle( { label, className, onDragChange } ) {
 			<button
 				className="pattern-preview__drag-handle-button"
 				aria-label={ label }
-				onMouseDown={ startDrag }
+				{ ...dragGestures() }
 			/>
 		</div>
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/drag-handle.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/drag-handle.js
@@ -3,19 +3,39 @@
  */
 import { useDrag } from 'react-use-gesture';
 
-function DragHandle( { label, className, onDragChange, direction = 'left' } ) {
+/**
+ * WordPress dependencies
+ */
+import { LEFT, RIGHT } from '@wordpress/keycodes';
+
+function DragHandle( { label, className, onDragChange, direction = 'left', ...props } ) {
 	const dragGestures = useDrag( ( { delta, dragging } ) => {
-		const multiplier = direction === 'left' ? 2 : -2;
+		const multiplier = direction === 'left' ? -2 : 2;
 		if ( dragging ) {
 			onDragChange( delta[ 0 ] * multiplier );
 		}
 	} );
+
+	const onKeyDown = ( event ) => {
+		const { keyCode } = event;
+
+		if ( ( direction === 'left' && keyCode === LEFT ) || ( direction === 'right' && keyCode === RIGHT ) ) {
+			onDragChange( 20 );
+		} else if (
+			( direction === 'left' && keyCode === RIGHT ) ||
+			( direction === 'right' && keyCode === LEFT )
+		) {
+			onDragChange( -20 );
+		}
+	};
 
 	return (
 		<div className={ `pattern-preview__drag-handle ${ className }` }>
 			<button
 				className="pattern-preview__drag-handle-button"
 				aria-label={ label }
+				{ ...props }
+				onKeyDown={ onKeyDown }
 				{ ...dragGestures() }
 			/>
 		</div>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -11,8 +11,10 @@ import DragHandle from './drag-handle';
 
 /* eslint-disable jsx-a11y/anchor-is-valid -- These are just placeholders. */
 
+const INITIAL_WIDTH = 1200;
+
 function PatternPreview( { blockContent } ) {
-	const [ width, setWidth ] = useState( 800 );
+	const [ width, setWidth ] = useState( window.innerWidth < INITIAL_WIDTH ? window.innerWidth : INITIAL_WIDTH );
 	const onDragChange = useCallback(
 		( delta ) => {
 			setWidth( ( value ) => value + delta );

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -46,14 +46,6 @@ function PatternPreview( { blockContent } ) {
 					{ __( 'Use left and right arrow keys to resize the preview.', 'wporg-patterns' ) }
 				</VisuallyHidden>
 			</div>
-			<div className="pattern-preview__meta">
-				<div className="pattern-preview__categories">
-					Categories: <a href="#">Ecommerce,</a> <a href="#">Columns,</a> <a href="#">Marketing</a>
-				</div>
-				<div className="pattern-preview__report">
-					<button className="button">Report this pattern</button>
-				</div>
-			</div>
 		</>
 	);
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useCallback, useState } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
 /**
@@ -16,6 +17,7 @@ import DragHandle from './drag-handle';
 const INITIAL_WIDTH = 1200;
 
 function PatternPreview( { blockContent } ) {
+	const instanceId = useInstanceId( PatternPreview );
 	const [ width, setWidth ] = useState( window.innerWidth < INITIAL_WIDTH ? window.innerWidth : INITIAL_WIDTH );
 	const onDragChange = useCallback(
 		( delta ) => {
@@ -32,7 +34,7 @@ function PatternPreview( { blockContent } ) {
 					className="is-left"
 					onDragChange={ onDragChange }
 					direction="left"
-					aria-describedby="pattern-preview__resize-help"
+					aria-describedby={ `pattern-preview__resize-help-${ instanceId }` }
 				/>
 				<Canvas html={ blockContent } />
 				<DragHandle
@@ -40,9 +42,12 @@ function PatternPreview( { blockContent } ) {
 					className="is-right"
 					onDragChange={ onDragChange }
 					direction="right"
-					aria-describedby="pattern-preview__resize-help"
+					aria-describedby={ `pattern-preview__resize-help-${ instanceId }` }
 				/>
-				<VisuallyHidden id="pattern-preview__resize-help">
+				<VisuallyHidden
+					id={ `pattern-preview__resize-help-${ instanceId }` }
+					className="pattern-preview__resize-help"
+				>
 					{ __( 'Use left and right arrow keys to resize the preview.', 'wporg-patterns' ) }
 				</VisuallyHidden>
 			</div>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,32 +13,19 @@ import DragHandle from './drag-handle';
 
 function PatternPreview( { blockContent } ) {
 	const [ width, setWidth ] = useState( 800 );
-	const onLeftDragChange = useCallback(
+	const onDragChange = useCallback(
 		( delta ) => {
-			setWidth( ( value ) => value + ( delta * 2 ) ); // prettier-ignore
+			setWidth( ( value ) => value + delta );
 		},
 		[ setWidth ]
 	);
-	const onRightDragChange = useCallback(
-		( delta ) => {
-			setWidth( ( value ) => value - ( delta * 2 ) ); // prettier-ignore
-		},
-		[ setWidth ]
-	);
-	useEffect( () => {
-		if ( width > window.innerWidth ) {
-			setWidth( window.innerWidth );
-		} else if ( width < 320 ) {
-			setWidth( 320 );
-		}
-	}, [ width ] );
 
 	return (
 		<>
 			<div className="pattern-preview__viewport" style={ { width } }>
-				<DragHandle label="Left" className="is-left" onDragChange={ onLeftDragChange } />
+				<DragHandle label="Left" className="is-left" onDragChange={ onDragChange } direction="left" />
 				<Canvas html={ blockContent } />
-				<DragHandle label="Right" className="is-right" onDragChange={ onRightDragChange } />
+				<DragHandle label="Right" className="is-right" onDragChange={ onDragChange } direction="right" />
 			</div>
 			<div className="pattern-preview__meta">
 				<div className="pattern-preview__categories">

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -1,7 +1,9 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useCallback, useState } from '@wordpress/element';
+import { VisuallyHidden } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -25,9 +27,24 @@ function PatternPreview( { blockContent } ) {
 	return (
 		<>
 			<div className="pattern-preview__viewport" style={ { width } }>
-				<DragHandle label="Left" className="is-left" onDragChange={ onDragChange } direction="left" />
+				<DragHandle
+					label={ __( 'Drag to resize', 'wporg-patterns' ) }
+					className="is-left"
+					onDragChange={ onDragChange }
+					direction="left"
+					aria-describedby="pattern-preview__resize-help"
+				/>
 				<Canvas html={ blockContent } />
-				<DragHandle label="Right" className="is-right" onDragChange={ onDragChange } direction="right" />
+				<DragHandle
+					label={ __( 'Drag to resize', 'wporg-patterns' ) }
+					className="is-right"
+					onDragChange={ onDragChange }
+					direction="right"
+					aria-describedby="pattern-preview__resize-help"
+				/>
+				<VisuallyHidden id="pattern-preview__resize-help">
+					{ __( 'Use left and right arrow keys to resize the preview.', 'wporg-patterns' ) }
+				</VisuallyHidden>
 			</div>
 			<div className="pattern-preview__meta">
 				<div className="pattern-preview__categories">

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -40,8 +40,13 @@ function PatternPreview( { blockContent } ) {
 				<Canvas html={ blockContent } />
 				<DragHandle label="Right" className="is-right" onDragChange={ onRightDragChange } />
 			</div>
-			<div className="pattern-preview__categories">
-				Categories: <a href="#">Ecommerce,</a> <a href="#">Columns,</a> <a href="#">Marketing</a>
+			<div className="pattern-preview__meta">
+				<div className="pattern-preview__categories">
+					Categories: <a href="#">Ecommerce,</a> <a href="#">Columns,</a> <a href="#">Marketing</a>
+				</div>
+				<div className="pattern-preview__report">
+					<button className="button">Report this pattern</button>
+				</div>
 			</div>
 		</>
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -1,19 +1,46 @@
 /**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Canvas from './canvas';
+import DragHandle from './drag-handle';
 
 /* eslint-disable jsx-a11y/anchor-is-valid -- These are just placeholders. */
 
 function PatternPreview( { blockContent } ) {
+	const [ width, setWidth ] = useState( 800 );
+	const onLeftDragChange = useCallback(
+		( delta ) => {
+			setWidth( ( value ) => value + ( delta * 2 ) ); // prettier-ignore
+		},
+		[ setWidth ]
+	);
+	const onRightDragChange = useCallback(
+		( delta ) => {
+			setWidth( ( value ) => value - ( delta * 2 ) ); // prettier-ignore
+		},
+		[ setWidth ]
+	);
+	useEffect( () => {
+		if ( width > window.innerWidth ) {
+			setWidth( window.innerWidth );
+		} else if ( width < 320 ) {
+			setWidth( 320 );
+		}
+	}, [ width ] );
+
 	return (
 		<>
-			<div>
-				<button>Left</button>
+			<div className="pattern-preview__viewport" style={ { width } }>
+				<DragHandle label="Left" className="is-left" onDragChange={ onLeftDragChange } />
 				<Canvas html={ blockContent } />
-				<button>Right</button>
+				<DragHandle label="Right" className="is-right" onDragChange={ onRightDragChange } />
 			</div>
-			<div>
+			<div className="pattern-preview__categories">
 				Categories: <a href="#">Ecommerce,</a> <a href="#">Columns,</a> <a href="#">Marketing</a>
 			</div>
 		</>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import Canvas from './canvas';
+
+/* eslint-disable jsx-a11y/anchor-is-valid -- These are just placeholders. */
+
+function PatternPreview( { blockContent } ) {
+	return (
+		<>
+			<div>
+				<button>Left</button>
+				<Canvas html={ blockContent } />
+				<button>Right</button>
+			</div>
+			<div>
+				Categories: <a href="#">Ecommerce,</a> <a href="#">Columns,</a> <a href="#">Marketing</a>
+			</div>
+		</>
+	);
+}
+
+export default PatternPreview;

--- a/public_html/wp-content/themes/pattern-directory/src/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/index.js
@@ -1,1 +1,19 @@
-// TBD.
+/**
+ * WordPress dependencies
+ */
+import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import PatternPreview from './components/pattern-preview';
+
+const container = document.getElementById( 'wporg-pattern-container' );
+if ( container ) {
+	const blockContent = JSON.parse( decodeURIComponent( container.innerText ) );
+	// Use `wp.blocks.parse` to convert HTML to block objects (for use in editor), if needed.
+
+	render( <PatternPreview blockContent={ blockContent } />, container, () => {
+		container.hidden = false;
+	} );
+}

--- a/public_html/wp-content/themes/pattern-directory/src/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/index.js
@@ -8,12 +8,15 @@ import { render } from '@wordpress/element';
  */
 import PatternPreview from './components/pattern-preview';
 
-const container = document.getElementById( 'wporg-pattern-container' );
-if ( container ) {
+// Load the preview into any awaiting preview container.
+const previewContainers = document.querySelectorAll( '.pattern-preview__container' );
+for ( let i = 0; i < previewContainers.length; i++ ) {
+	const container = previewContainers[ i ];
 	const blockContent = JSON.parse( decodeURIComponent( container.innerText ) );
 	// Use `wp.blocks.parse` to convert HTML to block objects (for use in editor), if needed.
 
 	render( <PatternPreview blockContent={ blockContent } />, container, () => {
+		// This callback is called after the render to unhide the container.
 		container.hidden = false;
 	} );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11576,6 +11576,11 @@ react-textarea-autosize@^8.2.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
+react-use-gesture@9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-9.1.3.tgz#92bd143e4f58e69bd424514a5bfccba2a1d62ec0"
+  integrity sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg==
+
 react-use-gesture@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-9.0.0.tgz#c3c1d011e522315da6b31c38619cd4302f41a63b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3450,7 +3450,7 @@
     lodash "^4.17.19"
     rememo "^3.0.0"
 
-"@wordpress/keycodes@^2.19.0":
+"@wordpress/keycodes@2.19.0", "@wordpress/keycodes@^2.19.0":
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-2.19.0.tgz#696fc060d9ead2f3cc38bfaa0d4d5ad1e05a1f7f"
   integrity sha512-nHUh6IQoljY0ojbDCgjcZDFThAj013nFDk4JF25N+MMhEc98sPj9EItJnpGB0cU1M4C1POmm1bHnrMgPywlEqw==


### PR DESCRIPTION
Fixes #43 — Create a single pattern template & preview component. This adds an iframe to "containerize" the preview's CSS, and let us resize it like an actual browser would. I've pulled in Twenty Twenty-One's CSS from wp-themes.com, but left a note that we could swap this with a local file or from another theme as needed.

There is a good amount of placeholder content in here, which will be replaced in future PRs (I just want to get the framework in place).

### Screenshots

![preview](https://user-images.githubusercontent.com/541093/112337197-162c9100-8c94-11eb-9971-5c42e045f3f6.png)

The preview can be expanded or shrunk down to 320px by dragging the sidebars:
![responsive](https://user-images.githubusercontent.com/541093/112337202-16c52780-8c94-11eb-8820-ad4699c4b8d9.png)

I also tried making this keyboard accessible, so if you tab into the preview, you can focus on the handles (right handle has focus) and some helper text becomes visible. You can move right or left to adjust the preview size.
<img width="1046" alt="keyboard" src="https://user-images.githubusercontent.com/541093/112337194-1593fa80-8c94-11eb-8da6-f4e8336fb992.png">

### How to test the changes in this Pull Request:

1. Create a block pattern (using wp-admin)
2. View it
3. Try adjusting the preview width by mouse or keyboard


