### PR TITLE
[WIP] Add an active filter bar component.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_active-filter-bar.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_active-filter-bar.scss
@@ -1,5 +1,5 @@
 $font-size: 13px;
-$grid-unit: 16px; 
+$grid-unit: 16px;
 $border-radius: 2px;
 
 .active-filter__bar {

--- a/public_html/wp-content/themes/pattern-directory/css/components/_active-filter-bar.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_active-filter-bar.scss
@@ -1,0 +1,43 @@
+$font-size: 13px;
+$grid-unit: 16px; 
+$border-radius: 2px;
+
+.active-filter__bar {
+	background: $color-gray-light-300;
+	border-radius: $border-radius;
+	font-size: $font-size;
+
+	ul {
+		margin: 0;
+		padding: 0;
+		display: flex;
+		justify-content: space-between;
+
+		li {
+			list-style: none;
+			font-size: $font-size;
+
+			a {
+				display: block;
+				padding: $grid-unit $grid-unit / 2;
+				text-decoration: none;
+			}
+
+			&:last-child a {
+				padding-right: $grid-unit;
+			}
+		}
+	}
+
+	&__copy {
+		padding: $grid-unit;
+	}
+
+	&__title {
+		margin: 0;
+		padding-right: $grid-unit;
+		color: $color__text;
+		font-size: $font-size - 1;
+		text-transform: uppercase;
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -20,6 +20,7 @@
 @import "../../../wporg/css/components/widget-area";
 @import "../../../wporg/css/components/wporg-footer";
 @import "../../../wporg/css/components/wporg-header";
+@import "active-filter-bar";
 @import "pattern-preview";
 @import "pattern";
 @import "search-form";

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -28,10 +28,12 @@
 		"@wordpress/browserslist-config": "3.0.1",
 		"@wordpress/components": "13.0.0",
 		"@wordpress/compose": "3.25.0",
+		"@wordpress/data": "^4.27.0",
 		"@wordpress/element": "2.20.0",
 		"@wordpress/i18n": "3.19.0",
 		"@wordpress/keycodes": "2.19.0",
 		"@wordpress/scripts": "14.0.1",
+		"@wordpress/viewport": "^2.26.0",
 		"autoprefixer": "9.8.6",
 		"cssnano": "4.1.10",
 		"grunt": "1.3.0",
@@ -58,8 +60,5 @@
 			"**/*.css.map"
 		]
 	},
-	"dependencies": {
-		"@wordpress/data": "^4.27.0",
-		"@wordpress/viewport": "^2.26.0"
-	}
+	"dependencies": {}
 }

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -15,10 +15,9 @@
 		"build:css": "grunt css",
 		"build:js": "grunt js",
 		"dev": "grunt",
-		"format:js": "echo \"No JS.\"",
+		"format:js": "wp-scripts format-js src",
 		"lint:css": "wp-scripts lint-style css",
 		"lint:js": "wp-scripts lint-js src",
-		"format:js": "wp-scripts format-js src",
 		"packages-update": "wp-scripts packages-update"
 	},
 	"browserslist": [
@@ -54,6 +53,13 @@
 	"prettier": "../../../../.prettierrc.js",
 	"stylelint": {
 		"extends": "../../../../.stylelintrc",
-		"ignoreFiles": ["**/*.css", "**/*.css.map"]
+		"ignoreFiles": [
+			"**/*.css",
+			"**/*.css.map"
+		]
+	},
+	"dependencies": {
+		"@wordpress/data": "^4.27.0",
+		"@wordpress/viewport": "^2.26.0"
 	}
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/active-filter-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/active-filter-bar/index.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+import { store } from '@wordpress/viewport';
+import { Flex, FlexItem } from '@wordpress/components';
+
+function ActiveFilterBar( { children, actionsTitle, actions } ) {
+	const isSmall = select( store ).isViewportMatch( '< medium' );
+
+	return (
+		<Flex className="active-filter__bar" align="center">
+			<FlexItem className="active-filter__bar__copy">{ children }</FlexItem>
+			{ ! isSmall && actions.length > 0 && (
+				<FlexItem>
+					<Flex gap={ 0 }>
+						<FlexItem>
+							<h3 className="active-filter__bar__title">{ actionsTitle } </h3>
+						</FlexItem>
+
+						<FlexItem>
+							<ul>
+								{ actions.map( ( i ) => (
+									<li key={ i.href }>
+										<a href={ i.href }>{ i.label }</a>
+									</li>
+								) ) }
+							</ul>
+						</FlexItem>
+					</Flex>
+				</FlexItem>
+			) }
+		</Flex>
+	);
+}
+
+export default ActiveFilterBar;


### PR DESCRIPTION
This PR introduces a front-end component that provides context to the user about their current selected pattern.

See #48 for more context

### Example Usage
Since I'm unclear on how the frontend or backend will work, this should be considered a first attempt. We may want to use a more composite approach to the component; breaking out the "actions". 

```
<ActiveFilterBar
  actionsTitle="Related Categories"
  actions={ [
    {
        label: 'Ecommerce',
        href: '#intro',
    },
    {
        label: 'Columns',
        href: '#columns',
    },
    {
        label: 'Marketing',
        href: '#marketing',
    },
  ] }
>
12 patterns by <b>Bill Brasky</b>
</ActiveFilterBar>
```

### Screenshot
![](https://d.pr/i/LIajG3.png)
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->


### Questions
- In terms of mobile, I just hid the "actions side" of the component
  - It only works on page load right now, I'm not sure what our/gutenberg's preferred way to track window resize.
- Are we keen on building out the components using JS or do we want to build them in PHP templates?

### How to test the changes in this Pull Request:
Although there isn't a great way to test this since the parent UI doesn't exist yet.
