### PR TITLE
Theme: Update category navigation indicator to be a rectangle

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_category-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_category-menu.scss
@@ -17,7 +17,7 @@
 		text-decoration: none;
 
 		&:hover,
-		&:active
+		&:active,
 		&:focus {
 			color: $color-black;
 		}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_category-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_category-menu.scss
@@ -3,13 +3,6 @@
 	padding: 0;
 	position: relative;
 
-	background: linear-gradient(180deg, hsla(0, 0%, 100%, 0) 94%, $color__wp-blue 0);
-	background-repeat: no-repeat;
-	background-size: 0;
-	background-position-x: 0;
-	transition: all 75ms ease-out;
-	min-height: 45px;
-
 	li {
 		display: inline-block;
 		margin: 0;
@@ -18,20 +11,27 @@
 
 	a {
 		display: block;
-		padding: $gutter-default / 2;
+		padding: $gutter-default / 3 $gutter-default / 2;
 		color: $color-gray-600;
 		font-size: 0.875rem;
 		text-decoration: none;
 
 		&:hover,
-		&:active,
+		&:active
 		&:focus {
 			color: $color-black;
 		}
 	}
 
 	li &--is-active {
-		color: $color-black;
+		color: $color-white;
+		background: $color__wp-blue;
+		border-radius: 2px;
+
+		&:hover,
+		&:focus {
+			color: $color-white;
+		}
 	}
 
 	&__mobile {

--- a/public_html/wp-content/themes/pattern-directory/src/components/category-menu/default.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/category-menu/default.js
@@ -1,57 +1,27 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
 import { ifViewportMatches } from '@wordpress/viewport';
 
-const updateIndicatorLocation = ( container, { top, left, width, height } ) => {
-	if ( ! container ) {
-		return;
-	}
-
-	container.style.backgroundPositionX = `${ left }px`;
-	container.style.backgroundSize = `${ width }px ${ top + height }px`;
-};
-
 const DefaultMenu = ( { path, options, onClick, isLoading } ) => {
-	const containerRef = useRef( null );
-	const activeRef = useRef( null );
-
-	useEffect( () => {
-		if ( ! containerRef || ! containerRef.current || ! activeRef || ! activeRef.current ) {
-			return;
-		}
-
-		updateIndicatorLocation( containerRef.current, {
-			top: activeRef.current.offsetTop,
-			left: activeRef.current.offsetLeft,
-			width: activeRef.current.offsetWidth,
-			height: activeRef.current.offsetHeight,
-		} );
-	} );
 
 	if ( ! isLoading && ! options.length ) {
 		return null;
 	}
 
 	return (
-		<ul className={ `category-menu ${ isLoading ? 'category-menu--is-loading' : '' } ` } ref={ containerRef }>
-			{ options.map( ( i ) => {
-				const isActive = path === i.value;
-
-				return (
+		<ul className={ `category-menu ${ isLoading ? 'category-menu--is-loading' : '' } ` }>
+			{ options.map( ( i ) => (
 					<li key={ i.value }>
 						<a
-							className={ isActive ? 'category-menu--is-active' : '' }
+							className={ path === i.value ? 'category-menu--is-active' : '' }
 							href={ i.value }
-							ref={ isActive ? activeRef : null }
 							onClick={ onClick }
 						>
 							{ i.label }
 						</a>
 					</li>
-				);
-			} ) }
+				) ) }
 		</ul>
 	);
 };

--- a/public_html/wp-content/themes/pattern-directory/src/components/category-menu/default.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/category-menu/default.js
@@ -4,7 +4,6 @@
 import { ifViewportMatches } from '@wordpress/viewport';
 
 const DefaultMenu = ( { path, options, onClick, isLoading } ) => {
-
 	if ( ! isLoading && ! options.length ) {
 		return null;
 	}
@@ -12,16 +11,16 @@ const DefaultMenu = ( { path, options, onClick, isLoading } ) => {
 	return (
 		<ul className={ `category-menu ${ isLoading ? 'category-menu--is-loading' : '' } ` }>
 			{ options.map( ( i ) => (
-					<li key={ i.value }>
-						<a
-							className={ path === i.value ? 'category-menu--is-active' : '' }
-							href={ i.value }
-							onClick={ onClick }
-						>
-							{ i.label }
-						</a>
-					</li>
-				) ) }
+				<li key={ i.value }>
+					<a
+						className={ path === i.value ? 'category-menu--is-active' : '' }
+						href={ i.value }
+						onClick={ onClick }
+					>
+						{ i.label }
+					</a>
+				</li>
+			) ) }
 		</ul>
 	);
 };


### PR DESCRIPTION
This PR updates the active category indicator from a line to a rectangle to match new designs.

I also removed the existing animation which was too distracting when a square moves laterally as opposed to a line.

I think we can add a more appropriate animation in the future although maybe the loading indicator and the grid loading state is enough.

### Screenshots
![](https://d.pr/i/Pi7BMp.gif)

### How to test the changes in this Pull Request:

1. Create block pattern Categories
2. Visit `/`
3. Click different categories and verify the correct category is selected as in the screenshot/gif.

<!-- If you can, add the appropriate [Component] label(s). -->
