### PR TITLE
Add an ordinal to the category taxonomy.

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -9,5 +9,6 @@
 namespace WordPressdotorg\Pattern_Directory;
 
 require_once __DIR__ . '/includes/pattern-post-type.php';
+require_once __DIR__ . '/includes/pattern-taxonomy-modifications.php';
 require_once __DIR__ . '/includes/pattern-validation.php';
 require_once __DIR__ . '/includes/search.php';

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
@@ -60,10 +60,11 @@ function edit_ordering_form_field( $term ) {
  * @param integer $term_id Term id.
  */
 function save_term_field( $term_id ) {
+	/* phpcs:disable WordPress.Security.NonceVerification.Missing */
 	update_term_meta(
 		$term_id,
 		CATEGORY_TAXONOMY_ID,
-		sanitize_text_field( $_POST[ CATEGORY_TAXONOMY_ID ] )
+		absint( wp_unslash( $_POST[ CATEGORY_TAXONOMY_ID ] ) )
 	);
 }
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
@@ -21,7 +21,7 @@ add_filter( "rest_prepare_{$CATEGORY_TAXONOMY}", __NAMESPACE__ . '\rest_prepare_
 function add_ordering_form_field() {
 	echo '
 		<div class="form-field">
-			<label for="category-order">Order</label>
+			<label for="category-order">Display Order</label>
 			<input type="number" min="1" name="category-order" id="category-order" />
 		</div>
 	';
@@ -40,7 +40,7 @@ function edit_ordering_form_field( $term ) {
 	echo '
 		<tr class="form-field">
 			<th>
-				<label for="category-order">Order</label>
+				<label for="category-order">Display Order</label>
 			</th>
 			<td>
 				<input name="category-order" min="1" id="category-order" type="number" value="' . esc_attr( $value ) . '" />
@@ -76,7 +76,7 @@ function save_term_field( $term_id ) {
  */
 function add_order_table_heading( $columns ) {
 	// Our our custom column heading
-	$columns[ CATEGORY_TAXONOMY_ID ] = __( 'Order' );
+	$columns[ CATEGORY_TAXONOMY_ID ] = __( 'Display Order' );
 
 	return $columns;
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
@@ -3,7 +3,7 @@
 namespace WordPressdotorg\Pattern_Directory\Pattern_Taxonomy_Modifications;
 
 $CATEGORY_TAXONOMY = 'wporg-pattern-category';
-const CATEGORY_TAXONOMY_ID = 'category-order';
+const CATEGORY_TAXONOMY_ID = 'display-order';
 
 add_action( "{$CATEGORY_TAXONOMY}_add_form_fields", __NAMESPACE__ . '\add_ordering_form_field', 0 );
 add_action( "{$CATEGORY_TAXONOMY}_edit_form_fields", __NAMESPACE__ . '\edit_ordering_form_field', 10, 2 );
@@ -21,8 +21,8 @@ add_filter( "rest_prepare_{$CATEGORY_TAXONOMY}", __NAMESPACE__ . '\rest_prepare_
 function add_ordering_form_field() {
 	echo '
 		<div class="form-field">
-			<label for="category-order">Display Order</label>
-			<input type="number" min="1" name="category-order" id="category-order" />
+			<label for="display-order">Display Order</label>
+			<input type="number" min="1" name="display-order" id="display-order" />
 		</div>
 	';
 }
@@ -40,10 +40,10 @@ function edit_ordering_form_field( $term ) {
 	echo '
 		<tr class="form-field">
 			<th>
-				<label for="category-order">Display Order</label>
+				<label for="display-order">Display Order</label>
 			</th>
 			<td>
-				<input name="category-order" min="1" id="category-order" type="number" value="' . esc_attr( $value ) . '" />
+				<input name="display-order" min="1" id="display-order" type="number" value="' . esc_attr( $value ) . '" />
 			</td>
 		</tr>
 	';

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Pattern_Taxonomy_Modifications;
+
+$CATEGORY_TAXONOMY = 'wporg-pattern-category';
+const CATEGORY_TAXONOMY_ID = 'category-order';
+
+add_action( "{$CATEGORY_TAXONOMY}_add_form_fields", __NAMESPACE__ . '\add_ordering_form_field', 0 );
+add_action( "{$CATEGORY_TAXONOMY}_edit_form_fields", __NAMESPACE__ . '\edit_ordering_form_field', 10, 2 );
+add_action( "created_{$CATEGORY_TAXONOMY}", __NAMESPACE__ . '\save_term_field' );
+add_action( "edited_{$CATEGORY_TAXONOMY}", __NAMESPACE__ . '\save_term_field' );
+add_filter( "manage_{$CATEGORY_TAXONOMY}_custom_column", __NAMESPACE__ . '\add_category_order_column_content', 10, 3 );
+add_filter( "manage_edit-{$CATEGORY_TAXONOMY}_columns", __NAMESPACE__ . '\add_order_table_heading' );
+add_filter( "rest_prepare_{$CATEGORY_TAXONOMY}", __NAMESPACE__ . '\rest_prepare_category_response', 10, 2 );
+
+/**
+ * Adds a form field for adding an ordinal number to a new category.
+ *
+ * This is a callback for the `{$taxonomy}_add_form_fields` filter, and it's used to modify the new taxonomy form.
+ */
+function add_ordering_form_field() {
+	echo '
+		<div class="form-field">
+			<label for="category-order">Order</label>
+			<input type="number" min="1" name="category-order" id="category-order" />
+		</div>
+	';
+}
+
+/**
+ * Adds a form field for editing an ordinal number for a category.
+ *
+ * This is a callback for the `{$taxonomy}_edit_form_fields` filter, and it's used to modify the edit taxonomy form.
+ *
+ * @param WP_Term $term Term object
+ */
+function edit_ordering_form_field( $term ) {
+	$value = get_term_meta( $term->term_id, CATEGORY_TAXONOMY_ID, true );
+
+	echo '
+		<tr class="form-field">
+			<th>
+				<label for="category-order">Order</label>
+			</th>
+			<td>
+				<input name="category-order" min="1" id="category-order" type="number" value="' . esc_attr( $value ) . '" />
+			</td>
+		</tr>
+	';
+
+}
+
+/**
+ * Saves the custom taxonomy field to the database.
+ *
+ * This is a callback for the `created_{$taxonomy}` and `edited_{$taxonomy}` filter, and it's used to save meta information to the database.
+ *
+ * @param integer $term_id Term id
+ */
+function save_term_field( $term_id ) {
+	update_term_meta(
+		$term_id,
+		CATEGORY_TAXONOMY_ID,
+		sanitize_text_field( $_POST[ CATEGORY_TAXONOMY_ID ] )
+	);
+}
+
+/**
+ * Adds the category ordinal table heading.
+ *
+ * This is a callback for the `manage_edit-{$taxonomy}_columns` filter, and it's used modify table headings on taxonomy pages.
+ *
+ * @param string[] $columns Columns that are displayed in the table.
+ *
+ * @return string[]
+ */
+function add_order_table_heading( $columns ) {
+	// Our our custom column heading
+	$columns[ CATEGORY_TAXONOMY_ID ] = __( 'Order' );
+
+	return $columns;
+}
+
+/**
+ * Adds the custom meta field data to category table row.
+ *
+ * This is a callback for the `manage_{$taxonomy}_custom_column` filter, and it's used to modify column content.
+ *
+ * @param string  $content
+ * @param string  $column
+ * @param integer $term_id
+ *
+ * @return string
+ */
+function add_category_order_column_content( $content, $column, $term_id ) {
+	$order = get_term_meta( $term_id, CATEGORY_TAXONOMY_ID, true );
+
+	return $order;
+}
+
+/**
+ * Modifies rest response to include "ordinal" for pattern-categories.
+ *
+ * This is a callback for the `rest_prepare_{$taxonomy}` filter, and it's used to modify rest responses.
+ *
+ * @param WP_REST_Response $response
+ * @param WP_Term          $term
+ *
+ * @return WP_REST_Response
+ */
+function rest_prepare_category_response( $response, $term ) {
+	$orderNum = get_term_meta( $term->term_id, CATEGORY_TAXONOMY_ID, true );
+
+	// If it's empty we'll make it very low priority
+	if ( empty( $orderNum ) ) {
+		$orderNum = 9999;
+	}
+
+	$response->data['ordinal'] = (int) $orderNum;
+
+	return $response;
+}
+

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
@@ -99,7 +99,7 @@ function add_category_order_column_content( $content, $column, $term_id ) {
 }
 
 /**
- * Modifies rest response to include "ordinal" for pattern-categories.
+ * Modifies rest response to include "displayOrder" for pattern-categories.
  *
  * This is a callback for the `rest_prepare_{$taxonomy}` filter, and it's used to modify rest responses.
  *
@@ -116,7 +116,7 @@ function rest_prepare_category_response( $response, $term ) {
 		$orderNum = 9999;
 	}
 
-	$response->data['ordinal'] = (int) $orderNum;
+	$response->data['displayOrder'] = (int) $orderNum;
 
 	return $response;
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
@@ -23,6 +23,7 @@ function add_ordering_form_field() {
 		<div class="form-field">
 			<label for="display-order">Display Order</label>
 			<input type="number" min="1" name="display-order" id="display-order" />
+			<p>This is used to order the categories in the pattern grid navigation.</p>
 		</div>
 	';
 }
@@ -44,6 +45,7 @@ function edit_ordering_form_field( $term ) {
 			</th>
 			<td>
 				<input name="display-order" min="1" id="display-order" type="number" value="' . esc_attr( $value ) . '" />
+				<p class="description">This is used to order the categories in the pattern grid navigation.</p>
 			</td>
 		</tr>
 	';

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
@@ -101,7 +101,7 @@ function add_category_order_column_content( $content, $column, $term_id ) {
 }
 
 /**
- * Modifies rest response to include "displayOrder" for pattern-categories.
+ * Modifies rest response to include "display_order" for pattern-categories.
  *
  * This is a callback for the `rest_prepare_{$taxonomy}` filter, and it's used to modify rest responses.
  *
@@ -118,7 +118,7 @@ function rest_prepare_category_response( $response, $term ) {
 		$orderNum = 9999;
 	}
 
-	$response->data['displayOrder'] = (int) $orderNum;
+	$response->data['display_order'] = (int) $orderNum;
 
 	return $response;
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-taxonomy-modifications.php
@@ -2,16 +2,16 @@
 
 namespace WordPressdotorg\Pattern_Directory\Pattern_Taxonomy_Modifications;
 
-$CATEGORY_TAXONOMY = 'wporg-pattern-category';
+$category_taxonomy = 'wporg-pattern-category';
 const CATEGORY_TAXONOMY_ID = 'display-order';
 
-add_action( "{$CATEGORY_TAXONOMY}_add_form_fields", __NAMESPACE__ . '\add_ordering_form_field', 0 );
-add_action( "{$CATEGORY_TAXONOMY}_edit_form_fields", __NAMESPACE__ . '\edit_ordering_form_field', 10, 2 );
-add_action( "created_{$CATEGORY_TAXONOMY}", __NAMESPACE__ . '\save_term_field' );
-add_action( "edited_{$CATEGORY_TAXONOMY}", __NAMESPACE__ . '\save_term_field' );
-add_filter( "manage_{$CATEGORY_TAXONOMY}_custom_column", __NAMESPACE__ . '\add_category_order_column_content', 10, 3 );
-add_filter( "manage_edit-{$CATEGORY_TAXONOMY}_columns", __NAMESPACE__ . '\add_order_table_heading' );
-add_filter( "rest_prepare_{$CATEGORY_TAXONOMY}", __NAMESPACE__ . '\rest_prepare_category_response', 10, 2 );
+add_action( "{$category_taxonomy}_add_form_fields", __NAMESPACE__ . '\add_ordering_form_field', 0 );
+add_action( "{$category_taxonomy}_edit_form_fields", __NAMESPACE__ . '\edit_ordering_form_field', 10, 2 );
+add_action( "created_{$category_taxonomy}", __NAMESPACE__ . '\save_term_field' );
+add_action( "edited_{$category_taxonomy}", __NAMESPACE__ . '\save_term_field' );
+add_filter( "manage_{$category_taxonomy}_custom_column", __NAMESPACE__ . '\add_category_order_column_content', 10, 3 );
+add_filter( "manage_edit-{$category_taxonomy}_columns", __NAMESPACE__ . '\add_order_table_heading' );
+add_filter( "rest_prepare_{$category_taxonomy}", __NAMESPACE__ . '\rest_prepare_category_response', 10, 2 );
 
 /**
  * Adds a form field for adding an ordinal number to a new category.
@@ -33,7 +33,7 @@ function add_ordering_form_field() {
  *
  * This is a callback for the `{$taxonomy}_edit_form_fields` filter, and it's used to modify the edit taxonomy form.
  *
- * @param WP_Term $term Term object
+ * @param WP_Term $term Term object.
  */
 function edit_ordering_form_field( $term ) {
 	$value = get_term_meta( $term->term_id, CATEGORY_TAXONOMY_ID, true );
@@ -57,7 +57,7 @@ function edit_ordering_form_field( $term ) {
  *
  * This is a callback for the `created_{$taxonomy}` and `edited_{$taxonomy}` filter, and it's used to save meta information to the database.
  *
- * @param integer $term_id Term id
+ * @param integer $term_id Term id.
  */
 function save_term_field( $term_id ) {
 	update_term_meta(
@@ -78,7 +78,7 @@ function save_term_field( $term_id ) {
  */
 function add_order_table_heading( $columns ) {
 	// Our our custom column heading
-	$columns[ CATEGORY_TAXONOMY_ID ] = __( 'Display Order' );
+	$columns[ CATEGORY_TAXONOMY_ID ] = __( 'Display Order', 'wporg-patterns' );
 
 	return $columns;
 }
@@ -111,14 +111,14 @@ function add_category_order_column_content( $content, $column, $term_id ) {
  * @return WP_REST_Response
  */
 function rest_prepare_category_response( $response, $term ) {
-	$orderNum = get_term_meta( $term->term_id, CATEGORY_TAXONOMY_ID, true );
+	$order_num = get_term_meta( $term->term_id, CATEGORY_TAXONOMY_ID, true );
 
 	// If it's empty we'll make it very low priority
-	if ( empty( $orderNum ) ) {
-		$orderNum = 9999;
+	if ( empty( $order_num ) ) {
+		$order_num = 9999;
 	}
 
-	$response->data['display_order'] = (int) $orderNum;
+	$response->data['display_order'] = (int) $order_num;
 
 	return $response;
 }


### PR DESCRIPTION
This PR adds a `display-order` property to `wporg-pattern-category` taxonomy so we can control the order of categories listed in the Pattern Grid Menu (Visible here: #48, being implemented here: #72). 

See #73.


**Example rest response:** 
```
[{
  "id":12,
  "count":0,
  "name":"Footer",
  "slug":"footer",
  "taxonomy":"wporg-pattern-category",
  "parent":0,
  "meta":[],
  "display_order":1,
...
}]
```

### Screenshots
| Add/View | Edit |
| --- | --- |
| ![](https://d.pr/i/uuyZiq.png)  |  ![](https://d.pr/i/K5FHvs.png)  |

### How to test the changes in this Pull Request:

1. Visit `/wp-admin/edit-tags.php?taxonomy=wporg-pattern-category&post_type=wporg-pattern`
2. Add a category, include a numerical value in the `Display Order` field
3. Click `Add new category`
4. Verify that it shows up in the category table column `Display Order`.
5. Click on the category in the table
6. Verify that it shows up in the `Display Order` field on the edit category page.
