### PR TITLE
Directory: Register custom post statuses

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -10,4 +10,5 @@ namespace WordPressdotorg\Pattern_Directory;
 
 require_once __DIR__ . '/includes/pattern-post-type.php';
 require_once __DIR__ . '/includes/pattern-validation.php';
+require_once __DIR__ . '/includes/post-status.php';
 require_once __DIR__ . '/includes/search.php';

--- a/public_html/wp-content/plugins/pattern-directory/includes/post-status.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/post-status.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Post_Status;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_action( 'init', __NAMESPACE__ . '\register_post_statuses' );
+
+/**
+ * Register custom statuses for patterns.
+ *
+ * @return void
+ */
+function register_post_statuses() {
+	register_post_status(
+		'declined',
+		array(
+			'label'     => __( 'Declined', 'wporg-patterns' ),
+			'public'    => false,
+			'protected' => true,
+		)
+	);
+
+	register_post_status(
+		'removed',
+		array(
+			'label'     => __( 'Removed', 'wporg-patterns' ),
+			'public'    => false,
+			'protected' => true,
+		)
+	);
+}


### PR DESCRIPTION
This simply registers the two post statuses to be used for patterns that aren't already built-in. There could be need in the future for more functionality around these statuses, but we can build that as needed in separate PRs.

Fixes #56
