### PR TITLE
Pattern Details: Add a global asset URL variable, used to build links to theme assets

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -58,6 +58,12 @@ function enqueue_assets() {
 		wp_enqueue_style( 'wp-components' );
 
 		wp_set_script_translations( 'wporg-pattern-script', 'wporg-patterns' );
+
+		wp_add_inline_script(
+			'wporg-pattern-script',
+			sprintf( 'var wporgAssetUrl = "%s";', esc_url( get_stylesheet_directory_uri() ) ),
+			'before'
+		);
 	}
 
 	wp_enqueue_script( 'wporg-navigation', get_template_directory_uri() . "/js/navigation$suffix.js", array(), '20210331', true );

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -54,7 +54,7 @@
 	"eslintConfig": {
 		"extends": "../../../../.eslintrc.js",
 		"globals": {
-			"wporgBlockPattern": "readonly"
+			"wporgAssetUrl": "readonly"
 		}
 	},
 	"prettier": "../../../../.prettierrc.js",

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
@@ -9,7 +9,7 @@ const CopyPasteImage = () => (
 	// Wrap the image to avoid the UI shift after the GIF loads
 	<div style={ { height: '220px' } }>
 		<img
-			src="/wp-content/themes/pattern-directory/images/copy-paste-demo.gif"
+			src={ `${ wporgAssetUrl }/images/copy-paste-demo.gif` }
 			alt={ __( 'GIF of copy and pasting.', 'wporg-patterns' ) }
 		/>
 	</div>


### PR DESCRIPTION
The theme path is different in different environments, so instead of hard-coding this value, we should provide a variable that uses the dynamic URL from WordPress. We can pass a global variable into the app using `wp_add_inline_script`, so I've set up `wporgAssetUrl`. This is used in the copy-paste guide to load the image from the correct location.

### How to test the changes in this Pull Request:

1. View a single pattern page
2. Click Copy, then click Learn More in the success message
3. The image in the modal should appear

