### PR TITLE
Directory: Add a system for flagging patterns

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -9,6 +9,7 @@
 namespace WordPressdotorg\Pattern_Directory;
 
 require_once __DIR__ . '/includes/pattern-post-type.php';
+require_once __DIR__ . '/includes/pattern-flag-post-type.php';
 require_once __DIR__ . '/includes/pattern-validation.php';
 require_once __DIR__ . '/includes/post-status.php';
 require_once __DIR__ . '/includes/search.php';

--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -8,10 +8,10 @@
 
 namespace WordPressdotorg\Pattern_Directory;
 
-require_once __DIR__ . '/includes/admin.php';
 require_once __DIR__ . '/includes/class-rest-flags-controller.php';
 require_once __DIR__ . '/includes/pattern-post-type.php';
 require_once __DIR__ . '/includes/pattern-flag-post-type.php';
 require_once __DIR__ . '/includes/pattern-validation.php';
 require_once __DIR__ . '/includes/post-status.php';
 require_once __DIR__ . '/includes/search.php';
+require_once __DIR__ . '/includes/admin.php';

--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -8,6 +8,7 @@
 
 namespace WordPressdotorg\Pattern_Directory;
 
+require_once __DIR__ . '/includes/class-rest-flags-controller.php';
 require_once __DIR__ . '/includes/pattern-post-type.php';
 require_once __DIR__ . '/includes/pattern-flag-post-type.php';
 require_once __DIR__ . '/includes/pattern-validation.php';

--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -8,6 +8,7 @@
 
 namespace WordPressdotorg\Pattern_Directory;
 
+require_once __DIR__ . '/includes/admin.php';
 require_once __DIR__ . '/includes/class-rest-flags-controller.php';
 require_once __DIR__ . '/includes/pattern-post-type.php';
 require_once __DIR__ . '/includes/pattern-flag-post-type.php';

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Admin;
+
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN;
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\TAX_TYPE as FLAG_REASON;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_action( 'admin_menu', __NAMESPACE__ . '\taxonomy_submenu_page' );
+add_filter( 'parent_file', __NAMESPACE__ . '\taxonomy_submenu_highlight' );
+
+/**
+ * Add the Flag Reason taxonomy page as a subpage of Block Pattern.
+ *
+ * WP won't do this on its own because Flag Reason is associated with the Pattern Flag post type rather than
+ * the post type that we want to put it under.
+ *
+ * @return void
+ */
+function taxonomy_submenu_page() {
+	$taxonomy = get_taxonomy( FLAG_REASON );
+
+	add_submenu_page(
+		'edit.php?post_type=wporg-pattern',
+		__( 'Flag Reasons', 'wporg-patterns' ),
+		__( 'Reasons', 'wporg-patterns' ),
+		$taxonomy->cap->manage_terms,
+		'edit-tags.php?taxonomy=' . FLAG_REASON . '&post_type=' . PATTERN,
+		null
+	);
+}
+
+/**
+ * Make sure the Reasons submenu item is highlighted when editing terms.
+ *
+ * @param string $parent_file
+ *
+ * @return string
+ */
+function taxonomy_submenu_highlight( $parent_file ) {
+	global $plugin_page, $submenu_file, $post_type, $taxonomy;
+
+	if ( PATTERN === $post_type && FLAG_REASON === $taxonomy ) {
+		$plugin_page  = 'edit-tags.php?taxonomy=' . FLAG_REASON . '&post_type=' . PATTERN;
+		$submenu_file = 'edit-tags.php?taxonomy=' . FLAG_REASON . '&post_type=' . PATTERN;
+	}
+
+	return $parent_file;
+}

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin.php
@@ -10,8 +10,8 @@ defined( 'WPINC' ) || die();
 /**
  * Actions and filters.
  */
-add_action( 'admin_menu', __NAMESPACE__ . '\taxonomy_submenu_page' );
-add_filter( 'parent_file', __NAMESPACE__ . '\taxonomy_submenu_highlight' );
+add_action( 'admin_menu', __NAMESPACE__ . '\flag_reason_submenu_page' );
+add_filter( 'parent_file', __NAMESPACE__ . '\flag_reason_submenu_highlight' );
 
 /**
  * Add the Flag Reason taxonomy page as a subpage of Block Pattern.
@@ -21,7 +21,7 @@ add_filter( 'parent_file', __NAMESPACE__ . '\taxonomy_submenu_highlight' );
  *
  * @return void
  */
-function taxonomy_submenu_page() {
+function flag_reason_submenu_page() {
 	$taxonomy = get_taxonomy( FLAG_REASON );
 
 	add_submenu_page(
@@ -41,7 +41,7 @@ function taxonomy_submenu_page() {
  *
  * @return string
  */
-function taxonomy_submenu_highlight( $parent_file ) {
+function flag_reason_submenu_highlight( $parent_file ) {
 	global $plugin_page, $submenu_file, $post_type, $taxonomy;
 
 	if ( PATTERN === $post_type && FLAG_REASON === $taxonomy ) {

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin.php
@@ -21,7 +21,7 @@ add_filter( 'post_row_actions', __NAMESPACE__ . '\flag_list_table_row_actions', 
 add_filter( 'bulk_actions-edit-wporg-pattern-flag', __NAMESPACE__ . '\flag_list_table_bulk_actions' );
 add_filter( 'handle_bulk_actions-edit-wporg-pattern-flag', __NAMESPACE__ . '\flag_list_table_handle_bulk_actions', 10, 3 );
 add_action( 'admin_menu', __NAMESPACE__ . '\flag_reason_submenu_page' );
-add_filter( 'parent_file', __NAMESPACE__ . '\flag_reason_submenu_highlight' );
+add_filter( 'submenu_file', __NAMESPACE__ . '\flag_reason_submenu_highlight', 10, 2 );
 
 /**
  * Modify the flags list table columns and their order.
@@ -79,7 +79,7 @@ function flag_list_table_render_custom_columns( $column_name, $post_id ) {
 			}
 
 			printf(
-				$title_wrapper,
+				$title_wrapper, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				esc_html( _draft_or_post_title( $pattern ) )
 			);
 
@@ -87,7 +87,7 @@ function flag_list_table_render_custom_columns( $column_name, $post_id ) {
 			break;
 
 		case 'details':
-			echo get_the_excerpt( $current_flag );
+			echo wp_kses_data( get_the_excerpt( $current_flag ) );
 			break;
 	}
 }
@@ -262,17 +262,20 @@ function flag_reason_submenu_page() {
 /**
  * Make sure the Reasons submenu item is highlighted when editing terms.
  *
- * @param string $parent_file
+ * @param string $submenu_file
  *
  * @return string
  */
-function flag_reason_submenu_highlight( $parent_file ) {
-	global $plugin_page, $submenu_file, $post_type, $taxonomy;
+function flag_reason_submenu_highlight( $submenu_file, $parent_file ) {
+	global $post_type, $taxonomy;
 
-	if ( PATTERN === $post_type && FLAG_REASON === $taxonomy ) {
-		$plugin_page  = 'edit-tags.php?taxonomy=' . FLAG_REASON . '&post_type=' . PATTERN;
+	if (
+		'edit.php?post_type=wporg-pattern' === $parent_file
+		&& PATTERN === $post_type
+		&& FLAG_REASON === $taxonomy
+	) {
 		$submenu_file = 'edit-tags.php?taxonomy=' . FLAG_REASON . '&post_type=' . PATTERN;
 	}
 
-	return $parent_file;
+	return $submenu_file;
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin.php
@@ -197,12 +197,14 @@ function flag_list_table_row_actions( $actions, $post ) {
  * @return array
  */
 function flag_list_table_bulk_actions( $actions ) {
+	$saved_actions = array_intersect_key( $actions, array_fill_keys( array( 'trash', 'untrash', 'delete' ), true ) );
+
 	$actions = array(
 		'resolve'   => __( 'Resolve', 'wporg-patterns' ),
 		'unresolve' => __( 'Unresolve', 'wporg-patterns' ),
 	);
 
-	return $actions;
+	return $actions + $saved_actions;
 }
 
 /**

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin.php
@@ -2,16 +2,241 @@
 
 namespace WordPressdotorg\Pattern_Directory\Admin;
 
+use WP_Post;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN;
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\TAX_TYPE as FLAG_REASON;
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\PENDING_STATUS;
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\RESOLVED_STATUS;
 
 defined( 'WPINC' ) || die();
 
 /**
  * Actions and filters.
  */
+add_filter( 'manage_' . FLAG . '_posts_columns', __NAMESPACE__ . '\flag_list_table_columns' );
+add_action( 'manage_' . FLAG . '_posts_custom_column', __NAMESPACE__ . '\flag_list_table_render_custom_columns', 10, 2 );
+add_filter( 'display_post_states', __NAMESPACE__ . '\flag_list_table_post_states', 10, 2 );
+add_filter( 'post_row_actions', __NAMESPACE__ . '\flag_list_table_row_actions', 10, 2 );
+add_filter( 'bulk_actions-edit-wporg-pattern-flag', __NAMESPACE__ . '\flag_list_table_bulk_actions' );
+add_filter( 'handle_bulk_actions-edit-wporg-pattern-flag', __NAMESPACE__ . '\flag_list_table_handle_bulk_actions', 10, 3 );
 add_action( 'admin_menu', __NAMESPACE__ . '\flag_reason_submenu_page' );
 add_filter( 'parent_file', __NAMESPACE__ . '\flag_reason_submenu_highlight' );
+
+/**
+ * Modify the flags list table columns and their order.
+ *
+ * @param array $columns
+ *
+ * @return array
+ */
+function flag_list_table_columns( $columns ) {
+	$block_pattern = get_post_type_object( PATTERN );
+	$flag_reason   = get_taxonomy( FLAG_REASON );
+
+	$cb = array(
+		'cb' => $columns['cb'],
+	);
+
+	$front_columns = array(
+		'pattern'                            => $block_pattern->labels->singular_name,
+		'taxonomy-wporg-pattern-flag-reason' => $flag_reason->labels->singular_name,
+		'details'                            => __( 'Details', 'wporg-patterns' ),
+	);
+
+	$columns['author'] = __( 'Reporter', 'wporg-patterns' );
+
+	unset( $columns['cb'] );
+	unset( $columns['title'] );
+	unset( $columns['taxonomy-wporg-pattern-flag-reason'] );
+
+	$columns = $cb + $front_columns + $columns;
+
+	return $columns;
+}
+
+/**
+ * Render the contents of custom list table columns.
+ *
+ * @param string $column_name
+ * @param int    $post_id
+ *
+ * @return void
+ */
+function flag_list_table_render_custom_columns( $column_name, $post_id ) {
+	global $wp_list_table;
+
+	$current_flag = get_post( $post_id );
+	$pattern      = get_post( $current_flag->post_parent );
+
+	switch ( $column_name ) {
+		case 'pattern':
+			$status = get_post_status( $current_flag );
+			if ( PENDING_STATUS === $status ) {
+				$title_wrapper = '<strong>%s</strong>';
+			} else {
+				$title_wrapper = '<span>%s</span>';
+			}
+
+			printf(
+				$title_wrapper,
+				esc_html( _draft_or_post_title( $pattern ) )
+			);
+
+			_post_states( $current_flag );
+			break;
+
+		case 'details':
+			echo get_the_excerpt( $current_flag );
+			break;
+	}
+}
+
+/**
+ * Modify the post states for the flags list table.
+ *
+ * @param array   $post_states
+ * @param WP_Post $post
+ *
+ * @return array
+ */
+function flag_list_table_post_states( $post_states, $post ) {
+	if ( FLAG === get_post_type( $post ) && RESOLVED_STATUS === get_post_status( $post ) ) {
+		$status_obj = get_post_status_object( RESOLVED_STATUS );
+		$post_states[ RESOLVED_STATUS ] = $status_obj->label;
+	}
+
+	return $post_states;
+}
+
+/**
+ * Set up row actions for pattern flags list table.
+ *
+ * @param array   $actions
+ * @param WP_Post $post
+ *
+ * @return array
+ */
+function flag_list_table_row_actions( $actions, $post ) {
+	if ( FLAG !== get_post_type( $post ) ) {
+		return $actions;
+	}
+
+	$current_screen = get_current_screen();
+	$screen_file    = add_query_arg(
+		'post_type',
+		FLAG,
+		'edit.php'
+	);
+
+	$actions = array();
+
+	$pattern       = get_post( $post->post_parent );
+	$pattern_title = _draft_or_post_title( $pattern );
+	$pattern_url   = add_query_arg(
+		array(
+			'post'   => $pattern->ID,
+			'action' => 'edit',
+		),
+		admin_url( 'post.php' )
+	);
+
+	$actions['review'] = sprintf(
+		'<a href="%s" aria-label="%s">%s</a>',
+		esc_attr( $pattern_url ),
+		/* translators: %s: Post title. */
+		esc_attr( sprintf( __( 'Review &#8220;%s&#8221;', 'wporg-patterns' ), $pattern_title ) ),
+		__( 'Review Pattern', 'wporg-patterns' )
+	);
+
+	if ( PENDING_STATUS === get_post_status( $post ) ) {
+		$resolve_url = add_query_arg(
+			array(
+				'action' => 'resolve',
+				'post'   => array( $post->ID ),
+			),
+			wp_nonce_url( $screen_file, 'bulk-posts' )
+		);
+
+		$actions['resolve'] = sprintf(
+			'<a href="%s" aria-label="%s">%s</a>',
+			esc_attr( $resolve_url ),
+			esc_attr( __( 'Mark this flag as resolved', 'wporg-patterns' ) ),
+			__( 'Resolve', 'wporg-patterns' )
+		);
+	}
+
+	if ( RESOLVED_STATUS === get_post_status( $post ) ) {
+		$unresolve_url = add_query_arg(
+			array(
+				'action' => 'unresolve',
+				'post'   => array( $post->ID ),
+			),
+			wp_nonce_url( $screen_file, 'bulk-posts' )
+		);
+
+		$actions['unresolve'] = sprintf(
+			'<a href="%s" aria-label="%s">%s</a>',
+			esc_attr( $unresolve_url ),
+			esc_attr( __( 'Mark this flag as pending', 'wporg-patterns' ) ),
+			__( 'Unresolve', 'wporg-patterns' )
+		);
+	}
+
+	return $actions;
+}
+
+/**
+ * Define bulk actions for the flag list table.
+ *
+ * @param array $actions
+ *
+ * @return array
+ */
+function flag_list_table_bulk_actions( $actions ) {
+	$actions = array(
+		'resolve'   => __( 'Resolve', 'wporg-patterns' ),
+		'unresolve' => __( 'Unresolve', 'wporg-patterns' ),
+	);
+
+	return $actions;
+}
+
+/**
+ * Execute bulk actions for the flag list table.
+ *
+ * @param string $sendback
+ * @param string $doaction
+ * @param array  $post_ids
+ *
+ * @return mixed|string
+ */
+function flag_list_table_handle_bulk_actions( $sendback, $doaction, $post_ids ) {
+	$post_data = array(
+		'post_type' => FLAG,
+		'post'      => $post_ids,
+	);
+
+	switch ( $doaction ) {
+		case 'resolve':
+			$post_data['_status'] = RESOLVED_STATUS;
+			break;
+		case 'unresolve':
+			$post_data['_status'] = PENDING_STATUS;
+			break;
+	}
+
+	$result = bulk_edit_posts( $post_data );
+
+	if ( is_array( $result ) ) {
+		$result['updated'] = count( $result['updated'] );
+		$result['skipped'] = count( $result['skipped'] );
+		$result['locked']  = count( $result['locked'] );
+		$sendback          = add_query_arg( $result, $sendback );
+	}
+
+	return $sendback;
+}
 
 /**
  * Add the Flag Reason taxonomy page as a subpage of Block Pattern.

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
@@ -159,8 +159,8 @@ class REST_Flags_Controller extends WP_REST_Posts_Controller {
 		$flag_check = new WP_Query( array(
 			'post_type'   => $this->post_type,
 			'post_parent' => $parent->ID,
-			'post_status' => 'any',
-			'author' => get_current_user_id(),
+			'post_status' => 'pending',
+			'author'      => get_current_user_id(),
 		) );
 		if ( $flag_check->found_posts > 0 ) {
 			return new WP_Error(

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
@@ -191,6 +191,16 @@ class REST_Flags_Controller extends WP_REST_Posts_Controller {
 			$prepared_post->post_status = $schema['properties']['status']['default'];
 		}
 
+		foreach ( $request['wporg-pattern-flag-reason'] as $term_id ) {
+			if ( ! term_exists( $term_id, FLAG_TAX ) ) {
+				return new WP_Error(
+					'rest_invalid_term_id',
+					__( 'Invalid term ID.', 'wporg-patterns' ),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
 		return $prepared_post;
 	}
 
@@ -211,6 +221,8 @@ class REST_Flags_Controller extends WP_REST_Posts_Controller {
 			'context'     => array( 'view', 'edit' ),
 			'required'    => true,
 		);
+
+		$schema['properties']['wporg-pattern-flag-reason']['required'] = true;
 
 		return $schema;
 	}

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
@@ -160,7 +160,7 @@ class REST_Flags_Controller extends WP_REST_Posts_Controller {
 			'post_type'   => $this->post_type,
 			'post_parent' => $parent->ID,
 			'post_status' => 'any',
-			'post_author' => get_current_user_id(),
+			'author' => get_current_user_id(),
 		) );
 		if ( $flag_check->found_posts > 0 ) {
 			return new WP_Error(

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
@@ -79,7 +79,7 @@ class REST_Flags_Controller extends WP_REST_Posts_Controller {
 		if ( ! current_user_can( $parent_post_type->cap->edit_posts ) ) {
 			return new WP_Error(
 				'rest_forbidden_context',
-				__( 'Sorry, you are not allowed to edit patterns.', 'wporg-patterns' ),
+				__( 'Sorry, you are not allowed to view pattern flags.', 'wporg-patterns' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -179,6 +179,7 @@ class REST_Flags_Controller extends WP_REST_Posts_Controller {
 			'description' => __( 'The ID for the parent of the object.', 'wporg-patterns' ),
 			'type'        => 'integer',
 			'context'     => array( 'view', 'edit' ),
+			'required'    => true,
 		);
 
 		return $schema;

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory;
+
+use WP_Error, WP_Post, WP_Post_Type;
+use WP_REST_Posts_Controller, WP_REST_Request, WP_REST_Server;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN;
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\TAX_TYPE as FLAG_TAX;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class REST_Flags_Controller
+ *
+ * @package WordPressdotorg\Pattern_Directory
+ */
+class REST_Flags_Controller extends WP_REST_Posts_Controller {
+	/**
+	 * Parent post type.
+	 *
+	 * @var string
+	 */
+	protected $parent_post_type;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $post_type Post type.
+	 */
+	public function __construct( $post_type ) {
+		parent::__construct( $post_type );
+
+		$this->parent_post_type = PATTERN;
+	}
+
+	/**
+	 * Retrieves an array of endpoint arguments from the item schema for the controller.
+	 *
+	 * @param string $method Optional. HTTP method of the request. The arguments for `CREATABLE` requests are
+	 *                       checked for required values and may fall-back to a given default, this is not done
+	 *                       on `EDITABLE` requests. Default WP_REST_Server::CREATABLE.
+	 * @return array Endpoint arguments.
+	 */
+	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
+		$endpoint_args = $this->get_item_schema();
+
+		if ( WP_REST_Server::CREATABLE === $method ) {
+			$endpoint_args['properties'] = array_intersect_key(
+				$endpoint_args['properties'],
+				array(
+					'parent'  => true,
+					'excerpt' => true,
+					FLAG_TAX  => true,
+				)
+			);
+		} elseif ( WP_REST_Server::EDITABLE === $method ) {
+			$endpoint_args['properties'] = array_intersect_key(
+				$endpoint_args['properties'],
+				array(
+					'status' => true,
+					FLAG_TAX => true,
+				)
+			);
+		}
+
+		return rest_get_endpoint_args_for_schema( $endpoint_args, $method );
+	}
+
+	/**
+	 * Checks if a given request has access to read posts.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$parent_post_type = get_post_type_object( PATTERN );
+
+		if ( ! current_user_can( $parent_post_type->cap->edit_posts ) ) {
+			return new WP_Error(
+				'rest_forbidden_context',
+				__( 'Sorry, you are not allowed to edit patterns.', 'wporg-patterns' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Checks if a given request has access to read a post.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+		$post = $this->get_post( $request['id'] );
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		$parent = $this->get_parent( $post->post_parent );
+		if ( is_wp_error( $parent ) ) {
+			return $parent;
+		}
+
+		if ( ! current_user_can( 'edit_post', $parent->ID ) ) {
+			return new WP_Error(
+				'rest_cannot_read',
+				__( 'Sorry, you are not allowed to view flags for this pattern.', 'wporg-patterns' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return parent::get_item_permissions_check( $request );
+	}
+
+	/**
+	 * Checks if a given request has access to create a post.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( ! empty( $request['id'] ) ) {
+			return new WP_Error(
+				'rest_post_exists',
+				__( 'Cannot create existing post.', 'wporg-patterns' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_post_exists',
+				__( 'You must be logged in to submit a flag.', 'wporg-patterns' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Prepares a single post for create or update.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return \stdClass|WP_Error Post object or WP_Error.
+	 */
+	protected function prepare_item_for_database( $request ) {
+		$schema = $this->get_item_schema();
+
+		$prepared_post = parent::prepare_item_for_database( $request );
+
+		$prepared_post->post_author = get_current_user_id();
+
+		if ( ! isset( $request['status'] ) ) {
+			$prepared_post->post_status = $schema['properties']['status']['default'];
+		}
+
+		return $prepared_post;
+	}
+
+	/**
+	 * Retrieves the post's schema, conforming to JSON Schema.
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		$schema['properties']['status']['default'] = 'pending';
+		$schema['properties']['status']['enum']    = array( 'pending', 'private' );
+
+		$schema['properties']['parent'] = array(
+			'description' => __( 'The ID for the parent of the object.', 'wporg-patterns' ),
+			'type'        => 'integer',
+			'context'     => array( 'view', 'edit' ),
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Retrieves the query params for the posts collection.
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		$query_params = parent::get_collection_params();
+
+		$query_params['status']['default']       = 'pending';
+		$query_params['status']['items']['enum'] = array( 'pending', 'private', 'any' );
+
+		$query_params['parent']         = array(
+			'description' => __( 'Limit result set to items with particular parent IDs.', 'wporg-patterns' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'integer',
+			),
+			'default'     => array(),
+		);
+		$query_params['parent_exclude'] = array(
+			'description' => __( 'Limit result set to all items except those of a particular parent ID.', 'wporg-patterns' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'integer',
+			),
+			'default'     => array(),
+		);
+
+		return $query_params;
+	}
+
+	/**
+	 * Get the parent post, if the ID is valid.
+	 *
+	 * @since 4.7.2
+	 *
+	 * @param int $parent Supplied ID.
+	 *
+	 * @return WP_Post|WP_Error Post object if ID is valid, WP_Error otherwise.
+	 */
+	protected function get_parent( $parent ) {
+		$error = new WP_Error(
+			'rest_post_invalid_parent',
+			__( 'Invalid post parent ID.', 'wporg-patterns' ),
+			array( 'status' => 404 )
+		);
+		if ( (int) $parent <= 0 ) {
+			return $error;
+		}
+
+		$parent = get_post( (int) $parent );
+		if ( empty( $parent ) || empty( $parent->ID ) || $this->parent_post_type !== $parent->post_type ) {
+			return $error;
+		}
+
+		return $parent;
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
@@ -2,7 +2,7 @@
 
 namespace WordPressdotorg\Pattern_Directory;
 
-use WP_Error, WP_Post, WP_Post_Type;
+use WP_Error, WP_Post, WP_Query;
 use WP_REST_Posts_Controller, WP_REST_Request, WP_REST_Server;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\TAX_TYPE as FLAG_TAX;
@@ -151,6 +151,21 @@ class REST_Flags_Controller extends WP_REST_Posts_Controller {
 			return new WP_Error(
 				'rest_invalid_post',
 				__( 'Flags cannot be submitted for this pattern.', 'wporg-patterns' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Check if the user has already submitted a flag for the pattern.
+		$flag_check = new WP_Query( array(
+			'post_type'   => $this->post_type,
+			'post_parent' => $parent->ID,
+			'post_status' => 'any',
+			'post_author' => get_current_user_id(),
+		) );
+		if ( $flag_check->found_posts > 0 ) {
+			return new WP_Error(
+				'rest_already_flagged',
+				__( 'You have already flagged this pattern.', 'wporg-patterns' ),
 				array( 'status' => 403 )
 			);
 		}

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -13,8 +13,6 @@ const TAX_TYPE  = 'wporg-pattern-flag-reason';
  * Actions and filters.
  */
 add_action( 'init', __NAMESPACE__ . '\register_post_type_data' );
-add_action( 'admin_menu', __NAMESPACE__ . '\taxonomy_submenu_page' );
-add_filter( 'parent_file', __NAMESPACE__ . '\taxonomy_submenu_highlight' );
 
 /**
  * Register entities for block pattern flags.
@@ -61,6 +59,8 @@ function register_post_type_data() {
 		'singular_name'              => __( 'Flag Reason', 'wporg-patterns' ),
 		'search_items'               => __( 'Search Reasons', 'wporg-patterns' ),
 		'all_items'                  => __( 'All Reasons', 'wporg-patterns' ),
+		'parent_item'                => __( 'Parent Reason', 'wporg-patterns' ),
+		'parent_item_colon'          => __( 'Parent Reason:', 'wporg-patterns' ),
 		'edit_item'                  => __( 'Edit Reason', 'wporg-patterns' ),
 		'view_item'                  => __( 'View Reason', 'wporg-patterns' ),
 		'update_item'                => __( 'Update Reason', 'wporg-patterns' ),
@@ -92,43 +92,4 @@ function register_post_type_data() {
 			'show_admin_column'  => true,
 		)
 	);
-}
-
-/**
- * Add the Flag Reason taxonomy page as a subpage of Block Pattern.
- *
- * WP won't do this on its own because Flag Reason is associated with the Pattern Flag post type rather than
- * the post type that we want to put it under.
- *
- * @return void
- */
-function taxonomy_submenu_page() {
-	$taxonomy = get_taxonomy( TAX_TYPE );
-
-	add_submenu_page(
-		'edit.php?post_type=wporg-pattern',
-		__( 'Flag Reasons', 'wporg-patterns' ),
-		__( 'Reasons', 'wporg-patterns' ),
-		$taxonomy->cap->manage_terms,
-		'edit-tags.php?taxonomy=' . TAX_TYPE . '&post_type=' . PATTERN,
-		null
-	);
-}
-
-/**
- * Make sure the Reasons submenu item is highlighted when editing terms.
- *
- * @param string $parent_file
- *
- * @return string
- */
-function taxonomy_submenu_highlight( $parent_file ) {
-	global $plugin_page, $submenu_file, $post_type, $taxonomy;
-
-	if ( PATTERN === $post_type && TAX_TYPE === $taxonomy ) {
-		$plugin_page  = 'edit-tags.php?taxonomy=' . TAX_TYPE . '&post_type=' . PATTERN;
-		$submenu_file = 'edit-tags.php?taxonomy=' . TAX_TYPE . '&post_type=' . PATTERN;
-	}
-
-	return $parent_file;
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -2,6 +2,8 @@
 
 namespace WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type;
 
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN;
+
 defined( 'WPINC' ) || die();
 
 const POST_TYPE = 'wporg-pattern-flag';
@@ -11,6 +13,8 @@ const TAX_TYPE  = 'wporg-pattern-flag-reason';
  * Actions and filters.
  */
 add_action( 'init', __NAMESPACE__ . '\register_post_type_data' );
+add_action( 'admin_menu', __NAMESPACE__ . '\taxonomy_submenu_page' );
+add_filter( 'parent_file', __NAMESPACE__ . '\taxonomy_submenu_highlight' );
 
 /**
  * Register entities for block pattern flags.
@@ -29,7 +33,7 @@ function register_post_type_data() {
 		'search_items'          => __( 'Search Flags', 'wporg-patterns' ),
 		'not_found'             => __( 'No flags found.', 'wporg-patterns' ),
 		'not_found_in_trash'    => __( 'No flags found in Trash.', 'wporg-patterns' ),
-		'all_items'             => __( 'All Flags', 'wporg-patterns' ),
+		'all_items'             => __( 'Flags', 'wporg-patterns' ),
 		'insert_into_item'      => __( 'Insert into flag', 'wporg-patterns' ),
 		'filter_items_list'     => __( 'Filter flags list', 'wporg-patterns' ),
 		'items_list_navigation' => __( 'Flags list navigation', 'wporg-patterns' ),
@@ -81,11 +85,50 @@ function register_post_type_data() {
 			'public'             => false,
 			'hierarchical'       => true,
 			'show_ui'            => true,
-			'show_in_menu'       => 'edit.php?post_type=wporg-pattern',
+			'show_in_menu'       => 'edit.php?post_type=' . PATTERN,
 			'show_in_rest'       => true,
 			'show_tagcloud'      => false,
 			'show_in_quick_edit' => false,
 			'show_admin_column'  => true,
 		)
 	);
+}
+
+/**
+ * Add the Flag Reason taxonomy page as a subpage of Block Pattern.
+ *
+ * WP won't do this on its own because Flag Reason is associated with the Pattern Flag post type rather than
+ * the post type that we want to put it under.
+ *
+ * @return void
+ */
+function taxonomy_submenu_page() {
+	$taxonomy = get_taxonomy( TAX_TYPE );
+
+	add_submenu_page(
+		'edit.php?post_type=wporg-pattern',
+		__( 'Flag Reasons', 'wporg-patterns' ),
+		__( 'Reasons', 'wporg-patterns' ),
+		$taxonomy->cap->manage_terms,
+		'edit-tags.php?taxonomy=' . TAX_TYPE . '&post_type=' . PATTERN,
+		null
+	);
+}
+
+/**
+ * Make sure the Reasons submenu item is highlighted when editing terms.
+ *
+ * @param string $parent_file
+ *
+ * @return string
+ */
+function taxonomy_submenu_highlight( $parent_file ) {
+	global $plugin_page, $submenu_file, $post_type, $taxonomy;
+
+	if ( PATTERN === $post_type && TAX_TYPE === $taxonomy ) {
+		$plugin_page  = 'edit-tags.php?taxonomy=' . TAX_TYPE . '&post_type=' . PATTERN;
+		$submenu_file = 'edit-tags.php?taxonomy=' . TAX_TYPE . '&post_type=' . PATTERN;
+	}
+
+	return $parent_file;
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -6,8 +6,10 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTE
 
 defined( 'WPINC' ) || die();
 
-const POST_TYPE = 'wporg-pattern-flag';
-const TAX_TYPE  = 'wporg-pattern-flag-reason';
+const POST_TYPE       = 'wporg-pattern-flag';
+const TAX_TYPE        = 'wporg-pattern-flag-reason';
+const PENDING_STATUS  = 'pending';
+const RESOLVED_STATUS = 'resolved';
 
 /**
  * Actions and filters.
@@ -90,6 +92,19 @@ function register_post_type_data() {
 			'show_tagcloud'      => false,
 			'show_in_quick_edit' => false,
 			'show_admin_column'  => true,
+		)
+	);
+
+	register_post_status(
+		RESOLVED_STATUS,
+		array(
+			'label'       => __( 'Resolved', 'wporg-patterns' ),
+			'label_count' => _n_noop(
+				'Resolved <span class="count">(%s)</span>',
+				'Resolved <span class="count">(%s)</span>',
+				'wporg-patterns'
+			),
+			'protected'   => true,
 		)
 	);
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -45,8 +45,8 @@ function register_post_type_data() {
 			'show_in_menu'          => 'edit.php?post_type=wporg-pattern',
 			'show_in_admin_bar'     => false,
 			'show_in_rest'          => true,
-			'rest_controller_class' => '', // TODO
-			'supports'              => array( 'editor', 'author', 'excerpt' ),
+			'rest_controller_class' => '\\WordPressdotorg\\Pattern_Directory\\REST_Flags_Controller',
+			'supports'              => array( 'author', 'excerpt' ),
 			'can_export'            => false,
 			'delete_with_user'      => false,
 		)

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type;
+
+defined( 'WPINC' ) || die();
+
+const POST_TYPE = 'wporg-pattern-flag';
+const TAX_TYPE  = 'wporg-pattern-flag-reason';
+
+/**
+ * Actions and filters.
+ */
+add_action( 'init', __NAMESPACE__ . '\register_post_type_data' );
+
+/**
+ * Register entities for block pattern flags.
+ *
+ * @return void
+ */
+function register_post_type_data() {
+	$post_type_labels = array(
+		'name'                  => __( 'Block Pattern Flags', 'wporg-patterns' ),
+		'singular_name'         => __( 'Block Pattern Flag', 'wporg-patterns' ),
+		'add_new_item'          => __( 'Add New Flag', 'wporg-patterns' ),
+		'edit_item'             => __( 'Edit Flag', 'wporg-patterns' ),
+		'new_item'              => __( 'New Flag', 'wporg-patterns' ),
+		'view_item'             => __( 'View Flag', 'wporg-patterns' ),
+		'view_items'            => __( 'View Flags', 'wporg-patterns' ),
+		'search_items'          => __( 'Search Flags', 'wporg-patterns' ),
+		'not_found'             => __( 'No flags found.', 'wporg-patterns' ),
+		'not_found_in_trash'    => __( 'No flags found in Trash.', 'wporg-patterns' ),
+		'all_items'             => __( 'All Flags', 'wporg-patterns' ),
+		'insert_into_item'      => __( 'Insert into flag', 'wporg-patterns' ),
+		'filter_items_list'     => __( 'Filter flags list', 'wporg-patterns' ),
+		'items_list_navigation' => __( 'Flags list navigation', 'wporg-patterns' ),
+		'items_list'            => __( 'Flags list', 'wporg-patterns' ),
+	);
+
+	register_post_type(
+		POST_TYPE,
+		array(
+			'labels'                => $post_type_labels,
+			'description'           => 'Flags are added to patterns by users when the pattern needs to be reviewed by a moderator.',
+			'show_ui'               => true,
+			'show_in_menu'          => 'edit.php?post_type=wporg-pattern',
+			'show_in_admin_bar'     => false,
+			'show_in_rest'          => true,
+			'rest_controller_class' => '', // TODO
+			'supports'              => array( 'editor', 'author', 'excerpt' ),
+			'can_export'            => false,
+			'delete_with_user'      => false,
+		)
+	);
+
+	$taxonomy_labels = array(
+		'name'                       => __( 'Flag Reasons', 'wporg-patterns' ),
+		'singular_name'              => __( 'Flag Reason', 'wporg-patterns' ),
+		'search_items'               => __( 'Search Reasons', 'wporg-patterns' ),
+		'all_items'                  => __( 'All Reasons', 'wporg-patterns' ),
+		'edit_item'                  => __( 'Edit Reason', 'wporg-patterns' ),
+		'view_item'                  => __( 'View Reason', 'wporg-patterns' ),
+		'update_item'                => __( 'Update Reason', 'wporg-patterns' ),
+		'add_new_item'               => __( 'Add New Reason', 'wporg-patterns' ),
+		'new_item_name'              => __( 'New Reason', 'wporg-patterns' ),
+		'separate_items_with_commas' => __( 'Separate reasons with commas', 'wporg-patterns' ),
+		'add_or_remove_items'        => __( 'Add or remove reasons', 'wporg-patterns' ),
+		'not_found'                  => __( 'No reasons found.', 'wporg-patterns' ),
+		'no_terms'                   => __( 'No reasons', 'wporg-patterns' ),
+		'filter_by_item'             => __( 'Filter by reason', 'wporg-patterns' ),
+		'items_list_navigation'      => __( 'Reasons list navigation', 'wporg-patterns' ),
+		'items_list'                 => __( 'Reasons list', 'wporg-patterns' ),
+		'back_to_items'              => __( '&larr; Go to Reasons', 'wporg-patterns' ),
+	);
+
+	register_taxonomy(
+		TAX_TYPE,
+		POST_TYPE,
+		array(
+			'labels'             => $taxonomy_labels,
+			'description'        => 'Flag reason indicates why a flag was added to a pattern.',
+			'public'             => false,
+			'hierarchical'       => true,
+			'show_ui'            => true,
+			'show_in_menu'       => 'edit.php?post_type=wporg-pattern',
+			'show_in_rest'       => true,
+			'show_tagcloud'      => false,
+			'show_in_quick_edit' => false,
+			'show_admin_column'  => true,
+		)
+	);
+}


### PR DESCRIPTION
This adds the REST API endpoint, flag schema, and back-end UI described in #61. The front end UI will probably get a separate PR, and maybe a separate issue as well.

This introduces the `wporg-pattern-flag` post type, the `wporg-pattern-flag-reason` taxonomy, and the `resolved` post status to store and manage data when a pattern in the pattern directory is flagged for review. A flag is comprised of:

* A reason for the flag, stored as a term in the `wporg-pattern-flag-reason` taxonomy. There will be a few pre-defined terms that a user can choose from on the front end as the reason for the flag.
* Details about the flag, stored in `post_excerpt`. This provides more context for the moderator reviewing the pattern and its flags.
* The ID of the "parent" pattern post, stored in `post_parent`
* The ID of the user who submitted the flag, stored in `post_author`.
* The status of the flag, stored in `post_status`. A new flag starts as `pending` and can be marked as `resolved` once it has been reviewed.

The still-in-the-works front end form will submit the flag data to the REST API endpoint, which is a slightly modified version of the standard endpoint for WP post types. The main differences are:

* To view flags, you must have edit permissions for the `wporg-pattern` post type.
* To create flags, you don't need edit permissions, but you must be logged into your wp.org account.
* There are checks to prevent submitting a flag to a pattern that isn't published, and to prevent submitting a flag to a pattern that you've already flagged previously, regardless of the status of previous flags.

For the back-end UI, this PR focuses on screens directly related to the new post type and taxonomy, namely a list table and a UI for creating new terms. Adding info about a pattern's flags to the patterns list table will be covered in a separate issue/PR.

The list table is a standard posts list table that has been modified via filters and actions. Of note are the custom columns, row actions, and bulk actions to facilitate reviewing flags.

### Screenshot

![Screen Shot 2021-04-16 at 11 50 03](https://user-images.githubusercontent.com/916023/114922649-c64b7080-9de0-11eb-82d8-f703fce00c0e.png)

### How to test the changes in this Pull Request:

**Setup**

* Create one or more block patterns.
* Create one or more terms on the Reasons subpage.

**Test the API**

* This is most easily done with a client app like [Insomnia](https://insomnia.rest/).
* To create a new flag, send a POST request to `http://localhost:8888/wp-json/wp/v2/wporg-pattern-flag`. It needs to have the following parameters:
  * `parent`: The post ID of a pattern post
  * `wporg-pattern-flag-reason`: The ID of a Reason term
  * `excerpt`: A "details" string
* To get existing flags, send a GET request to `http://localhost:8888/wp-json/wp/v2/wporg-pattern-flag` with the usual optional parameters for any kind of posts.

**Test the back end UI**

* Once you have some flags created, point your browser to `http://localhost:8888/wp-admin/edit.php?post_type=wporg-pattern-flag`.
* Try resolving/unresolving and trashing/untrashing flags with row actions (links that appear when you hover over a flag row), and bulk actions.
* Try viewing only flags for one particular pattern.
