### PR TITLE
Pattern Directory: Allow container blocks to pass validation if they have child-blocks

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -7,13 +7,12 @@ add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_content',
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_title', 11, 2 );
 
 /**
- * Check if a block is real - does it have actual content in it, or is it an
- * empty/placeholder block.
+ * Check if a block has been edited by the user, as opposed to an empty/placeholder block.
  *
  * @param array $block A parsed block object.
- * @return bool Whether the block has been edited by a user.
+ * @return bool Whether the block has been edited.
  */
-function is_real_block( $block ) {
+function is_not_empty_block( $block ) {
 	$registry = \WP_Block_Type_Registry::get_instance();
 	$block_type = $registry->get_registered( $block['blockName'] );
 
@@ -27,7 +26,7 @@ function is_real_block( $block ) {
 	// If there are any child blocks, check those. Only return if there are real child blocks,
 	// otherwise continue on to check for any other content.
 	if ( count( $block['innerBlocks'] ) >= 1 ) {
-		$child_blocks = array_filter( $block['innerBlocks'], __NAMESPACE__ . '\is_real_block' );
+		$child_blocks = array_filter( $block['innerBlocks'], __NAMESPACE__ . '\is_not_empty_block' );
 		if ( count( $child_blocks ) ) {
 			return true;
 		}
@@ -83,7 +82,7 @@ function validate_content( $prepared_post, $request ) {
 	}
 
 	// Next, we should check that we have at least one non-empty block.
-	$real_blocks = array_filter( $blocks, __NAMESPACE__ . '\is_real_block' );
+	$real_blocks = array_filter( $blocks, __NAMESPACE__ . '\is_not_empty_block' );
 
 	if ( ! count( $real_blocks ) ) {
 		return new \WP_Error(

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -7,6 +7,22 @@ add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_content',
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_title', 11, 2 );
 
 /**
+ * Strip out basic HTML to get at the manually-entered content in block content.
+ *
+ * First, remove class attributes, since custom class names will be caught by attribute checks.
+ * Next, remove empty alt tags, which are present on default image blocks.
+ * Lastly, remove any HTML tags without attributes- this regex catches opening, closing, and self-closing tags.
+ * After all this, any block_content left should be there intentionally by the author.
+ *
+ * @param string $html The block content, from `innerHTML` of a parsed block.
+ * @return string Any content that doesn't match the cases described above.
+ */
+function strip_basic_html( $html ) {
+	$to_replace = array( '/class="[^"]*"/', '/alt=""/', '/<\/?[a-zA-Z]+\s*\/?>/' );
+	return trim( preg_replace( $to_replace, '', $html ) );
+}
+
+/**
  * Check if a block has been edited by the user, as opposed to an empty/placeholder block.
  *
  * @param array $block A parsed block object.
@@ -15,6 +31,14 @@ add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_title', 1
 function is_not_empty_block( $block ) {
 	$registry = \WP_Block_Type_Registry::get_instance();
 	$block_type = $registry->get_registered( $block['blockName'] );
+
+	// Paragraphs are a special case, these should never be empty.
+	if ( 'core/paragraph' === $block['blockName'] ) {
+		$block_content = strip_basic_html( $block['innerHTML'] );
+		if ( empty( $block_content ) ) {
+			return false;
+		}
+	}
 
 	// Check if the attributes are different from the default attributes.
 	$block_attrs = $block_type->prepare_attributes_for_render( $block['attrs'] );
@@ -32,13 +56,7 @@ function is_not_empty_block( $block ) {
 		}
 	}
 
-	// Try to judge whether a block has text content, or a valid image.
-	// First, remove class attributes, since custom class names would be caught above.
-	// Next, remove empty alt tags, which are present on default image blocks.
-	// Lastly, remove HTML tags without attributes- this regex catches opening, closing, and self-closing tags.
-	// After all this, any block_content left should be there intentionally by the author.
-	$to_replace = array( '/class="[^"]*"/', '/alt=""/', '/<\/?[a-zA-Z]+\s*\/?>/' );
-	$block_content = trim( preg_replace( $to_replace, '', $block['innerHTML'] ) );
+	$block_content = strip_basic_html( $block['innerHTML'] );
 	if ( ! empty( $block_content ) ) {
 		return true;
 	}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -108,7 +108,29 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	public function test_valid_group_block() {
 		wp_set_current_user( self::$user );
 		$response = $this->save_block_content(
+			"<!-- wp:group -->\n<div class=\"wp-block-group\"><div class=\"wp-block-group__inner-container\"><!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://s.w.org/style/images/wporg-logo.svg?3\" alt=\"\"/></figure>\n<!-- /wp:image --></div></div>\n<!-- /wp:group -->"
+		);
+		$this->assertFalse( $response->is_error() );
+	}
+
+	/**
+	 * Test valid block content: a group block with an image and a background color.
+	 */
+	public function test_valid_group_block_with_color() {
+		wp_set_current_user( self::$user );
+		$response = $this->save_block_content(
 			"<!-- wp:group {\"backgroundColor\":\"black\",\"textColor\":\"cyan-bluish-gray\"} -->\n<div class=\"wp-block-group has-cyan-bluish-gray-color has-black-background-color has-text-color has-background\"><div class=\"wp-block-group__inner-container\"><!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://s.w.org/style/images/wporg-logo.svg?3\" alt=\"\"/></figure>\n<!-- /wp:image --></div></div>\n<!-- /wp:group -->"
+		);
+		$this->assertFalse( $response->is_error() );
+	}
+
+	/**
+	 * Test valid block content: two columns, one empty, should still be valid.
+	 */
+	public function test_valid_columns_block() {
+		wp_set_current_user( self::$user );
+		$response = $this->save_block_content(
+			"<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:spacer -->\n<div style=\"height:100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:paragraph {\"style\":{\"typography\":{\"fontSize\":\"21px\"},\"color\":{\"text\":\"#000000\"}}} -->\n<p class=\"has-text-color\" style=\"color:#000000;font-size:21px\"><strong>We have worked with:</strong></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"style\":{\"typography\":{\"fontSize\":\"24px\",\"lineHeight\":\"1.2\"}}} -->\n<p style=\"font-size:24px;line-height:1.2\"><a href=\"https://wordpress.org\">EARTHFUND™<br>ARCHWEEKLY<br>FUTURE ROADS<br>BUILDING NY</a></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:spacer -->\n<div style=\"height:100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->"
 		);
 		$this->assertFalse( $response->is_error() );
 	}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -59,17 +59,6 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test valid block content: empty paragraph, with a class.
-	 */
-	public function test_valid_block_with_class() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:paragraph {\"className\":\"foo\"} -->\n<p class=\"foo\"></p>\n<!-- /wp:paragraph -->"
-		);
-		$this->assertFalse( $response->is_error() );
-	}
-
-	/**
 	 * Test valid block content: paragraph with only an image.
 	 */
 	public function test_valid_block_with_image() {
@@ -191,6 +180,19 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test invalid block content: empty paragraph, with a class.
+	 */
+	public function test_invalid_block_with_class() {
+		wp_set_current_user( self::$user );
+		$response = $this->save_block_content(
+			"<!-- wp:paragraph {\"className\":\"foo\"} -->\n<p class=\"foo\"></p>\n<!-- /wp:paragraph -->"
+		);
+		$this->assertTrue( $response->is_error() );
+		$data = $response->get_data();
+		$this->assertSame( 'rest_pattern_empty_blocks', $data['code'] );
+	}
+
+	/**
 	 * Test invalid block content: empty list (not default).
 	 */
 	public function test_invalid_empty_list() {
@@ -219,6 +221,19 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 		wp_set_current_user( self::$user );
 		$response = $this->save_block_content(
 			"<!-- wp:group -->\n<div class=\"wp-block-group\"><div class=\"wp-block-group__inner-container\"></div></div>\n<!-- /wp:group -->"
+		);
+		$this->assertTrue( $response->is_error() );
+		$data = $response->get_data();
+		$this->assertSame( 'rest_pattern_empty_blocks', $data['code'] );
+	}
+
+	/**
+	 * Test invalid block content: an empty media & text block.
+	 */
+	public function test_invalid_empty_media_text_block() {
+		wp_set_current_user( self::$user );
+		$response = $this->save_block_content(
+			"<!-- wp:media-text -->\n<div class=\"wp-block-media-text alignwide is-stacked-on-mobile\"><figure class=\"wp-block-media-text__media\"></figure><div class=\"wp-block-media-text__content\"><!-- wp:paragraph {\"placeholder\":\"Content…\",\"fontSize\":\"large\"} -->\n<p class=\"has-large-font-size\"></p>\n<!-- /wp:paragraph --></div></div>\n<!-- /wp:media-text -->"
 		);
 		$this->assertTrue( $response->is_error() );
 		$data = $response->get_data();

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -239,7 +239,7 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test invalid block content: an empty media & text block.
+	 * Test invalid block content: a block that doesn't exist on this site.
 	 */
 	public function test_invalid_fake_block() {
 		wp_set_current_user( self::$user );

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -226,19 +226,6 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test invalid block content: an empty media & text block.
-	 */
-	public function test_invalid_empty_media_text_block() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:media-text -->\n<div class=\"wp-block-media-text alignwide is-stacked-on-mobile\"><figure class=\"wp-block-media-text__media\"></figure><div class=\"wp-block-media-text__content\"><!-- wp:paragraph {\"placeholder\":\"Content…\",\"fontSize\":\"large\"} -->\n<p class=\"has-large-font-size\"></p>\n<!-- /wp:paragraph --></div></div>\n<!-- /wp:media-text -->"
-		);
-		$this->assertTrue( $response->is_error() );
-		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_empty_blocks', $data['code'] );
-	}
-
-	/**
 	 * Test invalid block content: a block that doesn't exist on this site.
 	 */
 	public function test_invalid_fake_block() {


### PR DESCRIPTION
Fixes #82 — Container blocks were not considered valid, because the content they have in `innerHTML` is technically empty, the actual child block content is in `innerBlocks`. This updates the validation code to check into `innerBlocks` too, so groups and columns are correctly validated.

It also updates how paragraphs are validated - now any empty paragraph is considered "empty", even if the user maybe customized the font or color. A pattern should contain more content than just an empty styled paragraph.

### How to test the changes in this Pull Request:

1. Make sure the tests pass: `yarn test:php` or ✅ on the actions here
2. Create a Block Pattern in wp-admin
3. Add a group or column block, but don't change background color or any other attributes
  Or copy this content into the block editor (by switching to the code editor)

<details>
<summary>Group block code</summary>

```html
<!-- wp:group -->
<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:separator {"className":"is-style-default"} -->
<hr class="wp-block-separator is-style-default"/>
<!-- /wp:separator -->

<!-- wp:image {"align":"center","id":null,"width":150,"height":150,"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
<div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large is-resized"><img src="https://s.w.org/images/core/5.8/portrait.jpg" alt="A side profile of a woman in a russet-colored turtleneck and white bag. She looks up with her eyes closed." width="150" height="150"/></figure></div>
<!-- /wp:image -->

<!-- wp:quote {"align":"center","className":"is-style-large"} -->
<blockquote class="wp-block-quote has-text-align-center is-style-large"><p>"Contributing makes me feel like I'm being useful to the planet."</p><cite>— Anna Wong, <em>Volunteer</em></cite></blockquote>
<!-- /wp:quote -->

<!-- wp:separator {"className":"is-style-default"} -->
<hr class="wp-block-separator is-style-default"/>
<!-- /wp:separator --></div></div>
<!-- /wp:group -->
```
</details>

<details>
<summary>Columns block code</summary>

```html
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph {"style":{"typography":{"fontSize":"21px"},"color":{"text":"#000000"}}} -->
<p class="has-text-color" style="color:#000000;font-size:21px"><strong>We have worked with:</strong></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"typography":{"fontSize":"24px","lineHeight":"1.2"}}} -->
<p style="font-size:24px;line-height:1.2"><a href="https://wordpress.org">EARTHFUND™<br>ARCHWEEKLY<br>FUTURE ROADS<br>BUILDING NY</a></p>
<!-- /wp:paragraph -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:spacer {"height":160} -->
<div style="height:160px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph {"style":{"typography":{"fontSize":"24px","lineHeight":"1.2"}}} -->
<p style="font-size:24px;line-height:1.2"><a href="https://wordpress.org">DUBAI ROOFS<br>MAY WATSON STUDIO<br>Y.O.L<br>RUDIMENTAR</a></p>
<!-- /wp:paragraph -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```
</details>

4. Save the block pattern, it should successfully save, no validation errors.

