### PR TITLE
Theme: Use new `wporgSiteUrl` to link back to All patterns page

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -64,7 +64,11 @@ function enqueue_assets() {
 
 		wp_add_inline_script(
 			'wporg-pattern-script',
-			sprintf( 'var wporgAssetUrl = "%s";', esc_url( get_stylesheet_directory_uri() ) ),
+			sprintf(
+				'var wporgAssetUrl = "%s", wporgSiteUrl = "%s";',
+				esc_url( get_stylesheet_directory_uri() ),
+				esc_url( home_url() )
+			),
 			'before'
 		);
 	}

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -57,7 +57,8 @@
 	"eslintConfig": {
 		"extends": "../../../../.eslintrc.js",
 		"globals": {
-			"wporgAssetUrl": "readonly"
+			"wporgAssetUrl": "readonly",
+			"wporgSiteUrl": "readonly"
 		}
 	},
 	"prettier": "../../../../.prettierrc.js",

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
@@ -7,6 +7,9 @@ import apiCategories from './fixtures/categories';
 import apiPatternFlagReasons from './fixtures/pattern-flag-reasons';
 import { categories, favorites, patternFlagReasons, patterns } from '../reducer';
 
+// Set up the global.
+global.wporgSiteUrl = 'http://localhost:8889/';
+
 describe( 'state', () => {
 	describe( 'patterns', () => {
 		it( 'should store the patterns in state', () => {

--- a/public_html/wp-content/themes/pattern-directory/src/store/utils.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/utils.js
@@ -53,6 +53,6 @@ export function getAllCategory() {
 		id: -1,
 		slug: '', // Slug matches url
 		name: __( 'All', 'wporg-patterns' ),
-		link: '/',
+		link: wporgSiteUrl,
 	};
 }


### PR DESCRIPTION
This fixes the broken All link on wordpress.org/patterns, which had been removing the site's subdirectory. By getting the URL from WP directly, we know we're going back to the correct page. This provides a new global, `wporgSiteUrl`, which can also be used elsewhere in navigation if needed.

Fixes #117 

### How to test the changes in this Pull Request:

1. Try using the All link, it should work ✅ 
