### PR TITLE
Pattern CPT & API: Add block types meta field

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -143,6 +143,25 @@ function register_post_type_data() {
 			),
 		)
 	);
+
+	register_post_meta(
+		POST_TYPE,
+		'wpop_block_types',
+		array(
+			'type'              => 'string',
+			'description'       => 'A list of block types this pattern supports for transforms.',
+			'single'            => false,
+			'sanitize_callback' => function( $value, $key, $type ) {
+				return preg_replace( '/[^a-z0-9-\/]/', '', $value );
+			},
+			'auth_callback'     => __NAMESPACE__ . '\can_edit_this_pattern',
+			'show_in_rest'      => array(
+				'schema' => array(
+					'type' => 'string',
+				),
+			),
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
See #33 — this adds a meta field for block types, which is exposed in the API as `meta.wpop_block_types`. This is an array of block type names. Once this is added to the CPT and deployed, it will become available to `http://api.wordpress.org/patterns/1.0/`. A corresponding PR will be made in gutenberg to add support to the `/__experimental/pattern-directory/patterns` endpoint.

I went with a meta field for now, since it can easily be set (in UI or WP-CLI) for the existing core patterns, and doesn't need the full infrastructure of a taxonomy. If we decide once building the UI that a taxonomy makes more sense, we can write a script to convert the post meta (but I think meta will be the way to go).

### How to test the changes in this Pull Request:

1. Add a custom field called `wpop_block_types` to a pattern. The value must be a block type name, formatted like `namespace/name` - it should strip any non-alphanumeric characters out (allowing / and -).
2. GET /wp-json/wp/v2/wporg-pattern/[ID] — the meta value should include the value you entered.
3. GET /wp-json/wp/v2/wporg-pattern/ — all patterns should have a `meta.wpop_block_types` value, defaulting to empty array.

Try adding various values to the meta field, add multiple, etc.

