### PR TITLE
Theme: Users can copy pattern to clipboard.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -12,9 +12,13 @@ body.single-wporg-pattern {
 
 	.entry-header {
 		max-width: $size__site-main;
-		padding: 2rem 0;
+		padding: 1.5rem;
 		margin-left: auto;
 		margin-right: auto;
+
+		@media only screen and (min-width: $breakpoint-small) {
+			padding: 1.5rem 0;
+		}
 
 		.entry-title {
 			margin-top: 0;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -62,10 +62,22 @@ body.single-wporg-pattern {
 
 			&-content {
 				padding: 1.5rem;
+				line-height: 1.5;
 			}
 
 			&-title {
 				margin: 0;
+			}
+
+			&-shortcut {
+				background: $color-gray-light-300;
+				box-shadow: 0 0 0 1px $color-gray-light-700;
+				padding: 1px;
+				font-weight: 600;
+				min-width: 20px;
+				display: inline-block;
+				text-align: center;
+				border-radius: 2px;
 			}
 		}
 	}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -16,7 +16,7 @@ body.single-wporg-pattern {
 		margin-left: auto;
 		margin-right: auto;
 
-		@media only screen and (min-width: $breakpoint-small) {
+		@media only screen and (min-width: $breakpoint-large) {
 			padding: 1.5rem 0;
 		}
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -26,6 +26,7 @@ body.single-wporg-pattern {
 		display: flex;
 		align-items: stretch;
 		flex-wrap: wrap;
+		overflow: hidden;
 
 		button + button {
 			margin-left: 2em;
@@ -34,6 +35,22 @@ body.single-wporg-pattern {
 		&__notice {
 			margin: 1.5rem 0 0;
 			flex-basis: 100%;
+			transform: translateY(0);
+			transition: transform 0.15s ease-in-out;
+
+			// Gutenberg wraps content
+			> * {
+				display: flex;
+				margin: 0;
+				justify-content: space-between;
+				align-items: center;
+			}
+
+			&--is-hidden {
+				margin: 0;
+				flex-basis: auto;
+				transform: translateY(60px);
+			}
 		}
 	}
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -25,9 +25,15 @@ body.single-wporg-pattern {
 	.pattern-actions {
 		display: flex;
 		align-items: stretch;
+		flex-wrap: wrap;
 
 		button + button {
 			margin-left: 2em;
+		}
+
+		&__notice {
+			margin: 1.5rem 0 0;
+			flex-basis: 100%;
 		}
 	}
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -30,7 +30,6 @@ body.single-wporg-pattern {
 		display: flex;
 		align-items: stretch;
 		flex-wrap: wrap;
-		overflow: hidden;
 
 		button + button {
 			margin-left: 2em;
@@ -40,8 +39,6 @@ body.single-wporg-pattern {
 			margin: 1.5rem 0 0;
 			height: auto;
 			flex-basis: 100%;
-			transform: translateY(0);
-			transition: transform 0.15s ease-in-out;
 
 			// @wordpress/components/notice wraps content
 			> * {
@@ -63,13 +60,6 @@ body.single-wporg-pattern {
 						margin-top: 0;
 					}
 				}
-			}
-
-			&--is-hidden {
-				margin: 0;
-				flex-basis: auto;
-				height: 0;
-				transform: translateY(60px);
 			}
 		}
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -41,9 +41,23 @@ body.single-wporg-pattern {
 			// @wordpress/components/notice wraps content
 			> * {
 				display: flex;
-				margin: 0;
+				flex-direction: column; // stack on mobile
 				justify-content: space-between;
-				align-items: center;
+				align-items: flex-start;
+				margin: 0;
+
+				button {
+					margin-top: 0.75rem;
+				}
+
+				@media only screen and (min-width: $breakpoint-small) {
+					align-items: center;
+					flex-direction: row;
+
+					button {
+						margin-top: 0;
+					}
+				}
 			}
 
 			&--is-hidden {

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -34,6 +34,7 @@ body.single-wporg-pattern {
 
 		&__notice {
 			margin: 1.5rem 0 0;
+			height: auto;
 			flex-basis: 100%;
 			transform: translateY(0);
 			transition: transform 0.15s ease-in-out;
@@ -63,6 +64,7 @@ body.single-wporg-pattern {
 			&--is-hidden {
 				margin: 0;
 				flex-basis: auto;
+				height: 0;
 				transform: translateY(60px);
 			}
 		}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -34,62 +34,62 @@ body.single-wporg-pattern {
 		button + button {
 			margin-left: 2em;
 		}
+	}
 
-		&__notice {
-			margin: 1.5rem 0 0;
-			height: auto;
-			flex-basis: 100%;
+	.pattern-actions__notice {
+		margin: 1.5rem 0 0;
+		height: auto;
+		flex-basis: 100%;
 
-			// @wordpress/components/notice wraps content
-			> * {
-				display: flex;
-				flex-direction: column; // stack on mobile
-				justify-content: space-between;
-				align-items: flex-start;
-				margin: 0;
+		// @wordpress/components/notice wraps content
+		> * {
+			display: flex;
+			flex-direction: column; // stack on mobile
+			justify-content: space-between;
+			align-items: flex-start;
+			margin: 0;
+
+			button {
+				margin-top: 0.75rem;
+			}
+
+			@media only screen and (min-width: $breakpoint-small) {
+				align-items: center;
+				flex-direction: row;
 
 				button {
-					margin-top: 0.75rem;
-				}
-
-				@media only screen and (min-width: $breakpoint-small) {
-					align-items: center;
-					flex-direction: row;
-
-					button {
-						margin-top: 0;
-					}
+					margin-top: 0;
 				}
 			}
 		}
+	}
 
-		&__guide {
-			max-width: $breakpoint-mobile / 1.25;
+	.pattern-actions__guide {
+		max-width: $breakpoint-mobile / 1.25;
 
-			// @wordpress/components/guide overrides
-			height: auto;
-			max-height: none;
+		// @wordpress/components/guide overrides
+		height: auto;
+		max-height: none;
+	}
 
-			&-content {
-				padding: 1.5rem;
-				line-height: 1.5;
-			}
+	.pattern-actions__guide-content {
+		padding: 1.5rem;
+		line-height: 1.5;
+	}
 
-			&-title {
-				margin: 0;
-			}
+	.pattern-actions__guide-title {
+		margin: 0;
+	}
 
-			&-shortcut {
-				background: $color-gray-light-300;
-				box-shadow: 0 0 0 1px $color-gray-light-700;
-				padding: 1px;
-				font-weight: 600;
-				min-width: 20px;
-				display: inline-block;
-				text-align: center;
-				border-radius: 2px;
-			}
-		}
+	.pattern-actions__guide-shortcut {
+		background: $color-gray-light-300;
+		box-shadow: 0 0 0 1px $color-gray-light-700;
+		padding: 1px;
+		font-weight: 600;
+		min-width: 20px;
+		display: inline-block;
+		text-align: center;
+		border-radius: 2px;
 	}
 
 	.entry-content {

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -38,7 +38,7 @@ body.single-wporg-pattern {
 			transform: translateY(0);
 			transition: transform 0.15s ease-in-out;
 
-			// Gutenberg wraps content
+			// @wordpress/components/notice wraps content
 			> * {
 				display: flex;
 				margin: 0;
@@ -50,6 +50,22 @@ body.single-wporg-pattern {
 				margin: 0;
 				flex-basis: auto;
 				transform: translateY(60px);
+			}
+		}
+
+		&__guide {
+			max-width: $breakpoint-mobile / 1.25;
+
+			// @wordpress/components/guide overrides
+			height: auto;
+			max-height: none;
+
+			&-content {
+				padding: 1.5rem;
+			}
+
+			&-title {
+				margin: 0;
 			}
 		}
 	}

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -11,7 +11,7 @@ namespace WordPressdotorg\Theme;
 
 get_header();
 ?>
-
+	<input id="block-data" type="hidden" value="<?php echo rawurlencode( wp_json_encode( get_the_content() ) ); ?>" />
 	<main id="main" class="site-main col-12" role="main">
 
 		<?php
@@ -23,7 +23,7 @@ get_header();
 				<header class="entry-header">
 					<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 					<p>A large hero section with an example background image and a heading in the center.</p>
-					<div class="pattern-actions">
+					<div id="pattern-actions" class="pattern-actions">
 						<button class="button button-primary">Copy Pattern</button>
 						<button class="button">Add to favorites</button>
 					</div>

--- a/public_html/wp-content/themes/pattern-directory/src/components/add-to-favorite-button/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/add-to-favorite-button/index.js
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const AddToFavoriteButton = () => {
+	return <button className="button">{ __( 'Add to favorites', 'wporg-patterns' ) }</button>;
+};
+
+export default AddToFavoriteButton;

--- a/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
@@ -3,11 +3,23 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const copyToClipboard = ( value ) => {
+/**
+ * Uses a hidden textarea that is added and removed from the DOM in order to copy to clipboard via the Browser.
+ *
+ * @param {string} stringToCopy A string that will be copied to the clipboard
+ * @return {boolean} Whether the copy function succeeded
+ */
+const copyToClipboard = ( stringToCopy ) => {
 	const element = document.createElement( 'textarea' );
+
+	// We don't want the text area to be visible since it's temporary.
+	element.style.position = 'absolute';
+	element.style.left = '-9999px';
+
+	element.value = stringToCopy;
+
+	// We don't want the text area to be selected since it's temporary.
 	element.setAttribute( 'readonly', '' );
-	element.style = { position: 'absolute', left: '-9999px' };
-	element.value = value;
 
 	document.body.appendChild( element );
 	element.select();
@@ -20,6 +32,7 @@ const copyToClipboard = ( value ) => {
 
 const CopyPatternButton = ( { onSuccess } ) => {
 	const handleClick = () => {
+		// Grab the pattern markup from hidden input
 		const blockData = document.getElementById( 'block-data' );
 		const blockPattern = JSON.parse( decodeURIComponent( blockData.value ) );
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
@@ -33,8 +33,6 @@ const copyToClipboard = ( stringToCopy ) => {
 
 const CopyPatternButton = ( { onSuccess } ) => {
 	const handleClick = ( { target } ) => {
-		onSuccess();
-
 		// Grab the pattern markup from hidden input
 		const blockData = document.getElementById( 'block-data' );
 		const blockPattern = JSON.parse( decodeURIComponent( blockData.value ) );

--- a/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 
 /**
  * Uses a hidden textarea that is added and removed from the DOM in order to copy to clipboard via the Browser.
@@ -46,9 +47,9 @@ const CopyPatternButton = ( { onSuccess } ) => {
 	};
 
 	return (
-		<button className="button button-primary" onClick={ handleClick }>
+		<Button isPrimary onClick={ handleClick }>
 			{ __( 'Copy Pattern', 'wporg-patterns' ) }
-		</button>
+		</Button>
 	);
 };
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const copyToClipboard = ( value ) => {
+	const element = document.createElement( 'textarea' );
+	element.setAttribute( 'readonly', '' );
+	element.style = { position: 'absolute', left: '-9999px' };
+	element.value = value;
+
+	document.body.appendChild( element );
+	element.select();
+
+	const success = document.execCommand( 'copy' );
+	document.body.removeChild( element );
+
+	return success;
+};
+
+const CopyPatternButton = ( { onSuccess } ) => {
+	const handleClick = () => {
+		const blockData = document.getElementById( 'block-data' );
+		const blockPattern = JSON.parse( decodeURIComponent( blockData.value ) );
+
+		const success = copyToClipboard( blockPattern );
+
+		if ( success ) {
+			onSuccess();
+		} else {
+			// TODO Handle error case
+		}
+	};
+
+	return (
+		<button className="button button-primary" onClick={ handleClick }>
+			{ __( 'Copy Pattern', 'wporg-patterns' ) }
+		</button>
+	);
+};
+
+export default CopyPatternButton;

--- a/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
@@ -13,14 +13,14 @@ import { Button } from '@wordpress/components';
 const copyToClipboard = ( stringToCopy ) => {
 	const element = document.createElement( 'textarea' );
 
+	// We don't want the text area to be selected since it's temporary.
+	element.setAttribute( 'readonly', '' );
+
 	// We don't want the text area to be visible since it's temporary.
 	element.style.position = 'absolute';
 	element.style.left = '-9999px';
 
 	element.value = stringToCopy;
-
-	// We don't want the text area to be selected since it's temporary.
-	element.setAttribute( 'readonly', '' );
 
 	document.body.appendChild( element );
 	element.select();
@@ -32,12 +32,17 @@ const copyToClipboard = ( stringToCopy ) => {
 };
 
 const CopyPatternButton = ( { onSuccess } ) => {
-	const handleClick = () => {
+	const handleClick = ( { target } ) => {
+		onSuccess();
+
 		// Grab the pattern markup from hidden input
 		const blockData = document.getElementById( 'block-data' );
 		const blockPattern = JSON.parse( decodeURIComponent( blockData.value ) );
 
 		const success = copyToClipboard( blockPattern );
+
+		// Make sure we reset focus in case it was lost in the 'copy' command.
+		target.focus();
 
 		if ( success ) {
 			onSuccess();

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
@@ -9,7 +9,7 @@ const CopyPasteImage = () => (
 	// Wrap the image to avoid the UI shift after the GIF loads
 	<div style={ { height: '220px' } }>
 		<img
-			src="https://shaunandrews.com/wp-content/uploads/2021/03/pattern-paste-demo-2.gif"
+			src="/wp-content/themes/pattern-directory/images/copy-paste-demo.gif"
 			alt={ __( 'GIF of copy and pasting.', 'wporg-patterns' ) }
 		/>
 	</div>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
@@ -58,11 +58,11 @@ const CopyGuide = ( { onFinish } ) => {
 											<p>
 												{ createInterpolateElement(
 													__(
-														'Paste the contents of your clipboard by pressing both the <span>⌘</span> and <span>v</span> keys, or right-clicking and choose "Paste" from the menu.',
+														'Paste the contents of your clipboard by pressing both the <kbd>⌘</kbd> and <kbd>v</kbd> keys, or right-clicking and choose "Paste" from the menu.',
 														'wporg-patterns'
 													),
 													{
-														span: <span className="pattern-actions__guide-shortcut" />,
+														kbd: <kbd className="pattern-actions__guide-shortcut" />,
 													}
 												) }
 											</p>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Animate, Guide } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 
 const CopyPasteImage = () => (
 	// Wrap the image to avoid the UI shift after the GIF loads
@@ -55,9 +56,14 @@ const CopyGuide = ( { onFinish } ) => {
 										</li>
 										<li>
 											<p>
-												{ __(
-													'Paste the contents of your clipboard by pressing both the ⌘ and v keys, or right-clicking and choose "Paste" from the menu.',
-													'wporg-patterns'
+												{ createInterpolateElement(
+													__(
+														'Paste the contents of your clipboard by pressing both the <span>⌘</span> and <span>v</span> keys, or right-clicking and choose "Paste" from the menu.',
+														'wporg-patterns'
+													),
+													{
+														span: <span className="pattern-actions__guide-shortcut" />,
+													}
 												) }
 											</p>
 										</li>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Animate, Guide } from '@wordpress/components';
+
+const CopyPasteImage = () => (
+	// Wrap the image to avoid the UI shift after the GIF loads
+	<div style={ { height: '220px' } }>
+		<img
+			src="https://shaunandrews.com/wp-content/uploads/2021/03/pattern-paste-demo-2.gif"
+			alt={ __( 'GIF of copy and pasting.', 'wporg-patterns' ) }
+		/>
+	</div>
+);
+
+const CopyGuide = ( { onFinish } ) => {
+	return (
+		<Animate type="appear" options={ { origin: 'bottom' } }>
+			{ ( { className } ) => (
+				<Guide
+					className={ `pattern-actions__guide ${ className }` }
+					onFinish={ onFinish }
+					finishButtonText={ __( 'Close', 'wporg-patterns' ) }
+					pages={ [
+						{
+							image: <CopyPasteImage />,
+							content: (
+								<div className="pattern-actions__guide-content">
+									<h3 className="pattern-actions__guide-title">
+										{ __( 'How to use patterns on your WordPress site.', 'wporg-patterns' ) }
+									</h3>
+									<p>
+										{ __(
+											'Patterns are really just text. And, just like you can copy and paste text, you can copy and paste patterns. Its really easy!',
+											'wporg-patterns'
+										) }
+									</p>
+									<ol>
+										<li>
+											<p>
+												{ __(
+													'Open any post or page in the WordPress block editor.',
+													'wporg-patterns'
+												) }
+											</p>
+										</li>
+										<li>
+											<p>
+												{ __(
+													'Place your cursor where you want to add the pattern.',
+													'wporg-patterns'
+												) }
+											</p>
+										</li>
+										<li>
+											<p>
+												{ __(
+													'Paste the contents of your clipboard by pressing both the ⌘ and v keys, or right-clicking and choose "Paste" from the menu.',
+													'wporg-patterns'
+												) }
+											</p>
+										</li>
+									</ol>
+								</div>
+							),
+						},
+					] }
+				/>
+			) }
+		</Animate>
+	);
+};
+
+export default CopyGuide;

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-success-message.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-success-message.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/components';
 
-const SuccessMessage = ( { onClick } ) => (
+const CopySuccessMessage = ( { onClick } ) => (
 	<Notice
 		className="pattern-actions__notice"
 		status="success"
@@ -20,4 +20,4 @@ const SuccessMessage = ( { onClick } ) => (
 	</Notice>
 );
 
-export default SuccessMessage;
+export default CopySuccessMessage;

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
@@ -19,7 +19,7 @@ const PatternPreviewActions = () => {
 		<>
 			<CopyPatternButton onSuccess={ () => setShowSuccess( true ) } />
 			<AddToFavoriteButton />
-			<SuccessMessage showMessage={ showSuccess } onClick={ () => setShowGuide( true ) } />
+			{ showSuccess && <SuccessMessage onClick={ () => setShowGuide( true ) } /> }
 			{ showGuide && <CopyGuide onFinish={ () => setShowGuide( false ) } /> }
 		</>
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
@@ -8,7 +8,7 @@ import { useState } from '@wordpress/element';
  */
 import CopyPatternButton from '../copy-pattern-button';
 import AddToFavoriteButton from '../add-to-favorite-button';
-import SuccessMessage from './success-message';
+import CopySuccessMessage from './copy-success-message';
 import CopyGuide from './copy-guide';
 
 const PatternPreviewActions = () => {
@@ -19,7 +19,7 @@ const PatternPreviewActions = () => {
 		<>
 			<CopyPatternButton onSuccess={ () => setShowSuccess( true ) } />
 			<AddToFavoriteButton />
-			{ showSuccess && <SuccessMessage onClick={ () => setShowGuide( true ) } /> }
+			{ showSuccess && <CopySuccessMessage onClick={ () => setShowGuide( true ) } /> }
 			{ showGuide && <CopyGuide onFinish={ () => setShowGuide( false ) } /> }
 		</>
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { Notice } from '@wordpress/components';
+import { Button, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -11,10 +11,17 @@ import { Notice } from '@wordpress/components';
 import CopyPatternButton from '../copy-pattern-button';
 import AddToFavoriteButton from '../add-to-favorite-button';
 
-const SuccessMessage = () => (
-	<Notice className="pattern-actions__notice" status="success" isDismissible={ false }>
-		<b>{ __( 'Pattern copied!', 'wporg-patterns' ) }</b>
-		{ __( ' Now you can paste it into any WordPress post or page.', 'wporg-patterns' ) }
+const SuccessMessage = ( { showMessage } ) => (
+	<Notice
+		className={ `pattern-actions__notice ${ ! showMessage ? 'pattern-actions__notice--is-hidden' : '' }` }
+		status="success"
+		isDismissible={ false }
+	>
+		<div>
+			<b>{ __( 'Pattern copied!', 'wporg-patterns' ) }</b>
+			{ __( ' Now you can paste it into any WordPress post or page.', 'wporg-patterns' ) }
+		</div>
+		<Button isSecondary>{ __( 'Learn More', 'wporg-patterns' ) }</Button>
 	</Notice>
 );
 
@@ -25,7 +32,7 @@ const PatternPreviewActions = () => {
 		<>
 			<CopyPatternButton onSuccess={ () => setShowSuccess( true ) } />
 			<AddToFavoriteButton />
-			{ showSuccess && <SuccessMessage /> }
+			<SuccessMessage showMessage={ showSuccess } />
 		</>
 	);
 };

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import CopyPatternButton from '../copy-pattern-button';
+import AddToFavoriteButton from '../add-to-favorite-button';
+
+const SuccessMessage = () => (
+	<Notice className="pattern-actions__notice" status="success" isDismissible={ false }>
+		<b>{ __( 'Pattern copied!', 'wporg-patterns' ) }</b>
+		{ __( ' Now you can paste it into any WordPress post or page.', 'wporg-patterns' ) }
+	</Notice>
+);
+
+const PatternPreviewActions = () => {
+	const [ showSuccess, setShowSuccess ] = useState();
+
+	return (
+		<>
+			<CopyPatternButton onSuccess={ () => setShowSuccess( true ) } />
+			<AddToFavoriteButton />
+			{ showSuccess && <SuccessMessage /> }
+		</>
+	);
+};
+
+export default PatternPreviewActions;

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
@@ -1,38 +1,26 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { Button, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import CopyPatternButton from '../copy-pattern-button';
 import AddToFavoriteButton from '../add-to-favorite-button';
-
-const SuccessMessage = ( { showMessage } ) => (
-	<Notice
-		className={ `pattern-actions__notice ${ ! showMessage ? 'pattern-actions__notice--is-hidden' : '' }` }
-		status="success"
-		isDismissible={ false }
-	>
-		<div>
-			<b>{ __( 'Pattern copied!', 'wporg-patterns' ) }</b>
-			{ __( ' Now you can paste it into any WordPress post or page.', 'wporg-patterns' ) }
-		</div>
-		<Button isSecondary>{ __( 'Learn More', 'wporg-patterns' ) }</Button>
-	</Notice>
-);
+import SuccessMessage from './success-message';
+import CopyGuide from './copy-guide';
 
 const PatternPreviewActions = () => {
-	const [ showSuccess, setShowSuccess ] = useState();
+	const [ showSuccess, setShowSuccess ] = useState( false );
+	const [ showGuide, setShowGuide ] = useState( false );
 
 	return (
 		<>
 			<CopyPatternButton onSuccess={ () => setShowSuccess( true ) } />
 			<AddToFavoriteButton />
-			<SuccessMessage showMessage={ showSuccess } />
+			<SuccessMessage showMessage={ showSuccess } onClick={ () => setShowGuide( true ) } />
+			{ showGuide && <CopyGuide onFinish={ () => setShowGuide( false ) } /> }
 		</>
 	);
 };

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/success-message.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/success-message.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, Notice } from '@wordpress/components';
+
+const SuccessMessage = ( { showMessage, onClick } ) => (
+	<Notice
+		className={ `pattern-actions__notice ${ ! showMessage ? 'pattern-actions__notice--is-hidden' : '' }` }
+		status="success"
+		isDismissible={ false }
+	>
+		<div>
+			<b>{ __( 'Pattern copied!', 'wporg-patterns' ) }</b>
+			{ __( ' Now you can paste it into any WordPress post or page.', 'wporg-patterns' ) }
+		</div>
+		<Button onClick={ onClick } isSecondary>
+			{ __( 'Learn More', 'wporg-patterns' ) }
+		</Button>
+	</Notice>
+);
+
+export default SuccessMessage;

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/success-message.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/success-message.js
@@ -14,7 +14,7 @@ const SuccessMessage = ( { showMessage, onClick } ) => (
 			<b>{ __( 'Pattern copied!', 'wporg-patterns' ) }</b>
 			{ __( ' Now you can paste it into any WordPress post or page.', 'wporg-patterns' ) }
 		</div>
-		<Button onClick={ onClick } isSecondary>
+		<Button onClick={ onClick } isSecondary tabIndex={ showMessage ? '0' : '-1' }>
 			{ __( 'Learn More', 'wporg-patterns' ) }
 		</Button>
 	</Notice>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/success-message.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/success-message.js
@@ -4,9 +4,9 @@
 import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/components';
 
-const SuccessMessage = ( { showMessage, onClick } ) => (
+const SuccessMessage = ( { onClick } ) => (
 	<Notice
-		className={ `pattern-actions__notice ${ ! showMessage ? 'pattern-actions__notice--is-hidden' : '' }` }
+		className="pattern-actions__notice"
 		status="success"
 		isDismissible={ false }
 	>
@@ -14,7 +14,7 @@ const SuccessMessage = ( { showMessage, onClick } ) => (
 			<b>{ __( 'Pattern copied!', 'wporg-patterns' ) }</b>
 			{ __( ' Now you can paste it into any WordPress post or page.', 'wporg-patterns' ) }
 		</div>
-		<Button onClick={ onClick } isSecondary tabIndex={ showMessage ? '0' : '-1' }>
+		<Button onClick={ onClick } isSecondary>
 			{ __( 'Learn More', 'wporg-patterns' ) }
 		</Button>
 	</Notice>

--- a/public_html/wp-content/themes/pattern-directory/src/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/index.js
@@ -8,6 +8,7 @@ import { render } from '@wordpress/element';
  */
 import PatternPreview from './components/pattern-preview';
 import PatternGrid from './components/pattern-grid';
+import PatternPreviewActions from './components/pattern-preview-actions';
 
 // Load the preview into any awaiting preview container.
 const previewContainers = document.querySelectorAll( '.pattern-preview__container' );
@@ -26,4 +27,10 @@ for ( let i = 0; i < previewContainers.length; i++ ) {
 const gridContainer = document.getElementById( 'pattern-grid__container' );
 if ( gridContainer ) {
 	render( <PatternGrid />, gridContainer );
+}
+
+// Load the pattern preview actions
+const patternActionsContainer = document.getElementById( 'pattern-actions' );
+if ( patternActionsContainer ) {
+	render( <PatternPreviewActions />, patternActionsContainer );
 }


### PR DESCRIPTION
This PR allows users to copy a pattern to their clipboard.

### Key Points:
- This PR tries to use `@wordpress/components` as much as possible even though this slightly deviates from the design.
  - `Guide`, `Button`, `Notice`
- This PR leverages another [`render`](https://github.com/WordPress/pattern-directory/compare/update/copy-to-clipboard?expand=1#diff-6897a946f493ca3f66c4f3760d29fa084ffc6d48bfa634fe52566c36e63edebaR34) to integrate into the view.
  - We may want to consider having only one `render` for the whole preview...? Not sure what the pros & cons would be yet.
- This PR uses a hidden input to retrieve the pattern to copy to the clipboard (probably temporarily). 
  - We could pass it in the same way we do it for `.pattern-preview__container`, 
  - .. maybe it's retrievable from the state once we get that integrated.
 - This PR introduces an `AddToFavoriteButton` which is incomplete.

Fixes #53

### Screenshots

_Note: The add to favorites button needs updating. See #52._

| Mobile | Desktop |
| --- | --- |
| ![](https://d.pr/i/yXy7sd.gif) | ![](https://d.pr/i/xuub2l.gif)  |

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Create a block pattern
2. Visit `localhost:8888`
3. Click on the block pattern in the grid
4. Click on the `Copy Pattern` button
5. Verify that a success message is presented
6. Paste the contents of your clipboard somewhere to verify the pattern was copied
7. Click the 'Learn more' in the success message
8. Verify a modal window opens
9. Close the window.

