### PR TITLE
Pattern Grid: Add the pagination component

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -29,6 +29,7 @@
 @import "page";
 @import "pattern-grid-menu";
 @import "pattern-grid";
+@import "pattern-pagination";
 @import "pattern-preview";
 @import "pattern-report-button";
 @import "pattern-report-modal";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-pagination.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-pagination.scss
@@ -1,0 +1,39 @@
+.pagination {
+	max-width: 960px;
+	margin: 1.5rem;
+
+	@include breakpoint( $breakpoint-large ) {
+		margin-left: auto;
+		margin-right: auto;
+	}
+}
+
+.pagination__list {
+	margin: 0;
+	list-style: none;
+	text-align: center;
+}
+
+.pagination__item {
+	display: inline-block;
+}
+
+.pagination__item + .pagination__item {
+	margin-left: 0.75rem;
+}
+
+.pagination__link {
+	padding: 0.75rem;
+	background: $color-white;
+	border: 1px solid $color-gray-light-600;
+	box-sizing: border-box;
+	border-radius: 2px;
+	line-height: 1;
+	text-decoration: none;
+
+	&[aria-current="page"] {
+		border: 1px solid $color-gray-900;
+		background: $color-gray-900;
+		color: $color-white;
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-pagination.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-pagination.scss
@@ -31,6 +31,11 @@
 	line-height: 1;
 	text-decoration: none;
 
+	&:hover,
+	&:active {
+		text-decoration: none;
+	}
+
 	&[aria-current="page"] {
 		border: 1px solid $color-gray-900;
 		background: $color-gray-900;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-pagination.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-pagination.scss
@@ -9,24 +9,27 @@
 }
 
 .pagination__list {
+	display: flex;
 	margin: 0;
 	list-style: none;
-	text-align: center;
+	justify-content: center;
+	align-items: center;
+	gap: 0.75rem;
+
+	@media (max-width: $breakpoint-mobile) {
+		gap: 0.25rem;
+	}
 }
 
 .pagination__item {
 	display: inline-block;
 }
 
-.pagination__item + .pagination__item {
-	margin-left: 0.75rem;
-}
-
 .pagination__link {
+	display: inline-block;
 	padding: 0.75rem;
 	background: $color-white;
 	border: 1px solid $color-gray-light-600;
-	box-sizing: border-box;
 	border-radius: 2px;
 	line-height: 1;
 	text-decoration: none;
@@ -40,5 +43,26 @@
 		border: 1px solid $color-gray-900;
 		background: $color-gray-900;
 		color: $color-white;
+	}
+
+	@media (max-width: $breakpoint-mobile) {
+		padding: 0.5rem;
+	}
+}
+
+@media (max-width: $breakpoint-small) {
+	.pagination__item-previous-page,
+	.pagination__item-next-page {
+		.pagination__link span[aria-hidden] {
+			display: none;
+		}
+	}
+
+	.pagination__item-previous-page .pagination__link::before {
+		content: "<";
+	}
+
+	.pagination__item-next-page .pagination__link::before {
+		content: ">";
 	}
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
@@ -12,12 +12,15 @@ import PatternThumbnail from '../pattern-thumbnail';
 import { store as patternStore } from '../../store';
 
 function PatternGrid( { query } ) {
-	const { posts, isLoading } = useSelect( ( select ) => {
-		const { getPatternsByQuery, isLoadingPatternsByQuery } = select( patternStore );
+	const { isLoading, posts, totalPages } = useSelect( ( select ) => {
+		const { getPatternTotalPagesByQuery, getPatternsByQuery, isLoadingPatternsByQuery } = select(
+			patternStore
+		);
 
 		return {
-			posts: query ? getPatternsByQuery( query ) : [],
 			isLoading: query && isLoadingPatternsByQuery( query ),
+			posts: query ? getPatternsByQuery( query ) : [],
+			totalPages: query ? getPatternTotalPagesByQuery( query ) : 0,
 		};
 	} );
 
@@ -30,7 +33,7 @@ function PatternGrid( { query } ) {
 					posts.map( ( post ) => <PatternThumbnail key={ post.id } pattern={ post } /> )
 				) }
 			</div>
-			<Pagination totalPages={ 10 } currentPage={ 5 } />
+			<Pagination totalPages={ totalPages } currentPage={ query?.page } />
 		</>
 	);
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
@@ -7,6 +7,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import Pagination from './pagination';
 import PatternThumbnail from '../pattern-thumbnail';
 import { store as patternStore } from '../../store';
 
@@ -21,13 +22,16 @@ function PatternGrid( { query } ) {
 	} );
 
 	return (
-		<div className="pattern-grid">
-			{ isLoading ? (
-				<Spinner />
-			) : (
-				posts.map( ( post ) => <PatternThumbnail key={ post.id } pattern={ post } /> )
-			) }
-		</div>
+		<>
+			<div className="pattern-grid">
+				{ isLoading ? (
+					<Spinner />
+				) : (
+					posts.map( ( post ) => <PatternThumbnail key={ post.id } pattern={ post } /> )
+				) }
+			</div>
+			<Pagination totalPages={ 10 } currentPage={ 5 } />
+		</>
 	);
 }
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -37,18 +32,18 @@ export default function Pagination( { currentPage = 1, totalPages } ) {
 		<nav className="pagination" aria-label={ __( 'Pagination', 'wporg-patterns' ) }>
 			<ul className="pagination__list">
 				<li className="pagination__item pagination__item--previous-page">
-					<a
-						className={ classnames( {
-							pagination__link: true,
-							'pagination__link--is-disabled': ! hasPrevious,
-						} ) }
-						href={ `${ basePath }page/${ currentPage - 1 }` }
-						aria-disabled={ ! hasPrevious ? 'disabled' : undefined }
-						onClick={ ( event ) => onClick( event, currentPage - 1 ) }
-					>
-						<span className="screen-reader-text">{ __( 'Previous page', 'wporg-patterns' ) }</span>
-						<span aria-hidden>{ _x( 'Previous', 'previous page link label', 'wporg-patterns' ) }</span>
-					</a>
+					{ hasPrevious && (
+						<a
+							className="pagination__link"
+							href={ `${ basePath }page/${ currentPage - 1 }` }
+							onClick={ ( event ) => onClick( event, currentPage - 1 ) }
+						>
+							<span className="screen-reader-text">{ __( 'Previous page', 'wporg-patterns' ) }</span>
+							<span aria-hidden>
+								{ _x( 'Previous', 'previous page link label', 'wporg-patterns' ) }
+							</span>
+						</a>
+					) }
 				</li>
 				{ pages.map( ( page, index ) => {
 					if ( '…' === page ) {
@@ -79,18 +74,16 @@ export default function Pagination( { currentPage = 1, totalPages } ) {
 					);
 				} ) }
 				<li className="pagination__item pagination__item--next-page">
-					<a
-						className={ classnames( {
-							pagination__link: true,
-							'pagination__link--is-disabled': ! hasNext,
-						} ) }
-						href={ `${ basePath }page/${ currentPage + 1 }` }
-						aria-disabled={ ! hasNext ? 'disabled' : undefined }
-						onClick={ ( event ) => onClick( event, currentPage + 1 ) }
-					>
-						<span className="screen-reader-text">{ __( 'Next page', 'wporg-patterns' ) }</span>
-						<span aria-hidden>{ _x( 'Next', 'next page link label', 'wporg-patterns' ) }</span>
-					</a>
+					{ hasNext && (
+						<a
+							className="pagination__link"
+							href={ `${ basePath }page/${ currentPage + 1 }` }
+							onClick={ ( event ) => onClick( event, currentPage + 1 ) }
+						>
+							<span className="screen-reader-text">{ __( 'Next page', 'wporg-patterns' ) }</span>
+							<span aria-hidden>{ _x( 'Next', 'next page link label', 'wporg-patterns' ) }</span>
+						</a>
+					) }
 				</li>
 			</ul>
 		</nav>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 /**
  * External dependencies
  */
@@ -9,14 +8,30 @@ import classnames from 'classnames';
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 
-export default function Pagination( { currentPage = 1, totalPages } ) {
+/**
+ * Internal dependencies
+ */
+import getPaginationList from '../../utils/get-pagination-list';
+import { useRoute } from '../../hooks';
+
+export default function Pagination( { currentPage, totalPages } ) {
+	const { path, update: updatePath } = useRoute();
 	if ( ! totalPages ) {
 		return null;
 	}
 
 	const hasPrevious = currentPage > 1;
 	const hasNext = currentPage < totalPages;
-	const pages = Array.from( { length: totalPages }, ( val, i ) => i + 1 );
+	const basePath = path.replace( /page\/\d+\/?$/, '' );
+	const pages = getPaginationList( totalPages, currentPage );
+
+	const onClick = ( event, page ) => {
+		event.preventDefault();
+		if ( page === 1 ) {
+			updatePath( `${ basePath }` );
+		}
+		updatePath( `${ basePath }page/${ page }/` );
+	};
 
 	return (
 		<nav className="pagination" aria-label={ __( 'Pagination', 'wporg-patterns' ) }>
@@ -27,38 +42,49 @@ export default function Pagination( { currentPage = 1, totalPages } ) {
 							pagination__link: true,
 							'pagination__link--is-disabled': ! hasPrevious,
 						} ) }
-						href="#"
+						href={ `${ basePath }page/${ currentPage - 1 }` }
 						aria-disabled={ ! hasPrevious ? 'disabled' : undefined }
+						onClick={ ( event ) => onClick( event, currentPage - 1 ) }
 					>
 						<span className="screen-reader-text">{ __( 'Previous page', 'wporg-patterns' ) }</span>
 						<span aria-hidden>{ _x( 'Previous', 'previous page link label', 'wporg-patterns' ) }</span>
 					</a>
 				</li>
-				{ pages.map( ( page ) => (
-					<li className="pagination__item" key={ page }>
-						<a
-							className="pagination__link"
-							href="#"
-							aria-current={ page === currentPage ? 'page' : undefined }
-						>
-							<span className="screen-reader-text">
-								{ sprintf(
-									// translators: %s is the page number.
-									__( 'Page %s', 'wporg-patterns' ),
-									page
-								) }
-							</span>
-							<span aria-hidden>{ page }</span>
-						</a>
-					</li>
-				) ) }
+				{ pages.map( ( page, index ) => {
+					if ( '…' === page ) {
+						return (
+							<li className="pagination__item" key={ `${ index }-${ page }` }>
+								{ page }
+							</li>
+						);
+					}
+					return (
+						<li className="pagination__item" key={ page }>
+							<a
+								className="pagination__link"
+								href={ `${ basePath }page/${ page }` }
+								aria-current={ page === currentPage ? 'page' : undefined }
+								onClick={ ( event ) => onClick( event, page ) }
+							>
+								<span className="screen-reader-text">
+									{ sprintf(
+										// translators: %s is the page number.
+										__( 'Page %s', 'wporg-patterns' ),
+										page
+									) }
+								</span>
+								<span aria-hidden>{ page }</span>
+							</a>
+						</li>
+					);
+				} ) }
 				<li className="pagination__item pagination__item--next-page">
 					<a
 						className={ classnames( {
 							pagination__link: true,
 							'pagination__link--is-disabled': ! hasNext,
 						} ) }
-						href="#"
+						href={ `${ basePath }page/${ currentPage + 1 }` }
 						aria-disabled={ ! hasNext ? 'disabled' : undefined }
 						onClick={ ( event ) => onClick( event, currentPage + 1 ) }
 					>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
@@ -31,7 +31,7 @@ export default function Pagination( { currentPage = 1, totalPages } ) {
 	return (
 		<nav className="pagination" aria-label={ __( 'Pagination', 'wporg-patterns' ) }>
 			<ul className="pagination__list">
-				<li className="pagination__item pagination__item--previous-page">
+				<li className="pagination__item pagination__item-previous-page">
 					{ hasPrevious && (
 						<a
 							className="pagination__link"
@@ -73,7 +73,7 @@ export default function Pagination( { currentPage = 1, totalPages } ) {
 						</li>
 					);
 				} ) }
-				<li className="pagination__item pagination__item--next-page">
+				<li className="pagination__item pagination__item-next-page">
 					{ hasNext && (
 						<a
 							className="pagination__link"

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
@@ -1,0 +1,69 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+export default function Pagination( { currentPage = 1, totalPages } ) {
+	if ( ! totalPages ) {
+		return null;
+	}
+
+	const hasPrevious = currentPage > 1;
+	const hasNext = currentPage < totalPages;
+	const pages = Array.from( { length: totalPages }, ( val, i ) => i + 1 );
+
+	return (
+		<nav aria-label={ __( 'Pagination', 'wporg-patterns' ) }>
+			<ul className="pagination">
+				<li className="pagination__item pagination__item--previous-page">
+					<a
+						className={ classnames( {
+							pagination__link: true,
+							'pagination__link--is-disabled': ! hasPrevious,
+						} ) }
+						href="#"
+						aria-disabled={ ! hasPrevious ? 'disabled' : undefined }
+					>
+						<span className="screen-reader-text">{ __( 'Previous page', 'wporg-patterns' ) }</span>
+					</a>
+				</li>
+				{ pages.map( ( page ) => (
+					<li className="pagination__item" key={ page }>
+						<a
+							className="pagination__link"
+							href="#"
+							aria-current={ page === currentPage ? 'page' : undefined }
+						>
+							<span className="screen-reader-text">
+								{ sprintf(
+									// translators: %s is the page number.
+									__( 'Page %s', 'wporg-patterns' ),
+									page
+								) }
+							</span>
+							<span aria-hidden>{ page }</span>
+						</a>
+					</li>
+				) ) }
+				<li className="pagination__item pagination__item--next-page">
+					<a
+						className={ classnames( {
+							pagination__link: true,
+							'pagination__link--is-disabled': ! hasNext,
+						} ) }
+						href="#"
+						aria-disabled={ ! hasNext ? 'disabled' : undefined }
+					>
+						<span className="screen-reader-text">{ __( 'Next page', 'wporg-patterns' ) }</span>
+					</a>
+				</li>
+			</ul>
+		</nav>
+	);
+}

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 
 export default function Pagination( { currentPage = 1, totalPages } ) {
 	if ( ! totalPages ) {
@@ -19,8 +19,8 @@ export default function Pagination( { currentPage = 1, totalPages } ) {
 	const pages = Array.from( { length: totalPages }, ( val, i ) => i + 1 );
 
 	return (
-		<nav aria-label={ __( 'Pagination', 'wporg-patterns' ) }>
-			<ul className="pagination">
+		<nav className="pagination" aria-label={ __( 'Pagination', 'wporg-patterns' ) }>
+			<ul className="pagination__list">
 				<li className="pagination__item pagination__item--previous-page">
 					<a
 						className={ classnames( {
@@ -31,6 +31,7 @@ export default function Pagination( { currentPage = 1, totalPages } ) {
 						aria-disabled={ ! hasPrevious ? 'disabled' : undefined }
 					>
 						<span className="screen-reader-text">{ __( 'Previous page', 'wporg-patterns' ) }</span>
+						<span aria-hidden>{ _x( 'Previous', 'previous page link label', 'wporg-patterns' ) }</span>
 					</a>
 				</li>
 				{ pages.map( ( page ) => (
@@ -59,8 +60,10 @@ export default function Pagination( { currentPage = 1, totalPages } ) {
 						} ) }
 						href="#"
 						aria-disabled={ ! hasNext ? 'disabled' : undefined }
+						onClick={ ( event ) => onClick( event, currentPage + 1 ) }
 					>
 						<span className="screen-reader-text">{ __( 'Next page', 'wporg-patterns' ) }</span>
+						<span aria-hidden>{ _x( 'Next', 'next page link label', 'wporg-patterns' ) }</span>
 					</a>
 				</li>
 			</ul>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
@@ -14,9 +14,9 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import getPaginationList from '../../utils/get-pagination-list';
 import { useRoute } from '../../hooks';
 
-export default function Pagination( { currentPage, totalPages } ) {
+export default function Pagination( { currentPage = 1, totalPages } ) {
 	const { path, update: updatePath } = useRoute();
-	if ( ! totalPages ) {
+	if ( ! totalPages || totalPages <= 1 ) {
 		return null;
 	}
 

--- a/public_html/wp-content/themes/pattern-directory/src/utils/get-pagination-list.js
+++ b/public_html/wp-content/themes/pattern-directory/src/utils/get-pagination-list.js
@@ -1,0 +1,45 @@
+/**
+ * Get the collapsed list of page numbers for a given range of pages, used to paginate queries.
+ *
+ * This will return an array of page numbers (1, 2, 3, etc) for a given length (number of pages). If there are
+ * less than 5 pages (inclusive), it will return 1 through 5. If there are more, it will collapse between the
+ * start and end with an ellipsis. If the current page is in the middle, it will add pages to the middle.
+ *
+ * See test/get-pagination-list.js for examples.
+ *
+ * @param {number} length The total number of pages.
+ * @param {?number} current The current page, used to output extra pages if necessary. Default 1.
+ * @return {Array.<number|string>} Array of numbers and … used to display pagination links.
+ */
+export default function getPaginationList( length, current = 1 ) {
+	const range = Array.from( { length }, ( val, i ) => i + 1 );
+	const list = [];
+	if ( length <= 5 ) {
+		return range;
+	}
+	list.push( ...range.slice( 0, 2 ) );
+	if ( current > 2 && current <= length - 1 ) {
+		list.push( ...range.slice( current - 2, current + 1 ) );
+	}
+	list.push( ...range.slice( -2 ) );
+
+	return list
+		// Remove duplicates.
+		.filter( ( value, i, a ) => a.indexOf( value ) === i )
+		// Add in … where there's a jump larger than 1.
+		.reduce( ( acc, value, i, a ) => {
+			if ( i === 0 ) {
+				acc.push( value );
+				return acc;
+			}
+			const diff = Math.abs( a[ i ] - a[ i - 1 ] );
+			if ( diff === 0 ) {
+				return acc;
+			}
+			if ( diff > 1 ) {
+				acc.push( '…' );
+			}
+			acc.push( value );
+			return acc;
+		}, [] );
+}

--- a/public_html/wp-content/themes/pattern-directory/src/utils/test/get-pagination-list.js
+++ b/public_html/wp-content/themes/pattern-directory/src/utils/test/get-pagination-list.js
@@ -1,0 +1,33 @@
+import getPaginationList from '../get-pagination-list';
+
+describe( 'getPageList', () => {
+	it( 'should return empty array if no pages', async () => {
+		expect( getPaginationList( 0 ) ).toEqual( [] );
+	} );
+
+	it( 'should return one item if one page', async () => {
+		expect( getPaginationList( 1 ) ).toEqual( [ 1 ] );
+	} );
+
+	it( 'should return a simple list if less than 5 pages', async () => {
+		expect( getPaginationList( 4 ) ).toEqual( [ 1, 2, 3, 4 ] );
+	} );
+
+	it( 'should return complex lists', async () => {
+		expect( getPaginationList( 10, 1 ) ).toEqual( [ 1, 2, '…', 9, 10 ] );
+		expect( getPaginationList( 10, 2 ) ).toEqual( [ 1, 2, '…', 9, 10 ] );
+		expect( getPaginationList( 10, 3 ) ).toEqual( [ 1, 2, 3, 4, '…', 9, 10 ] );
+		expect( getPaginationList( 10, 4 ) ).toEqual( [ 1, 2, 3, 4, 5, '…', 9, 10 ] );
+		expect( getPaginationList( 10, 5 ) ).toEqual( [ 1, 2, '…', 4, 5, 6, '…', 9, 10 ] );
+		expect( getPaginationList( 10, 6 ) ).toEqual( [ 1, 2, '…', 5, 6, 7, '…', 9, 10 ] );
+		expect( getPaginationList( 10, 8 ) ).toEqual( [ 1, 2, '…', 7, 8, 9, 10 ] );
+		expect( getPaginationList( 10, 9 ) ).toEqual( [ 1, 2, '…', 8, 9, 10 ] );
+		expect( getPaginationList( 10, 10 ) ).toEqual( [ 1, 2, '…', 9, 10 ] );
+	} );
+
+	it( 'should ignore out of bound current values', async () => {
+		expect( getPaginationList( 4, 10 ) ).toEqual( [ 1, 2, 3, 4 ] );
+		expect( getPaginationList( 10, 100 ) ).toEqual( [ 1, 2, '…', 9, 10 ] );
+		expect( getPaginationList( 10, -2 ) ).toEqual( [ 1, 2, '…', 9, 10 ] );
+	} );
+} );


### PR DESCRIPTION
Fixes #102, based on #113. This PR finally adds the pagination component 🎉 

This adds a new component, Pagination, which takes a currentPage and totalPages & outputs a possibly truncated list of pages to navigate to. It expects to be within the Route provider, since it uses `path` & `updatePath` to navigate around pages.

I created a helper function for the truncated list, with tests in `utils/test/get-pagination-list.js`.

### Screenshots

Basic pagination with 2 pages
<img width="1018" alt="Screen Shot 2021-05-26 at 5 57 19 PM" src="https://user-images.githubusercontent.com/541093/119736524-d3319a00-be4b-11eb-8bb8-a4427d153a7b.png">

Pagination gets truncated after 2 if there are more than 5 total pages
<img width="1143" alt="page-first" src="https://user-images.githubusercontent.com/541093/119736252-7209c680-be4b-11eb-8d81-d27609f67284.png">

Previous & next only show up if there are next/prev to navigate to
<img width="974" alt="page-second" src="https://user-images.githubusercontent.com/541093/119736254-72a25d00-be4b-11eb-88c8-378c9bc28982.png">

If you navigate into the middle of a truncation, it truncates to either side
<img width="662" alt="page-lots" src="https://user-images.githubusercontent.com/541093/119736253-72a25d00-be4b-11eb-9aea-cb296d860a9e.png">

On smaller screens, the spacing shrinks a bit and the Next/Previous labels switch to arrows
<img width="400" alt="page-small" src="https://user-images.githubusercontent.com/541093/119736255-72a25d00-be4b-11eb-9d29-14e082e5e088.png">

### How to test the changes in this Pull Request:

1. Create more than 18 patterns (or adjust [the value here](https://github.com/WordPress/pattern-directory/blob/4dbef7c0c97e8e9e8506ad2be4b2036f1ef690ce/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php#L341)) so that you have paged results
2. View any pattern list page, it should show the pagination at the bottom
3. Click through the pages, it should work
4. If you have a category with few patterns (just one page), it should not show pagination

