### PR TITLE
Pattern Previews: Always add a theme stylesheet to preview iframes

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
@@ -90,8 +90,17 @@ function setHead( doc, head ) {
 		'<style>body{margin:0}</style>' + head;
 }
 
-function Iframe( { contentRef, children, head, headHTML, ...props }, ref ) {
+function Iframe( { contentRef, children, head, headHTML, themeSlug, ...props }, ref ) {
 	const [ iframeDocument, setIframeDocument ] = useState();
+
+	headHTML +=
+		'<style>body{pointer-events:none;display: flex;align-items: center;justify-content: center;min-height: 100vh;} body > div {width: 100%}</style>';
+
+	if ( themeSlug ) {
+		headHTML += `<link rel="stylesheet" href="https://wp-themes.com/wp-content/themes/${ themeSlug }/style.css" media="all" />`;
+	} else {
+		headHTML += `<link rel="stylesheet" href="https://wp-themes.com/wp-content/themes/twentytwentyone/style.css" media="all" />`;
+	}
 
 	const setRef = useCallback( ( node ) => {
 		if ( ! node ) {

--- a/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
@@ -99,7 +99,7 @@ function Iframe( { contentRef, children, head, headHTML, themeSlug, ...props }, 
 	if ( themeSlug ) {
 		headHTML += `<link rel="stylesheet" href="https://wp-themes.com/wp-content/themes/${ themeSlug }/style.css" media="all" />`;
 	} else {
-		headHTML += `<link rel="stylesheet" href="https://wp-themes.com/wp-content/themes/twentytwentyone/style.css" media="all" />`;
+		headHTML += '<link rel="stylesheet" href="https://wp-themes.com/wp-content/themes/twentytwentyone/style.css" media="all" />';
 	}
 
 	const setRef = useCallback( ( node ) => {

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
@@ -1,10 +1,7 @@
 /**
- * WordPress dependencies
+ * Internal dependencies
  */
-import {
-	/* eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- Experimental is OK. */
-	__unstableIframe as Iframe,
-} from '@wordpress/block-editor';
+import Iframe from '../iframe';
 
 function Canvas( { html } ) {
 	const style = {
@@ -13,17 +10,13 @@ function Canvas( { html } ) {
 		minHeight: '600px',
 		overflowY: 'auto',
 	};
-	const extraIframeStyles =
-		// @todo - Should we keep the TT1 style? Load css from a local file?
-		'<link rel="stylesheet" id="twenty-twenty-one-style-css"  href="https://wp-themes.com/wp-content/themes/twentytwentyone/style.css?ver=1.2" media="all" />' +
-		'<style>body{pointer-events:none;display: flex;align-items: center;justify-content: center;min-height: 100vh;} body > div {width: 100%}</style>';
 
 	return (
 		<div>
 			<Iframe
 				className="pattern-preview__viewport-iframe"
 				style={ style }
-				headHTML={ window.__editorStyles.html + extraIframeStyles }
+				headHTML={ window.__editorStyles.html }
 			>
 				<div
 					dangerouslySetInnerHTML={ {


### PR DESCRIPTION
This updates the `Iframe` component to always provide a theme stylesheet for all pattern previews. It will default to Twenty Twenty-One, but can also be customized by providing a `themeSlug` to the `<Iframe>`.

This also switches the large preview from using the core "experimental iframe" to our forked iframe component, which I meant to do after #69 merged.

I think we can consider this Fixes #31 — I have a note about trying shadow DOM to see if that improves performance, but a) I'm not seeing any perf issues yet, and b) react shadow DOM libraries seem like more overkill than a few iframes. Happy to revisit this before launch if we notice issues though.

### Screenshots

![Screen Shot 2021-04-27 at 12 52 09](https://user-images.githubusercontent.com/541093/116124182-f7a22700-a691-11eb-94c0-06ac758b2a15.png)
![Screen Shot 2021-04-27 at 12 52 29](https://user-images.githubusercontent.com/541093/116124184-f8d35400-a691-11eb-963e-7b499218ad94.png)

### How to test the changes in this Pull Request:

0. Build the files: `yarn workspaces run build`
1. View the patterns grid, any archive view
2. The pattern previews should use Twenty Twenty-One styles
3. Click into any pattern
4. The large preview should also use Twenty Twenty-One styles
