### PR TITLE
Theme: Add initial style and layout for the pattern grid

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -20,8 +20,11 @@
 @import "../../../wporg/css/components/widget-area";
 @import "../../../wporg/css/components/wporg-footer";
 @import "../../../wporg/css/components/wporg-header";
+@import "copy-button";
+@import "favorite-button";
 @import "main-navigation";
 @import "page";
+@import "pattern-grid";
 @import "pattern-preview";
 @import "pattern";
 @import "search-form";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_copy-button.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_copy-button.scss
@@ -1,0 +1,9 @@
+.pattern__copy-button {
+	transition: all 0.075s ease-in-out;
+
+	&.is-small {
+		font-size: 0.75rem;
+		padding: 0.75rem;
+		height: auto;
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_favorite-button.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_favorite-button.scss
@@ -1,0 +1,98 @@
+.pattern__favorite-button {
+	position: relative;
+	font-size: 0.875rem;
+	height: 2.25rem;
+	width: 2.25rem;
+	border-radius: 2px;
+	color: $color-gray-400;
+
+	svg {
+		position: absolute;
+		top: calc(50% - 0.75rem);
+		left: calc(50% - 0.75rem);
+		height: 1.5rem;
+		width: 1.5rem;
+		transition: all 0.15s ease-out;
+
+		path {
+			fill: $color-gray-300;
+		}
+	}
+
+	.favorite-filled {
+		opacity: 0;
+	}
+
+	&:hover {
+		color: $color__text;
+		background: transparent;
+
+		svg path {
+			fill: $color__text;
+		}
+	}
+
+	&:active {
+		background: transparent;
+		box-shadow: none;
+		transform: none;
+	}
+
+	&.is-favorited {
+		color: $color__text;
+
+		svg path {
+			fill: $color-alert-red;
+		}
+
+		.pattern__favorite-outline {
+			opacity: 0;
+			transform: scale(2.8);
+		}
+
+		.pattern__favorite-filled {
+			opacity: 1;
+		}
+
+		&:hover .pattern__favorite-filled {
+			animation: 0.9s infinite HeartBeat;
+
+			@media (prefers-reduced-motion) {
+				animation: none;
+			}
+		}
+	}
+
+	&.has-label {
+		padding: 12px 18px 12px 38px;
+		height: auto;
+		width: auto;
+
+		svg {
+			top: calc(50% - 12px);
+			left: 9px;
+		}
+	}
+}
+
+@keyframes HeartBeat {
+	0% {
+		transform: scale(1);
+	}
+
+	25% {
+		transform: scale(1.2);
+	}
+
+	40% {
+		transform: scale(1);
+	}
+
+	60% {
+		transform: scale(1.2);
+	}
+
+	100% {
+		transform: scale(1);
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -1,19 +1,33 @@
 .pattern-grid {
 	max-width: 960px;
-	margin: 1.5rem auto;
-	display: grid;
-	grid-template-columns: repeat(3, 1fr);
-	gap: 1.5rem;
-	align-items: baseline;
+	margin: 1.5rem;
+
+	@include breakpoint( $breakpoint-small ) {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1.5rem;
+		align-items: baseline;
+	}
+
+	@include breakpoint( $breakpoint-large ) {
+		margin-left: auto;
+		margin-right: auto;
+		grid-template-columns: repeat(3, 1fr);
+	}
 }
 
 .pattern-grid__pattern {
 	position: relative;
-	display: inline-block;
+	margin: 0 0 1.5rem;
 	border: 1px solid $color-gray-light-600;
 	border-radius: 2px;
 	transition: all 0.075s ease-in-out;
 	overflow: hidden;
+
+	@include breakpoint( $breakpoint-small ) {
+		display: inline-block;
+		margin: 0;
+	}
 
 	.pattern-grid__preview {
 		background: $color-gray-light-300;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -1,0 +1,56 @@
+.pattern-grid {
+	max-width: 960px;
+	margin: 1.5rem auto;
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 1.5rem;
+	align-items: baseline;
+}
+
+.pattern-grid__pattern {
+	position: relative;
+	display: inline-block;
+	border: 1px solid $color-gray-light-600;
+	border-radius: 2px;
+	transition: all 0.075s ease-in-out;
+	overflow: hidden;
+
+	.pattern-grid__preview {
+		background: $color-gray-light-300;
+	}
+
+	.pattern-grid__actions {
+		position: absolute;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		display: flex;
+		align-items: center;
+		padding: 0.375rem;
+		background: rgba($color-white, 0.8);
+		backdrop-filter: blur(3px);
+		opacity: 0;
+		transform: translateY(6px);
+		transition: all 0.075s ease-in-out;
+
+		.pattern-grid__title {
+			flex-grow: 1;
+			margin: 0;
+			padding: 0 0.375rem 0 0.75rem;
+			font-size: 0.75rem;
+			pointer-events: none;
+		}
+
+		.button + .button {
+			margin-left: 0.375rem;
+		}
+	}
+
+	&:hover,
+	&:focus-within {
+		.pattern-grid__actions {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -55,6 +55,11 @@
 			pointer-events: none;
 		}
 
+		.pattern__favorite-button,
+		.pattern__copy-button {
+			flex-shrink: 0;
+		}
+
 		.button + .button {
 			margin-left: 0.375rem;
 		}

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -9,6 +9,9 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'wp_head', __NAMESPACE__ . '\generate_block_editor_styles_html' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );
 
+add_filter( 'search_template', __NAMESPACE__ . '\use_index_php_as_template' );
+add_filter( 'archive_template', __NAMESPACE__ . '\use_index_php_as_template' );
+
 /**
  * Sets up theme defaults and registers support for various WordPress features.
  *
@@ -124,4 +127,10 @@ function pre_get_posts( $wp_query ) {
 		$wp_query->query_vars['post_type']   = array( POST_TYPE );
 		$wp_query->query_vars['post_status'] = array( 'publish' );
 	}
+}
+/**
+ * Use the index.php template for various WordPress views that would otherwise be handled by the parent theme.
+ */
+function use_index_php_as_template() {
+	return __DIR__ . '/index.php';
 }

--- a/public_html/wp-content/themes/pattern-directory/index.php
+++ b/public_html/wp-content/themes/pattern-directory/index.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * The main template file.
+ *
+ * This is the most generic template file in a WordPress theme
+ * and one of the two required files for a theme (the other being style.css).
+ * It is used to display a page when nothing more specific matches a query.
+ * E.g., it puts together the home page when no home.php file exists.
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package WordPressdotorg\Theme
+ */
+
+namespace WordPressdotorg\Theme;
+
+get_header();
+?>
+
+	<main id="main" class="site-main col-9" role="main">
+
+		<!-- Filter placeholder -->
+		<header style="background:whitesmoke;padding:24px;text-align:center;margin:0 0 24px;">
+			Section filters
+		</header>
+
+		<div class="pattern-grid">
+			<?php
+			if ( have_posts() ) :
+				/* Start the Loop */
+				while ( have_posts() ) :
+					the_post();
+					get_template_part( 'template-parts/content', 'grid' );
+				endwhile;
+			else :
+				get_template_part( 'template-parts/content', 'none' );
+			endif;
+			?>
+		</div>
+
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/public_html/wp-content/themes/pattern-directory/index.php
+++ b/public_html/wp-content/themes/pattern-directory/index.php
@@ -17,7 +17,7 @@ namespace WordPressdotorg\Theme;
 get_header();
 ?>
 
-	<main id="main" class="site-main col-9" role="main">
+	<main id="main" class="site-main" role="main">
 
 		<!-- Filter placeholder -->
 		<header style="background:whitesmoke;padding:24px;text-align:center;margin:0 0 24px;">

--- a/public_html/wp-content/themes/pattern-directory/template-parts/content-grid.php
+++ b/public_html/wp-content/themes/pattern-directory/template-parts/content-grid.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * The template part for displaying content
+ *
+ * @package WordPressdotorg\Theme;
+ */
+
+namespace WordPressdotorg\Theme;
+
+?>
+
+<div id="post-<?php the_ID(); ?>" <?php post_class( 'pattern-grid__pattern' ); ?>>
+	<div class="pattern-grid__preview" style="height:<?php echo esc_attr( rand( 100, 300 ) ); ?>px">
+		Pattern ID: <?php the_ID(); ?>
+	</div>
+	<div class="pattern-grid__actions">
+		<?php the_title( '<h2 class="pattern-grid__title">', '</h2>' ); ?>
+		<button class="button button-link pattern__favorite-button <?php echo 58 === get_the_ID() ? 'is-favorited' : ''; ?>">
+			<svg class="pattern__favorite-outline" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<path fill-rule="evenodd" clip-rule="evenodd" d="M12 4.915c1.09-1.28 2.76-2.09 4.5-2.09 3.08 0 5.5 2.42 5.5 5.5 0 3.777-3.394 6.855-8.537 11.518l-.013.012-1.45 1.32-1.45-1.31-.04-.036C5.384 15.17 2 12.095 2 8.325c0-3.08 2.42-5.5 5.5-5.5 1.74 0 3.41.81 4.5 2.09zm0 13.56l.1-.1c4.76-4.31 7.9-7.16 7.9-10.05 0-2-1.5-3.5-3.5-3.5-1.54 0-3.04.99-3.56 2.36h-1.87c-.53-1.37-2.03-2.36-3.57-2.36-2 0-3.5 1.5-3.5 3.5 0 2.89 3.14 5.74 7.9 10.05l.1.1z" fill="#000"></path>
+			</svg>
+			<svg class="pattern__favorite-filled" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<path d="M11.941 21.175l-1.443-1.32c-5.124-4.67-8.508-7.75-8.508-11.53 0-3.08 2.408-5.5 5.473-5.5 1.732 0 3.394.81 4.478 2.09 1.085-1.28 2.747-2.09 4.478-2.09 3.065 0 5.473 2.42 5.473 5.5 0 3.78-3.383 6.86-8.508 11.54l-1.443 1.31z" fill="#000"></path>
+			</svg>
+		</button>
+		<button class="button button-primary pattern__copy-button is-small"><?php esc_html_e( 'Copy', 'wporg-patterns' ); ?></button>
+	</div>
+</div>

--- a/public_html/wp-content/themes/pattern-directory/template-parts/content-grid.php
+++ b/public_html/wp-content/themes/pattern-directory/template-parts/content-grid.php
@@ -19,7 +19,7 @@ namespace WordPressdotorg\Theme;
 	</a>
 	<div class="pattern-grid__actions">
 		<?php the_title( '<h2 class="pattern-grid__title">', '</h2>' ); ?>
-		<button class="button button-link pattern__favorite-button <?php echo 58 === get_the_ID() ? 'is-favorited' : ''; ?>">
+		<button class="button button-link pattern__favorite-button">
 			<svg class="pattern__favorite-outline" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path fill-rule="evenodd" clip-rule="evenodd" d="M12 4.915c1.09-1.28 2.76-2.09 4.5-2.09 3.08 0 5.5 2.42 5.5 5.5 0 3.777-3.394 6.855-8.537 11.518l-.013.012-1.45 1.32-1.45-1.31-.04-.036C5.384 15.17 2 12.095 2 8.325c0-3.08 2.42-5.5 5.5-5.5 1.74 0 3.41.81 4.5 2.09zm0 13.56l.1-.1c4.76-4.31 7.9-7.16 7.9-10.05 0-2-1.5-3.5-3.5-3.5-1.54 0-3.04.99-3.56 2.36h-1.87c-.53-1.37-2.03-2.36-3.57-2.36-2 0-3.5 1.5-3.5 3.5 0 2.89 3.14 5.74 7.9 10.05l.1.1z" fill="#000"></path>
 			</svg>

--- a/public_html/wp-content/themes/pattern-directory/template-parts/content-grid.php
+++ b/public_html/wp-content/themes/pattern-directory/template-parts/content-grid.php
@@ -10,9 +10,13 @@ namespace WordPressdotorg\Theme;
 ?>
 
 <div id="post-<?php the_ID(); ?>" <?php post_class( 'pattern-grid__pattern' ); ?>>
-	<div class="pattern-grid__preview" style="height:<?php echo esc_attr( rand( 100, 300 ) ); ?>px">
-		Pattern ID: <?php the_ID(); ?>
-	</div>
+	<?php /* This link only wraps the "preview" container to avoid nesting the buttons inside the link. */ ?>
+	<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
+		<?php the_title( '<span class="screen-reader-text">', '</span>' ); ?>
+		<div class="pattern-grid__preview" style="height:<?php echo esc_attr( rand( 100, 300 ) ); ?>px">
+			Pattern ID: <?php the_ID(); ?>
+		</div>
+	</a>
 	<div class="pattern-grid__actions">
 		<?php the_title( '<h2 class="pattern-grid__title">', '</h2>' ); ?>
 		<button class="button button-link pattern__favorite-button <?php echo 58 === get_the_ID() ? 'is-favorited' : ''; ?>">


### PR DESCRIPTION
See #31, #62 — Start styling the pattern grid. PR only includes the PHP & CSS changes, I'm concurrently working on the JS side of things, but I think it makes more sense to do that in a following PR to avoid massive a changeset. So this does contain some placeholder sections (the preview, the filter bar).

### Screenshots

![Screen Shot 2021-03-31 at 12 29 41](https://user-images.githubusercontent.com/541093/113178651-c95d3300-921c-11eb-9891-18278fccc743.png)

Smaller screen:
![Screen Shot 2021-03-31 at 12 34 21](https://user-images.githubusercontent.com/541093/113179262-6fa93880-921d-11eb-834c-f13ca7221b2f.png)

Hover or focus-within:
![Screen Shot 2021-03-31 at 12 16 12](https://user-images.githubusercontent.com/541093/113177672-c746a480-921b-11eb-927f-e14a13418b48.png)

Hover or focus-within on a favorited pattern:
![Screen Shot 2021-03-31 at 12 16 19](https://user-images.githubusercontent.com/541093/113177673-c746a480-921b-11eb-8589-da453ff9d18b.png)

### How to test the changes in this Pull Request:

1. View any archive page (home, categories, search, … etc)
2. You should see a list of "patterns" (right now no preview, just a grey box of random height + the pattern ID).
3. Hover or tab through the patterns to see the title, copy, and favorite button.
4. Manually add the `is-favorited` class to a favorite button to see the favorited state.
5. Clicking on the pattern preview should bring you to the pattern itself.