### PR TITLE
Patterns: Use CopyPatternButton in thumbnail

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_copy-button.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_copy-button.scss
@@ -1,9 +1,5 @@
 .pattern__copy-button {
-	transition: all 0.075s ease-in-out;
-
-	&.is-small {
-		font-size: 0.75rem;
-		padding: 0.75rem;
-		height: auto;
+	&.is-small-label {
+		box-shadow: 0 1px 2px rgba($color-black, 0.15);
 	}
 }

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -61,7 +61,7 @@
 			flex-shrink: 0;
 		}
 
-		.button + .button {
+		.button + .components-button {
 			margin-left: 0.375rem;
 		}
 	}

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -51,6 +51,7 @@
 		"grunt-sass": "3.1.0",
 		"grunt-sass-globbing": "1.5.1",
 		"grunt-webpack": "4.0.2",
+		"lodash": "4.17.21",
 		"react-use-gesture": "9.1.3",
 		"sass": "1.32.8"
 	},

--- a/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
@@ -1,6 +1,11 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
+
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { Button } from '@wordpress/components';
@@ -53,8 +58,13 @@ const CopyPatternButton = ( { isSmall = false, onSuccess, content } ) => {
 		label = copied ? __( 'Copied', 'wporg-patterns' ) : __( 'Copy', 'wporg-patterns' );
 	}
 
+	const classes = classnames( {
+		'pattern__copy-button': true,
+		'is-small-label': isSmall,
+	} );
+
 	return (
-		<Button isPrimary onClick={ handleClick }>
+		<Button className={ classes } isPrimary onClick={ handleClick }>
 			{ label }
 		</Button>
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/copy-pattern-button/index.js
@@ -2,9 +2,10 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { noop } from 'lodash';
 
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
@@ -16,7 +17,7 @@ import { useEffect, useState } from '@wordpress/element';
  */
 import { copyToClipboard } from '../../utils';
 
-const CopyPatternButton = ( { isSmall = false, onSuccess, content } ) => {
+const CopyPatternButton = ( { isSmall = false, onSuccess = noop, content } ) => {
 	const [ copied, setCopied ] = useState( false );
 
 	if ( ! content ) {
@@ -33,7 +34,7 @@ const CopyPatternButton = ( { isSmall = false, onSuccess, content } ) => {
 		// Make sure we reset focus in case it was lost in the 'copy' command.
 		target.focus();
 
-		if ( success && 'function' === typeof onSuccess ) {
+		if ( success ) {
 			onSuccess();
 		} else {
 			// TODO Handle error case

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
@@ -1,46 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { speak } from '@wordpress/a11y';
-import { __, sprintf } from '@wordpress/i18n';
-import { Button, Disabled } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { Disabled } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import FavoriteButton from '../favorite-button';
+import CopyPatternButton from '../copy-pattern-button';
 import Canvas from './canvas';
-import { copyToClipboard } from '../../utils';
 
 function PatternThumbnail( { pattern } ) {
-	const [ copied, setCopied ] = useState( false );
-
-	const handleCopy = () => {
-		const result = copyToClipboard( pattern.pattern_content );
-
-		setCopied( result );
-	};
-
-	useEffect( () => {
-		if ( ! copied ) {
-			return;
-		}
-
-		speak(
-			sprintf(
-				/* translators: %s: pattern title. */
-				__( 'Copied %s pattern to clipboard.', 'wporg-patterns' ),
-				pattern.title.rendered
-			)
-		);
-
-		const timer = setTimeout( () => setCopied( false ), 20000 );
-		return () => {
-			clearTimeout( timer );
-		};
-	}, [ copied ] );
-
 	return (
 		<div className="pattern-grid__pattern">
 			<a href={ pattern.link } rel="bookmark">
@@ -52,9 +22,7 @@ function PatternThumbnail( { pattern } ) {
 			<div className="pattern-grid__actions">
 				<h2 className="pattern-grid__title">{ pattern.title.rendered }</h2>
 				<FavoriteButton showLabel={ false } patternId={ pattern.id } />
-				<Button className="pattern__copy-button is-small" isPrimary onClick={ handleCopy }>
-					{ copied ? __( 'Copied!', 'wporg-patterns' ) : __( 'Copy', 'wporg-patterns' ) }
-				</Button>
+				<CopyPatternButton isSmall={ true } content={ pattern.pattern_content } />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
This consolidates the copy code, removing the duplicate code from PatternThumbnail. There should be no functionality changes here.

### Screenshots

<img width="325" alt="Screen Shot 2021-06-02 at 3 08 00 PM" src="https://user-images.githubusercontent.com/541093/120538672-cfa29380-c3b4-11eb-84a4-af2397997a4d.png">

### How to test the changes in this Pull Request:

1. Make sure the copy buttons in the grid and on single patterns still work as expected.
