### PR TITLE
Update the patterns state to track results per-page

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -10,6 +10,7 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_fields' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_assets' );
 add_filter( 'allowed_block_types', __NAMESPACE__ . '\remove_disallowed_blocks', 10, 2 );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\disable_block_directory', 0 );
+add_filter( 'rest_' . POST_TYPE . '_collection_params', __NAMESPACE__ . '\filter_patterns_collection_params' );
 
 
 /**
@@ -326,6 +327,21 @@ function disable_block_directory() {
 		remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
 		remove_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_block_editor_assets_block_directory' );
 	}
+}
+
+/**
+ * Filter the collection parameters to set a new default for per_page.
+ *
+ * @param array $query_params JSON Schema-formatted collection parameters.
+ * @return array Filtered parameters.
+ */
+function filter_patterns_collection_params( $query_params ) {
+	if ( isset( $query_params['per_page'] ) ) {
+		// Number of patterns per page, should be multiple of 2 and 3 (for 2- and 3-column layouts).
+		$query_params['per_page']['default'] = 18;
+	}
+
+	return $query_params;
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/src/store/actions.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/actions.js
@@ -18,12 +18,23 @@ export function fetchPatterns( query ) {
  * Get the action object signalling that patterns have been loaded.
  *
  * @param {string} query Search string.
- * @param {Array} patterns A list of patterns.
+ * @param {Object} response
+ * @param {Array} response.page The current page.
+ * @param {Array} response.patterns A list of patterns.
+ * @param {number} response.total The total number of patterns.
+ * @param {number} response.totalPages The total number of pages.
  *
  * @return {Object} Action object.
  */
-export function loadPatterns( query, patterns ) {
-	return { type: 'LOAD_BLOCK_PATTERNS', query: query, patterns: patterns };
+export function loadPatterns( query, { page, patterns, total, totalPages } ) {
+	return {
+		type: 'LOAD_BLOCK_PATTERNS',
+		query: query,
+		page: page,
+		patterns: patterns,
+		total: total,
+		totalPages: totalPages,
+	};
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/src/store/reducer.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/reducer.js
@@ -34,9 +34,12 @@ function byId( state = {}, action ) {
 
 function queries( state = {}, action ) {
 	const patternIds = ( action.patterns || [] ).map( ( { id } ) => id );
+	const { page, total, totalPages } = action;
 	switch ( action.type ) {
 		case 'LOAD_BLOCK_PATTERNS':
-			return { ...state, [ action.query ]: [ ...( state[ action.query ] || [] ), ...patternIds ] };
+			const _queryState = { ...( state[ action.query ] || {} ), total, totalPages };
+			_queryState[ page ] = patternIds;
+			return { ...state, [ action.query ]: _queryState };
 		default:
 			return state;
 	}

--- a/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
@@ -22,8 +22,8 @@ import { getQueryString } from './utils';
 async function parseResponse( response ) {
 	try {
 		return {
-			total: response.headers?.get( 'X-WP-Total' ),
-			totalPages: response.headers?.get( 'X-WP-TotalPages' ),
+			total: Number( response.headers?.get( 'X-WP-Total' ) || 0 ),
+			totalPages: Number( response.headers?.get( 'X-WP-TotalPages' ) || 0 ),
 			results: await response.json(),
 		};
 	} catch ( error ) {
@@ -43,8 +43,8 @@ export function* getPatternsByQuery( query ) {
 		yield loadPatterns( queryString, {
 			page: query.page || 1,
 			patterns: results,
-			total: Number( total ),
-			totalPages: Number( totalPages ),
+			total: total,
+			totalPages: totalPages,
 		} );
 	} catch ( error ) {}
 }

--- a/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
@@ -43,8 +43,8 @@ export function* getPatternsByQuery( query ) {
 		yield loadPatterns( queryString, {
 			page: query.page || 1,
 			patterns: results,
-			total: total,
-			totalPages: totalPages,
+			total: Number( total ),
+			totalPages: Number( totalPages ),
 		} );
 	} catch ( error ) {}
 }

--- a/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
@@ -17,7 +17,7 @@ import {
 	loadPatternFlagReasons,
 	loadPatterns,
 } from './actions';
-import { PER_PAGE, getQueryString } from './utils';
+import { getQueryString } from './utils';
 
 async function parseResponse( response ) {
 	try {
@@ -36,7 +36,7 @@ export function* getPatternsByQuery( query ) {
 	try {
 		yield fetchPatterns( queryString );
 		const response = yield apiFetch( {
-			path: addQueryArgs( '/wp/v2/wporg-pattern', { ...query, per_page: PER_PAGE } ),
+			path: addQueryArgs( '/wp/v2/wporg-pattern', query ),
 			parse: false,
 		} );
 		const { total, totalPages, results } = yield __unstableAwaitPromise( parseResponse( response ) );

--- a/public_html/wp-content/themes/pattern-directory/src/store/selectors.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/selectors.js
@@ -13,7 +13,8 @@ import { getQueryString } from './utils';
  */
 export function isLoadingPatternsByQuery( state, query ) {
 	const queryString = getQueryString( query );
-	return ! Array.isArray( state.patterns.queries[ queryString ] );
+	const page = query?.page || 1;
+	return ! Array.isArray( state.patterns.queries?.[ queryString ]?.[ page ] );
 }
 
 /**
@@ -37,7 +38,9 @@ export function getPatterns( state ) {
  */
 export function getPatternsByQuery( state, query ) {
 	const queryString = getQueryString( query );
-	return ( state.patterns.queries[ queryString ] || [] ).map( ( id ) => state.patterns.byId[ id ] );
+	const page = query?.page || 1;
+	const patternIds = state.patterns.queries?.[ queryString ]?.[ page ];
+	return ( patternIds || [] ).map( ( id ) => state.patterns.byId[ id ] );
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/src/store/selectors.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/selectors.js
@@ -44,6 +44,32 @@ export function getPatternsByQuery( state, query ) {
 }
 
 /**
+ * Get the count of all patterns for a given query.
+ *
+ * @param {Object} state Global application state.
+ * @param {Object} query Query parameters.
+ *
+ * @return {number} The count of all patterns matching this query.
+ */
+export function getPatternTotalsByQuery( state, query ) {
+	const queryString = getQueryString( query );
+	return state.patterns.queries?.[ queryString ]?.total || 0;
+}
+
+/**
+ * Get the number of pages of patterns for a given query.
+ *
+ * @param {Object} state Global application state.
+ * @param {Object} query Query parameters.
+ *
+ * @return {number} The count of pages.
+ */
+export function getPatternTotalPagesByQuery( state, query ) {
+	const queryString = getQueryString( query );
+	return state.patterns.queries?.[ queryString ]?.totalPages || 0;
+}
+
+/**
  * Get a specific pattern.
  *
  * @param {Object} state Global application state.

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
@@ -14,29 +14,46 @@ describe( 'state', () => {
 				{},
 				{
 					type: 'LOAD_BLOCK_PATTERNS',
-					query: '',
+					page: 1,
 					patterns: apiPatterns,
+					query: '',
+					total: 10,
+					totalPages: 2,
 				}
 			);
 
-			expect( state.queries[ '' ] ).toHaveLength( 5 );
+			expect( state.queries[ '' ].total ).toBe( 10 );
+			expect( state.queries[ '' ].totalPages ).toBe( 2 );
+			expect( state.queries[ '' ][ '1' ] ).toHaveLength( 5 );
 			expect( state.byId ).toHaveProperty( '31' );
 		} );
 
 		it( 'should store the next page of patterns in state', () => {
 			const state = patterns(
 				{
-					queries: { '': [ 31, 25, 26, 27, 28 ] },
+					queries: {
+						'': {
+							total: 10,
+							totalPages: 2,
+							1: [ 31, 25, 26, 27, 28 ],
+						},
+					},
 					byId: apiPatterns.reduce( ( acc, cur ) => ( { ...acc, [ cur.id ]: cur } ), {} ),
 				},
 				{
 					type: 'LOAD_BLOCK_PATTERNS',
-					query: '',
+					page: 2,
 					patterns: apiPatternsPage2,
+					query: '',
+					total: 10,
+					totalPages: 2,
 				}
 			);
 
-			expect( state.queries[ '' ] ).toHaveLength( 10 );
+			expect( state.queries[ '' ].total ).toBe( 10 );
+			expect( state.queries[ '' ].totalPages ).toBe( 2 );
+			expect( state.queries[ '' ][ '1' ] ).toHaveLength( 5 );
+			expect( state.queries[ '' ][ '2' ] ).toHaveLength( 5 );
 			expect( state.byId ).toHaveProperty( '31' );
 			expect( state.byId ).toHaveProperty( '15' );
 		} );
@@ -44,18 +61,31 @@ describe( 'state', () => {
 		it( 'should store a different query of patterns in state', () => {
 			const state = patterns(
 				{
-					queries: { '': [ 31, 25, 26, 27, 28 ] },
+					queries: {
+						'': {
+							total: 10,
+							totalPages: 2,
+							1: [ 31, 25, 26, 27, 28 ],
+						},
+					},
 					byId: apiPatterns.reduce( ( acc, cur ) => ( { ...acc, [ cur.id ]: cur } ), {} ),
 				},
 				{
 					type: 'LOAD_BLOCK_PATTERNS',
-					query: 'pattern-categories=3',
+					page: 1,
 					patterns: apiPatternsPage2,
+					query: 'pattern-categories=3',
+					total: 5,
+					totalPages: 1,
 				}
 			);
 
-			expect( state.queries[ '' ] ).toHaveLength( 5 );
-			expect( state.queries[ 'pattern-categories=3' ] ).toHaveLength( 5 );
+			expect( state.queries[ '' ].total ).toBe( 10 );
+			expect( state.queries[ '' ].totalPages ).toBe( 2 );
+			expect( state.queries[ '' ][ '1' ] ).toHaveLength( 5 );
+			expect( state.queries[ 'pattern-categories=3' ].total ).toBe( 5 );
+			expect( state.queries[ 'pattern-categories=3' ].totalPages ).toBe( 1 );
+			expect( state.queries[ 'pattern-categories=3' ][ '1' ] ).toHaveLength( 5 );
 			expect( state.byId ).toHaveProperty( '31' );
 			expect( state.byId ).toHaveProperty( '15' );
 		} );

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/resolvers.js
@@ -5,9 +5,10 @@ import apiPatterns from './fixtures/patterns';
 import apiCategories from './fixtures/categories';
 import apiPatternFlagReasons from './fixtures/pattern-flag-reasons';
 import { getCategories, getFavorites, getPatternFlagReasons, getPatternsByQuery } from '../resolvers';
+import { PER_PAGE } from '../utils';
 
 describe( 'getPatternsByQuery', () => {
-	it( 'yields with the requested patterns', async () => {
+	it( 'yields with the requested patterns & query meta', async () => {
 		const generator = getPatternsByQuery( {} );
 
 		expect( generator.next().value ).toEqual( {
@@ -18,15 +19,27 @@ describe( 'getPatternsByQuery', () => {
 		// trigger apiFetch
 		const { value: apiFetchAction } = generator.next();
 		expect( apiFetchAction.request ).toEqual( {
-			path: '/wp/v2/wporg-pattern',
+			path: `/wp/v2/wporg-pattern?per_page=${ PER_PAGE }`,
+			parse: false,
 		} );
 
-		// Provide response and trigger action
-		const { value: received } = generator.next( apiPatterns );
+		// Step through the promise - the response is omitted here & mocked in the next step because `Response`
+		// is a browser feature, not available in node.
+		const { value: awaitPromiseControl } = generator.next( { /* Response omitted */ } );
+		expect( awaitPromiseControl ).toEqual( {
+			type: 'AWAIT_PROMISE',
+			promise: expect.any( Promise ),
+		} );
+
+		// Complete the promise and return content
+		const { value: received } = generator.next( { total: 8, totalPages: 2, results: apiPatterns } );
 		expect( received ).toEqual( {
 			type: 'LOAD_BLOCK_PATTERNS',
 			query: '',
+			page: 1,
 			patterns: apiPatterns,
+			total: 8,
+			totalPages: 2,
 		} );
 	} );
 } );

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/resolvers.js
@@ -5,7 +5,6 @@ import apiPatterns from './fixtures/patterns';
 import apiCategories from './fixtures/categories';
 import apiPatternFlagReasons from './fixtures/pattern-flag-reasons';
 import { getCategories, getFavorites, getPatternFlagReasons, getPatternsByQuery } from '../resolvers';
-import { PER_PAGE } from '../utils';
 
 describe( 'getPatternsByQuery', () => {
 	it( 'yields with the requested patterns & query meta', async () => {
@@ -19,7 +18,7 @@ describe( 'getPatternsByQuery', () => {
 		// trigger apiFetch
 		const { value: apiFetchAction } = generator.next();
 		expect( apiFetchAction.request ).toEqual( {
-			path: `/wp/v2/wporg-pattern?per_page=${ PER_PAGE }`,
+			path: `/wp/v2/wporg-pattern`,
 			parse: false,
 		} );
 

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/selectors.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/selectors.js
@@ -31,8 +31,17 @@ describe( 'selectors', () => {
 	const state = {
 		patterns: {
 			queries: {
-				'': [ 31, 25, 27, 26 ],
-				'empty=1': [],
+				'': {
+					total: 4,
+					totalPages: 2,
+					1: [ 31, 25 ],
+					2: [ 27, 26 ],
+				},
+				'empty=1': {
+					total: 0,
+					totalPages: 0,
+					1: [],
+				},
 			},
 			byId: apiPatterns.reduce( ( acc, cur ) => ( { ...acc, [ cur.id ]: cur } ), {} ),
 		},
@@ -74,7 +83,7 @@ describe( 'selectors', () => {
 
 	describe( 'getPatternsByQuery', () => {
 		it( 'should get an empty array if no patterns are loaded for this query', () => {
-			expect( getPatternsByQuery( initialState, '' ) ).toEqual( [] );
+			expect( getPatternsByQuery( initialState, {} ) ).toEqual( [] );
 		} );
 
 		it( 'should get an empty array if no patterns are loaded for this query, even if patterns exist for another query', () => {
@@ -82,13 +91,19 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should get the list of patterns for this query', () => {
-			const patternsByQuery = getPatternsByQuery( state, '' );
-			expect( patternsByQuery ).toHaveLength( 4 );
-			// Keep the sort order of the query: [ 31, 25, 27, 26 ]
+			const patternsByQuery = getPatternsByQuery( state, {} );
+			expect( patternsByQuery ).toHaveLength( 2 );
+			// Keep the sort order of the query: [ 31, 25 ]
 			expect( patternsByQuery[ 0 ] ).toHaveProperty( 'id', 31 );
 			expect( patternsByQuery[ 1 ] ).toHaveProperty( 'id', 25 );
-			expect( patternsByQuery[ 2 ] ).toHaveProperty( 'id', 27 );
-			expect( patternsByQuery[ 3 ] ).toHaveProperty( 'id', 26 );
+		} );
+
+		it( 'should get the second page of patterns for this query', () => {
+			const patternsByQuery = getPatternsByQuery( state, { page: 2 } );
+			expect( patternsByQuery ).toHaveLength( 2 );
+			// Keep the sort order of the query: [ 27, 26 ]
+			expect( patternsByQuery[ 0 ] ).toHaveProperty( 'id', 27 );
+			expect( patternsByQuery[ 1 ] ).toHaveProperty( 'id', 26 );
 		} );
 	} );
 

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/selectors.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/selectors.js
@@ -10,6 +10,8 @@ import {
 	getFavorites,
 	getPattern,
 	getPatternFlagReasons,
+	getPatternTotalPagesByQuery,
+	getPatternTotalsByQuery,
 	getPatterns,
 	getPatternsByQuery,
 	hasLoadedCategories,
@@ -104,6 +106,28 @@ describe( 'selectors', () => {
 			// Keep the sort order of the query: [ 27, 26 ]
 			expect( patternsByQuery[ 0 ] ).toHaveProperty( 'id', 27 );
 			expect( patternsByQuery[ 1 ] ).toHaveProperty( 'id', 26 );
+		} );
+	} );
+
+	describe( 'getPatternTotalsByQuery', () => {
+		it( 'should get 0 if no patterns are loaded for this query', () => {
+			expect( getPatternTotalsByQuery( initialState, {} ) ).toEqual( 0 );
+		} );
+
+		it( 'should get the total number of patterns for this query, regardless of pagination', () => {
+			expect( getPatternTotalsByQuery( state, {} ) ).toEqual( 4 );
+			expect( getPatternTotalsByQuery( state, { page: 2 } ) ).toEqual( 4 );
+		} );
+	} );
+
+	describe( 'getPatternTotalPagesByQuery', () => {
+		it( 'should get 0 if no patterns are loaded for this query', () => {
+			expect( getPatternTotalPagesByQuery( initialState, {} ) ).toEqual( 0 );
+		} );
+
+		it( 'should get the total number of pages for this query, regardless of pagination', () => {
+			expect( getPatternTotalPagesByQuery( state, {} ) ).toEqual( 2 );
+			expect( getPatternTotalPagesByQuery( state, { page: 2 } ) ).toEqual( 2 );
 		} );
 	} );
 

--- a/public_html/wp-content/themes/pattern-directory/src/store/utils.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/utils.js
@@ -4,6 +4,9 @@
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
+// Number of patterns per page, should be multiple of 2 and 3 (for 2- and 3-column layouts).
+export const PER_PAGE = 18;
+
 /**
  * Convert a query object into a standardized string.
  * See the `stableKey` generation in `getQueryParts`

--- a/public_html/wp-content/themes/pattern-directory/src/store/utils.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/utils.js
@@ -4,9 +4,6 @@
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
-// Number of patterns per page, should be multiple of 2 and 3 (for 2- and 3-column layouts).
-export const PER_PAGE = 18;
-
 /**
  * Convert a query object into a standardized string.
  * See the `stableKey` generation in `getQueryParts`


### PR DESCRIPTION
See #102 — the current patterns store was designed to ignore pagination & use infinite scroll. Now that we're bringing back pagination, we need to track the number of pages for each query response.

Before, `queries` just tracked a list of IDs per stringified query:
```js
'': [ 31, 25, 27, 26 ],
```

Now, we track an object with information about the query, including total pages, total pattern count, and then a list of IDs per page.
```js
'': {
	total: 4,
	totalPages: 2,
	1: [ 31, 25 ],
	2: [ 27, 26 ],
},
```

This also introduces new selectors for `getPatternTotalsByQuery` & `getPatternTotalPagesByQuery` (the former can be used in the context bar for result count). This shouldn't change any functionality in the theme yet, since the `getPatternsByQuery` selector still returns the patterns for the given query, and no UI for requesting other pages has been added yet.

### How to test the changes in this Pull Request:

1. Check that the current categories still work
2. Check that the tests pass: `yarn workspace wporg-pattern-directory-theme test:unit`
