### PR TITLE
Theme: Style page headers

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/Gruntfile.js
+++ b/public_html/wp-content/themes/pattern-directory/Gruntfile.js
@@ -30,6 +30,7 @@ module.exports = function( grunt ) {
 				processors: [
 					require( 'autoprefixer' )( {
 						cascade: false,
+						grid: true,
 					} ),
 					require( 'pixrem' ),
 					require( 'cssnano' )( {

--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -21,6 +21,7 @@
 @import "../../../wporg/css/components/wporg-footer";
 @import "../../../wporg/css/components/wporg-header";
 @import "main-navigation";
+@import "page";
 @import "pattern-preview";
 @import "pattern";
 @import "search-form";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -20,6 +20,7 @@
 @import "../../../wporg/css/components/widget-area";
 @import "../../../wporg/css/components/wporg-footer";
 @import "../../../wporg/css/components/wporg-header";
+@import "main-navigation";
 @import "pattern-preview";
 @import "pattern";
 @import "search-form";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -24,4 +24,6 @@
 @import "pattern";
 @import "search-form";
 @import "section-heading";
+@import "site-content";
+@import "site-header";
 @import "site-title";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_main-navigation.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_main-navigation.scss
@@ -1,6 +1,6 @@
 .main-navigation {
 	float: none;
-	position: initial;
+	position: static;
 	width: auto;
 
 	a {
@@ -19,7 +19,7 @@
 }
 
 .menu-toggle {
-	position: initial;
+	position: static;
 	height: auto;
 	width: auto;
 	font-size: 1.5625rem;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_main-navigation.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_main-navigation.scss
@@ -1,0 +1,29 @@
+.main-navigation {
+	float: none;
+	position: initial;
+	width: auto;
+
+	a {
+		font-size: 0.8125rem;
+	}
+
+	&.toggled {
+		div.menu {
+			position: absolute;
+			top: 57px;
+			right: 0;
+			width: 100%;
+			background: $color__wp-blue;
+		}
+	}
+}
+
+.menu-toggle {
+	position: initial;
+	height: auto;
+	width: auto;
+	font-size: 1.5625rem;
+	overflow: hidden;
+	-webkit-appearance: none;
+}
+

--- a/public_html/wp-content/themes/pattern-directory/css/components/_page.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_page.scss
@@ -1,7 +1,7 @@
 body.page {
 	.entry-header {
-		background: initial;
-		padding: initial;
+		background: none;
+		padding: 0;
 
 		.entry-title {
 			color: inherit;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_page.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_page.scss
@@ -1,0 +1,16 @@
+body.page {
+	.entry-header {
+		background: initial;
+		padding: initial;
+
+		.entry-title {
+			color: inherit;
+			margin: 2rem auto 1rem;
+			max-width: 960px;
+
+			@include breakpoint( $ms-breakpoint ) {
+				padding: 0 10px;
+			}
+		}
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_site-content.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_site-content.scss
@@ -1,0 +1,5 @@
+.site-content {
+	margin: 0 auto;
+	max-width: none;
+	padding: 0;
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
@@ -1,0 +1,56 @@
+body.home {
+	.site-header {
+		padding: 3.75rem 1rem;
+		text-align: left;
+	}
+
+	.site-branding {
+		display: grid;
+		grid-template-areas:
+			"title   callout"
+			"tagline callout";
+		grid-template-rows: auto 1fr;
+		grid-template-columns: 1fr 18rem;
+		gap: 0 4rem;
+		justify-content: center;
+		align-items: center;
+	}
+
+	// Duplicate class for specifity override.
+	.site-title.site-title {
+		grid-area: title;
+		margin-top: 0;
+		text-align: left;
+		font-size: 3rem;
+		line-height: $type__header--line-height;
+	}
+
+	.site-description {
+		grid-area: tagline;
+		margin: 0;
+		font-size: 1.25rem;
+		line-height: $type__line-height;
+		text-align: left;
+		color: $color-white;
+	}
+
+	.site-callout {
+		grid-area: callout;
+		padding: 1.125rem 1.5rem 1.5rem;
+		font-size: 0.875rem;
+		line-height: $type__line-height;
+		background: $color-white;
+		box-shadow: 0.75rem 0.75rem 0 rgba($color-black, 0.15);
+
+		h2 {
+			margin-top: 0;
+			font-size: 1.125rem;
+			line-height: $type__header--line-height;
+			font-weight: 600;
+		}
+
+		p:last-child {
+			margin-bottom: 0;
+		}
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
@@ -6,14 +6,12 @@ body.home {
 
 	.site-branding {
 		display: grid;
-		grid-template-areas:
-			"title   callout"
-			"tagline callout";
 		grid-template-rows: auto 1fr;
-		grid-template-columns: 1fr 18rem;
-		gap: 0 4rem;
-		justify-content: center;
-		align-items: center;
+		grid-template-columns: 1fr 22rem;
+
+		> * {
+			align-self: center;
+		}
 
 		@include breakpoint( 0, $ms-breakpoint - 1 ) {
 			display: block;
@@ -22,7 +20,8 @@ body.home {
 
 	// Duplicate class for specifity override.
 	.site-title.site-title {
-		grid-area: title;
+		grid-column-start: 1;
+		grid-row-start: 1;
 		margin-top: 0;
 		text-align: left;
 		font-size: 3rem;
@@ -30,7 +29,8 @@ body.home {
 	}
 
 	.site-description {
-		grid-area: tagline;
+		grid-column-start: 1;
+		grid-row-start: 2;
 		margin: 0;
 		font-size: 1.25rem;
 		line-height: $type__line-height;
@@ -39,7 +39,10 @@ body.home {
 	}
 
 	.site-callout {
-		grid-area: callout;
+		grid-column-start: 2;
+		grid-row-start: 1;
+		grid-row-end: span 2;
+		margin-left: 4rem;
 		padding: 1.125rem 1.5rem 1.5rem;
 		font-size: 0.875rem;
 		line-height: $type__line-height;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
@@ -14,6 +14,10 @@ body.home {
 		gap: 0 4rem;
 		justify-content: center;
 		align-items: center;
+
+		@include breakpoint( 0, $ms-breakpoint - 1 ) {
+			display: block;
+		}
 	}
 
 	// Duplicate class for specifity override.
@@ -51,6 +55,34 @@ body.home {
 
 		p:last-child {
 			margin-bottom: 0;
+		}
+
+		@include breakpoint( 0, $ms-breakpoint - 1 ) {
+			margin: 2rem auto 0;
+			max-width: 24rem;
+		}
+	}
+}
+
+body:not(.home) {
+	.site-branding {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		font-size: 0.8125rem;
+		color: $color-white;
+
+		a {
+			color: $color-white;
+		}
+
+		.sep {
+			margin-left: 0.5rem;
+			margin-right: 0.5rem;
+		}
+
+		.is-current-page {
+			font-weight: 600;
 		}
 	}
 }

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -57,7 +57,7 @@ function enqueue_assets() {
 		wp_set_script_translations( 'wporg-pattern-script', 'wporg-patterns' );
 	}
 
-	wp_enqueue_script( 'wporg-navigation', get_template_directory_uri() . "/js/navigation$suffix.js", array(), '20151215', true );
+	wp_enqueue_script( 'wporg-navigation', get_template_directory_uri() . "/js/navigation$suffix.js", array(), '20210331', true );
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -31,6 +31,9 @@ function setup() {
  * cache-busting. The version is set to the last modified time during development.
  */
 function enqueue_assets() {
+	$script_debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+	$suffix       = $script_debug ? '' : '.min';
+
 	wp_enqueue_style(
 		'wporg-style',
 		get_theme_file_uri( '/css/style.css' ),
@@ -53,6 +56,8 @@ function enqueue_assets() {
 
 		wp_set_script_translations( 'wporg-pattern-script', 'wporg-patterns' );
 	}
+
+	wp_enqueue_script( 'wporg-navigation', get_template_directory_uri() . "/js/navigation$suffix.js", array(), '20151215', true );
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/header.php
+++ b/public_html/wp-content/themes/pattern-directory/header.php
@@ -27,9 +27,14 @@ get_template_part( 'header', 'wporg' );
 				<?php if ( is_home() ) : ?>
 					<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo esc_html_x( 'Pattern Directory', 'Site title', 'wporg-patterns' ); ?></a></h1>
 
-					<p class="site-description"><?php esc_html_e( 'Extend your WordPress experience with block patterns.', 'wporg-patterns' ); ?></p>
+					<p class="site-description"><?php esc_html_e( 'Add a beautifully designed, ready to go layout to any WordPress site with a simple copy/paste.', 'wporg-patterns' ); ?></p>
 
-					<?php get_search_form(); ?>
+					<div class="site-callout">
+						<?php /* Logged in actions are different */ ?>
+						<h2><?php esc_html_e( 'Create and share patterns', 'wporg-patterns' ); ?></h2>
+						<p><?php esc_html_e( 'Build your own patterns and share them with the WordPress world.', 'wporg-patterns' ); ?></p>
+						<p><a href="/create"><?php esc_html_e( 'Learn more about patterns.', 'wporg-patterns' ); ?></a></p>
+					</div>
 				<?php else : ?>
 					<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo esc_html_x( 'Pattern Directory', 'Site title', 'wporg-patterns' ); ?></a></p>
 

--- a/public_html/wp-content/themes/pattern-directory/header.php
+++ b/public_html/wp-content/themes/pattern-directory/header.php
@@ -11,6 +11,8 @@
 
 namespace WordPressdotorg\Pattern_Directory\Theme;
 
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+
 $GLOBALS['pagetitle'] = wp_get_document_title();
 global $wporg_global_header_options;
 if ( ! isset( $wporg_global_header_options['in_wrapper'] ) ) {
@@ -36,9 +38,42 @@ get_template_part( 'header', 'wporg' );
 						<p><a href="/create"><?php esc_html_e( 'Learn more about patterns.', 'wporg-patterns' ); ?></a></p>
 					</div>
 				<?php else : ?>
-					<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo esc_html_x( 'Pattern Directory', 'Site title', 'wporg-patterns' ); ?></a></p>
+					<div>
+						<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
+							<?php esc_html_e( 'All Patterns', 'wporg-patterns' ); ?>
+						</a>
+						<span class="sep">/</span>
+						<span class="is-current-page">
+							<?php
+							if ( is_singular( POST_TYPE ) ) {
+								esc_html_e( 'Pattern Details', 'wporg-patterns' );
+							} else if ( is_singular() ) {
+								the_title();
+							} else {
+								the_archive_title();
+							}
+							?>
+						</span>
+					</div>
 
-					<!-- <nav id="site-navigation" class="main-navigation" role="navigation" /> -->
+					<nav id="site-navigation" class="main-navigation" role="navigation">
+						<button
+							class="menu-toggle dashicons dashicons-arrow-down-alt2"
+							aria-controls="primary-menu"
+							aria-expanded="false"
+							aria-label="<?php esc_attr_e( 'Primary Menu', 'wporg-patterns' ); ?>"
+						>
+						</button>
+
+						<div id="primary-menu" class="menu">
+							<?php
+							wp_nav_menu( array(
+								'theme_location' => 'primary',
+								'menu_id'        => 'primary-menu',
+							) );
+							?>
+						</div>
+					</nav><!-- #site-navigation -->
 				<?php endif; ?>
 			</div><!-- .site-branding -->
 		</header><!-- #masthead -->


### PR DESCRIPTION
This updates the page header (the blue section) style to match the mockups.

### Screenshots

Home
<img width="1023" alt="Screen Shot 2021-03-29 at 5 25 54 PM" src="https://user-images.githubusercontent.com/541093/112902426-1b367980-90b4-11eb-95b1-defa02499e9d.png">

Interiors
<img width="986" alt="Screen Shot 2021-03-29 at 5 27 06 PM" src="https://user-images.githubusercontent.com/541093/112902424-1b367980-90b4-11eb-97aa-239c0a1716de.png">
<img width="980" alt="Screen Shot 2021-03-29 at 5 25 43 PM" src="https://user-images.githubusercontent.com/541093/112902427-1bcf1000-90b4-11eb-9e0d-3eee413b52fe.png">
<img width="1005" alt="Screen Shot 2021-03-29 at 5 25 33 PM" src="https://user-images.githubusercontent.com/541093/112902428-1bcf1000-90b4-11eb-878c-d071b330b861.png">

Small screens
![Screen Shot 2021-03-29 at 17 26 10](https://user-images.githubusercontent.com/541093/112902468-28536880-90b4-11eb-94c9-0850f1fc190a.png)
![Screen Shot 2021-03-29 at 17 26 21](https://user-images.githubusercontent.com/541093/112902483-2db0b300-90b4-11eb-894e-efeddb04a91d.png)

Regular pages still include the page title - this will probably change as the rest of the site is built out.
<img width="995" alt="Screen Shot 2021-03-29 at 5 58 05 PM" src="https://user-images.githubusercontent.com/541093/112905458-723e4d80-90b8-11eb-9c36-d24ca5f222f4.png">

### How to test the changes in this Pull Request:

1. View some pages (home, a single pattern, the "new pattern" page)
2. Make sure the headers look correct

