### PR TITLE
Add API for saving block patterns to a user's favorites

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -15,3 +15,4 @@ require_once __DIR__ . '/includes/pattern-validation.php';
 require_once __DIR__ . '/includes/post-status.php';
 require_once __DIR__ . '/includes/search.php';
 require_once __DIR__ . '/includes/admin.php';
+require_once __DIR__ . '/includes/favorite.php';

--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -9,6 +9,7 @@
 namespace WordPressdotorg\Pattern_Directory;
 
 require_once __DIR__ . '/includes/class-rest-flags-controller.php';
+require_once __DIR__ . '/includes/class-rest-favorite-controller.php';
 require_once __DIR__ . '/includes/pattern-post-type.php';
 require_once __DIR__ . '/includes/pattern-flag-post-type.php';
 require_once __DIR__ . '/includes/pattern-validation.php';

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
@@ -2,7 +2,7 @@
 
 namespace WordPressdotorg\Pattern_Directory\Favorites_API;
 
-use function WordPressdotorg\Pattern_Directory\Favorite\{save_favorite, get_favorites};
+use function WordPressdotorg\Pattern_Directory\Favorite\{add_favorite, get_favorites, remove_favorite};
 use WP_Error, WP_REST_Server, WP_REST_Response;
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\init' );
@@ -87,7 +87,7 @@ function get_items( $request ) {
  */
 function update_item( $request ) {
 	$pattern_id = $request['id'];
-	$success = save_favorite( $pattern_id );
+	$success = add_favorite( $pattern_id );
 
 	if ( $success ) {
 		return new WP_REST_Response( true, 200 );
@@ -108,7 +108,7 @@ function update_item( $request ) {
  */
 function delete_item( $request ) {
 	$pattern_id = $request['id'];
-	$success = save_favorite( $pattern_id, null, false );
+	$success = remove_favorite( $pattern_id );
 
 	if ( $success ) {
 		return new WP_REST_Response( true, 200 );

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
@@ -60,7 +60,7 @@ function permissions_check() {
 	if ( ! is_user_logged_in() ) {
 		return new WP_Error(
 			'rest_authorization_required',
-			__( 'You must be logged in to save a pattern.', 'wporg-patterns' ),
+			__( 'You must be logged in to favorite a pattern.', 'wporg-patterns' ),
 			array( 'status' => rest_authorization_required_code() )
 		);
 	}

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
@@ -32,8 +32,8 @@ function init() {
 		'wporg/v1',
 		'pattern-favorites',
 		array(
-			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __NAMESPACE__ . '\update_item',
+			'methods' => WP_REST_Server::CREATABLE,
+			'callback' => __NAMESPACE__ . '\create_item',
 			'args' => $args,
 			'permission_callback' => __NAMESPACE__ . '\permissions_check',
 		)
@@ -85,7 +85,7 @@ function get_items( $request ) {
  * @param WP_REST_Request $request Full data about the request.
  * @return WP_Error|WP_REST_Response
  */
-function update_item( $request ) {
+function create_item( $request ) {
 	$pattern_id = $request['id'];
 	$success = add_favorite( $pattern_id );
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Favorites_API;
+
+use function WordPressdotorg\Pattern_Directory\Favorite\{save_favorite, get_favorites};
+use WP_Error, WP_REST_Server, WP_REST_Response;
+
+add_action( 'rest_api_init', __NAMESPACE__ . '\init' );
+
+/**
+ * Set up the endpoints for favoriting patterns.
+ */
+function init() {
+	register_rest_route(
+		'wporg/v1',
+		'pattern-favorites',
+		array(
+			'methods' => WP_REST_Server::READABLE,
+			'callback' => __NAMESPACE__ . '\get_items',
+			'permission_callback' => __NAMESPACE__ . '\permissions_check',
+		)
+	);
+
+	$args = array(
+		'id' => array(
+			'validate_callback' => function( $param, $request, $key ) {
+				return is_numeric( $param );
+			},
+		),
+	);
+	register_rest_route(
+		'wporg/v1',
+		'pattern-favorites',
+		array(
+			'methods' => WP_REST_Server::EDITABLE,
+			'callback' => __NAMESPACE__ . '\update_item',
+			'args' => $args,
+			'permission_callback' => __NAMESPACE__ . '\permissions_check',
+		)
+	);
+	register_rest_route(
+		'wporg/v1',
+		'pattern-favorites',
+		array(
+			'methods' => WP_REST_Server::DELETABLE,
+			'callback' => __NAMESPACE__ . '\delete_item',
+			'args' => $args,
+			'permission_callback' => __NAMESPACE__ . '\permissions_check',
+		)
+	);
+}
+
+/**
+ * Check if a given request has access to favorites.
+ * The only requirement for anything "favorite" is to be logged in.
+ *
+ * @return WP_Error|bool
+ */
+function permissions_check() {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error(
+			'rest_authorization_required',
+			__( 'You must be logged in to save a pattern.', 'wporg-patterns' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	return true;
+}
+
+/**
+ * Get the list of favorites for the current user.
+ *
+ * @param WP_REST_Request $request Full data about the request.
+ * @return WP_Error|WP_REST_Response
+ */
+function get_items( $request ) {
+	$favorites = get_favorites();
+	return new WP_REST_Response( $favorites, 200 );
+}
+
+/**
+ * Save a pattern to the user's favorites.
+ *
+ * @param WP_REST_Request $request Full data about the request.
+ * @return WP_Error|WP_REST_Response
+ */
+function update_item( $request ) {
+	$pattern_id = $request['id'];
+	$success = save_favorite( $pattern_id );
+
+	if ( $success ) {
+		return new WP_REST_Response( true, 200 );
+	}
+
+	return new WP_Error(
+		'favorite-failed',
+		__( 'Unable to favorite this pattern.', 'wporg-patterns' ),
+		array( 'status' => 500 )
+	);
+}
+
+/**
+ * Remove a pattern from the user's favorites.
+ *
+ * @param WP_REST_Request $request Full data about the request.
+ * @return WP_Error|WP_REST_Response
+ */
+function delete_item( $request ) {
+	$pattern_id = $request['id'];
+	$success = save_favorite( $pattern_id, null, false );
+
+	if ( $success ) {
+		return new WP_REST_Response( true, 200 );
+	}
+
+	return new WP_Error(
+		'unfavorite-failed',
+		__( 'Unable to remove this pattern from your favorites.', 'wporg-patterns' ),
+		array( 'status' => 500 )
+	);
+}

--- a/public_html/wp-content/plugins/pattern-directory/includes/favorite.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/favorite.php
@@ -28,7 +28,8 @@ function save_favorite( $post, $user = 0, $favorite = true ) {
 	} elseif ( $favorite ) {
 		$users_favorites[] = $post->ID;
 	} elseif ( ! $favorite && $already_favorited ) {
-		unset( $users_favorites[ array_search( $post->ID, $users_favorites, true ) ] );
+		$index = array_search( $post->ID, $users_favorites, true );
+		unset( $users_favorites[ $index ] );
 	} else {
 		return true;
 	}

--- a/public_html/wp-content/plugins/pattern-directory/includes/favorite.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/favorite.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Favorite;
+use function WordPressdotorg\Pattern_Directory\Pattern_Post_Type\get_block_pattern;
+
+const META_KEY = 'wporg-pattern-favorites';
+
+/**
+ * Save a pattern to a users's favorites list.
+ *
+ * @param mixed   $post     The block pattern to favorite.
+ * @param mixed   $user     The user favoriting. Optional. Default current user.
+ * @param boolean $favorite Whether it's a favorite, or unfavorite. Optional. Default true.
+ * @return boolean
+ */
+function save_favorite( $post, $user = 0, $favorite = true ) {
+	$post = get_block_pattern( $post );
+	$user = new \WP_User( $user ?: get_current_user_id() );
+	if ( ! $post || ! $user->exists() ) {
+		return false;
+	}
+
+	$users_favorites   = get_user_meta( $user->ID, META_KEY, true ) ?: array();
+	$already_favorited = in_array( $post->ID, $users_favorites, true );
+
+	if ( $favorite && $already_favorited ) {
+		return true;
+	} elseif ( $favorite ) {
+		$users_favorites[] = $post->ID;
+	} elseif ( ! $favorite && $already_favorited ) {
+		unset( $users_favorites[ array_search( $post->ID, $users_favorites, true ) ] );
+	} else {
+		return true;
+	}
+
+	return update_user_meta( $user->ID, META_KEY, array_values( $users_favorites ) );
+}
+
+/**
+ * Check if a pattern is in a user's favorites.
+ *
+ * @param mixed $post The block pattern to look up.
+ * @param mixed $user The user to check. Optional. Default current user.
+ * @return boolean
+ */
+function is_favorite( $post, $user = 0 ) {
+	$post = get_block_pattern( $post );
+	$user = new \WP_User( $user ?: get_current_user_id() );
+	if ( ! $post || ! $user->exists() ) {
+		return false;
+	}
+
+	$users_favorites   = get_user_meta( $user->ID, META_KEY, true ) ?: array();
+	return in_array( $post->ID, $users_favorites, true );
+}
+
+/**
+ * Get a list of the user's favorite patterns
+ *
+ * @param mixed $user The user to check. Optional. Default current user.
+ * @return integer[]
+ */
+function get_favorites( $user = 0 ) {
+	$user = new \WP_User( $user ?: get_current_user_id() );
+	if ( ! $user->exists() ) {
+		return array();
+	}
+	$favorites = get_user_meta( $user->ID, META_KEY, true ) ?: array();
+
+	return array_map( 'absint', $favorites );
+}

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -306,3 +306,18 @@ function disable_block_directory() {
 		remove_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_block_editor_assets_block_directory' );
 	}
 }
+
+/**
+ * Get the post object of a block pattern, or false if it's not a pattern or not found.
+ *
+ * @param int|WP_Post $post
+ *
+ * @return WP_Post|false
+ */
+function get_block_pattern( $post ) {
+	$pattern = get_post( $post );
+	if ( ! $pattern || POST_TYPE !== $pattern->post_type ) {
+		return false;
+	}
+	return $pattern;
+}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/favorite-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/favorite-test.php
@@ -3,7 +3,7 @@
  * Test Block Pattern validation.
  */
 
-use function WordPressdotorg\Pattern_Directory\Favorite\{save_favorite, get_favorites};
+use function WordPressdotorg\Pattern_Directory\Favorite\{add_favorite, get_favorites, remove_favorite};
 use const WordPressdotorg\Pattern_Directory\Favorite\META_KEY;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 
@@ -40,7 +40,7 @@ class Pattern_Favorite_Test extends WP_UnitTestCase {
 				'role' => 'subscriber',
 			)
 		);
-		update_user_meta( self::$user_admin, META_KEY, array( self::$faved_pattern_id ) );
+		add_user_meta( self::$user_admin, META_KEY, self::$faved_pattern_id );
 	}
 
 	/**
@@ -48,10 +48,10 @@ class Pattern_Favorite_Test extends WP_UnitTestCase {
 	 */
 	public function test_favorite_pattern() {
 		wp_set_current_user( self::$user_admin );
-		$success = save_favorite( self::$pattern_id );
+		$success = add_favorite( self::$pattern_id );
 		$this->assertTrue( (bool) $success );
 
-		$favorites = get_user_meta( self::$user_admin, META_KEY, true );
+		$favorites = get_favorites( self::$user_admin );
 		$this->assertSame( $favorites, array( self::$faved_pattern_id, self::$pattern_id ) );
 	}
 
@@ -60,10 +60,10 @@ class Pattern_Favorite_Test extends WP_UnitTestCase {
 	 */
 	public function test_unfavorite_faved_pattern() {
 		wp_set_current_user( self::$user_admin );
-		$success = save_favorite( self::$faved_pattern_id, null, false );
+		$success = remove_favorite( self::$faved_pattern_id );
 		$this->assertTrue( (bool) $success );
 
-		$favorites = get_user_meta( self::$user_admin, META_KEY, true );
+		$favorites = get_favorites( self::$user_admin );
 		$this->assertSame( $favorites, array() );
 	}
 
@@ -72,10 +72,10 @@ class Pattern_Favorite_Test extends WP_UnitTestCase {
 	 */
 	public function test_favorite_faved_pattern() {
 		wp_set_current_user( self::$user_admin );
-		$success = save_favorite( self::$faved_pattern_id );
+		$success = add_favorite( self::$faved_pattern_id );
 		$this->assertTrue( (bool) $success );
 
-		$favorites = get_user_meta( self::$user_admin, META_KEY, true );
+		$favorites = get_favorites( self::$user_admin );
 		$this->assertSame( $favorites, array( self::$faved_pattern_id ) );
 	}
 
@@ -84,10 +84,10 @@ class Pattern_Favorite_Test extends WP_UnitTestCase {
 	 */
 	public function test_unfavorite_nonfaved_pattern() {
 		wp_set_current_user( self::$user_admin );
-		$success = save_favorite( self::$pattern_id, null, false );
+		$success = remove_favorite( self::$pattern_id );
 		$this->assertTrue( (bool) $success );
 
-		$favorites = get_user_meta( self::$user_admin, META_KEY, true );
+		$favorites = get_favorites( self::$user_admin );
 		$this->assertSame( $favorites, array( self::$faved_pattern_id ) );
 	}
 
@@ -96,7 +96,7 @@ class Pattern_Favorite_Test extends WP_UnitTestCase {
 	 */
 	public function test_favorite_invalid_pattern() {
 		wp_set_current_user( self::$user_admin );
-		$success = save_favorite( 'invalid-id' );
+		$success = add_favorite( 'invalid-id' );
 		$this->assertFalse( (bool) $success );
 	}
 
@@ -105,7 +105,7 @@ class Pattern_Favorite_Test extends WP_UnitTestCase {
 	 */
 	public function test_favorite_page() {
 		wp_set_current_user( self::$user_admin );
-		$success = save_favorite( self::$page_id );
+		$success = add_favorite( self::$page_id );
 		$this->assertFalse( (bool) $success );
 	}
 
@@ -114,10 +114,10 @@ class Pattern_Favorite_Test extends WP_UnitTestCase {
 	 */
 	public function test_favorite_pattern_subscriber() {
 		wp_set_current_user( self::$user_subscriber );
-		$success = save_favorite( self::$pattern_id );
+		$success = add_favorite( self::$pattern_id );
 		$this->assertTrue( (bool) $success );
 
-		$favorites = get_user_meta( self::$user_subscriber, META_KEY, true );
+		$favorites = get_favorites( self::$user_subscriber );
 		$this->assertSame( $favorites, array( self::$pattern_id ) );
 	}
 
@@ -125,7 +125,7 @@ class Pattern_Favorite_Test extends WP_UnitTestCase {
 	 * Test favoriting a pattern as an anonymous (not logged in) user.
 	 */
 	public function test_favorite_pattern_anon() {
-		$success = save_favorite( self::$pattern_id );
+		$success = add_favorite( self::$pattern_id );
 		$this->assertFalse( (bool) $success );
 	}
 
@@ -134,10 +134,10 @@ class Pattern_Favorite_Test extends WP_UnitTestCase {
 	 * This would only be done from the server, so there isn't a security issue here.
 	 */
 	public function test_anon_favorite_pattern_admin() {
-		$success = save_favorite( self::$pattern_id, self::$user_admin );
+		$success = add_favorite( self::$pattern_id, self::$user_admin );
 		$this->assertTrue( (bool) $success );
 
-		$favorites = get_user_meta( self::$user_admin, META_KEY, true );
+		$favorites = get_favorites( self::$user_admin );
 		$this->assertSame( $favorites, array( self::$faved_pattern_id, self::$pattern_id ) );
 	}
 

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/favorite-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/favorite-test.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Test Block Pattern validation.
+ */
+
+use function WordPressdotorg\Pattern_Directory\Favorite\{save_favorite, get_favorites};
+use const WordPressdotorg\Pattern_Directory\Favorite\META_KEY;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+
+/**
+ * Test pattern validation.
+ */
+class Pattern_Favorite_Test extends WP_UnitTestCase {
+	protected static $pattern_id;
+	protected static $faved_pattern_id;
+	protected static $page_id;
+	protected static $user_admin;
+	protected static $user_subscriber;
+
+	/**
+	 * Setup fixtures that are shared across all tests.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$pattern_id = $factory->post->create(
+			array( 'post_type' => POST_TYPE )
+		);
+		self::$faved_pattern_id = $factory->post->create(
+			array( 'post_type' => POST_TYPE )
+		);
+		self::$page_id = $factory->post->create(
+			array( 'post_type' => 'page' )
+		);
+		self::$user_admin = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		self::$user_subscriber = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+		update_user_meta( self::$user_admin, META_KEY, array( self::$faved_pattern_id ) );
+	}
+
+	/**
+	 * Test favoriting a pattern as the admin user.
+	 */
+	public function test_favorite_pattern() {
+		wp_set_current_user( self::$user_admin );
+		$success = save_favorite( self::$pattern_id );
+		$this->assertTrue( (bool) $success );
+
+		$favorites = get_user_meta( self::$user_admin, META_KEY, true );
+		$this->assertSame( $favorites, array( self::$faved_pattern_id, self::$pattern_id ) );
+	}
+
+	/**
+	 * Test unfavoriting a pattern as the admin user.
+	 */
+	public function test_unfavorite_faved_pattern() {
+		wp_set_current_user( self::$user_admin );
+		$success = save_favorite( self::$faved_pattern_id, null, false );
+		$this->assertTrue( (bool) $success );
+
+		$favorites = get_user_meta( self::$user_admin, META_KEY, true );
+		$this->assertSame( $favorites, array() );
+	}
+
+	/**
+	 * Test favoriting an already favorited pattern.
+	 */
+	public function test_favorite_faved_pattern() {
+		wp_set_current_user( self::$user_admin );
+		$success = save_favorite( self::$faved_pattern_id );
+		$this->assertTrue( (bool) $success );
+
+		$favorites = get_user_meta( self::$user_admin, META_KEY, true );
+		$this->assertSame( $favorites, array( self::$faved_pattern_id ) );
+	}
+
+	/**
+	 * Test unfavoriting an non-favorited pattern.
+	 */
+	public function test_unfavorite_nonfaved_pattern() {
+		wp_set_current_user( self::$user_admin );
+		$success = save_favorite( self::$pattern_id, null, false );
+		$this->assertTrue( (bool) $success );
+
+		$favorites = get_user_meta( self::$user_admin, META_KEY, true );
+		$this->assertSame( $favorites, array( self::$faved_pattern_id ) );
+	}
+
+	/**
+	 * Test favoriting an invalid pattern (not allowed).
+	 */
+	public function test_favorite_invalid_pattern() {
+		wp_set_current_user( self::$user_admin );
+		$success = save_favorite( 'invalid-id' );
+		$this->assertFalse( (bool) $success );
+	}
+
+	/**
+	 * Test favoriting a page (not allowed).
+	 */
+	public function test_favorite_page() {
+		wp_set_current_user( self::$user_admin );
+		$success = save_favorite( self::$page_id );
+		$this->assertFalse( (bool) $success );
+	}
+
+	/**
+	 * Test favoriting a pattern as a subscriber.
+	 */
+	public function test_favorite_pattern_subscriber() {
+		wp_set_current_user( self::$user_subscriber );
+		$success = save_favorite( self::$pattern_id );
+		$this->assertTrue( (bool) $success );
+
+		$favorites = get_user_meta( self::$user_subscriber, META_KEY, true );
+		$this->assertSame( $favorites, array( self::$pattern_id ) );
+	}
+
+	/**
+	 * Test favoriting a pattern as an anonymous (not logged in) user.
+	 */
+	public function test_favorite_pattern_anon() {
+		$success = save_favorite( self::$pattern_id );
+		$this->assertFalse( (bool) $success );
+	}
+
+	/**
+	 * Test favoriting a pattern as an anonymous user, for a real user.
+	 * This would only be done from the server, so there isn't a security issue here.
+	 */
+	public function test_anon_favorite_pattern_admin() {
+		$success = save_favorite( self::$pattern_id, self::$user_admin );
+		$this->assertTrue( (bool) $success );
+
+		$favorites = get_user_meta( self::$user_admin, META_KEY, true );
+		$this->assertSame( $favorites, array( self::$faved_pattern_id, self::$pattern_id ) );
+	}
+
+	/**
+	 * Test getting favorite patterns when a user has some.
+	 */
+	public function test_get_favorite_patterns() {
+		wp_set_current_user( self::$user_admin );
+		$favorites = get_favorites();
+		$this->assertSame( $favorites, array( self::$faved_pattern_id ) );
+	}
+
+	/**
+	 * Test getting favorite patterns when a user has none.
+	 */
+	public function test_get_favorite_patterns_subscriber() {
+		$favorites = get_favorites( self::$user_subscriber );
+		$this->assertEmpty( $favorites );
+	}
+}


### PR DESCRIPTION
See #52 — This sets out the API side of saving a pattern to a user's favorites. Favoriting will be done via API requests by a logged in user, so we will save/fetch favorites only for that user.

Endpoints introduced:

- `GET /wporg/v1/pattern-favorites` — List all favorites (array of pattern IDs)
- `POST /wporg/v1/pattern-favorites` with arg `id` — add a pattern to favorites, returns true or error
- `DELETE /wporg/v1/pattern-favorites` with arg `id` — remove a pattern from favorites, returns true or error

### How to test the changes in this Pull Request:

1. Try interacting with the API in Insomnia/other REST client
2. Make sure the tests pass
