### PR TITLE
Single Patterns: Update pattern preview and header

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_favorite-button.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_favorite-button.scss
@@ -4,7 +4,7 @@
 	height: 2.25rem;
 	width: 2.25rem;
 	border-radius: 2px;
-	color: $color-gray-400;
+	color: $color__text;
 
 	svg {
 		position: absolute;
@@ -38,9 +38,22 @@
 		transform: none;
 	}
 
-	&.is-favorited {
-		color: $color__text;
+	&.has-label {
+		padding: 12px 18px 12px 38px;
+		height: auto;
+		width: auto;
 
+		svg {
+			top: calc(50% - 12px);
+			left: 9px;
+
+			path {
+				fill: $color-black;
+			}
+		}
+	}
+
+	&.is-favorited {
 		svg path {
 			fill: $color-alert-red;
 		}
@@ -61,23 +74,6 @@
 				animation: none;
 			}
 		}
-	}
-
-	&.has-label {
-		padding: 12px 18px 12px 38px;
-		height: auto;
-		width: auto;
-
-		svg {
-			top: calc(50% - 12px);
-			left: 9px;
-		}
-	}
-
-	&[disabled] {
-		background: transparent !important;
-		text-shadow: none !important;
-		color: $color-gray-400 !important;
 	}
 }
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
@@ -3,6 +3,16 @@
 	background: $color-gray-light-200;
 }
 
+.pattern-preview__size-control {
+	margin: 0 auto;
+	padding: 1rem 0;
+	max-width: 12rem;
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
+}
+
 .pattern-preview__viewport {
 	position: relative;
 	margin: 0 auto;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
@@ -1,5 +1,5 @@
 .pattern-preview__container {
-	padding: 2rem 0 0;
+	padding: 0;
 	background: $color-gray-light-200;
 }
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -10,15 +10,23 @@ body.single-wporg-pattern {
 		padding: 0;
 	}
 
-	.entry-header {
+	.entry-header,
+	.pattern-actions__container,
+	.pattern__meta {
 		max-width: $size__site-main;
 		padding: 1.5rem;
 		margin-left: auto;
 		margin-right: auto;
 
 		@media only screen and (min-width: $breakpoint-large) {
-			padding: 1.5rem 0;
+			padding-left: 0;
+			padding-right: 0;
 		}
+	}
+
+	.entry-header {
+		padding-top: 2.625rem;
+		padding-bottom: 1.875rem;
 
 		.entry-title {
 			margin-top: 0;
@@ -26,16 +34,44 @@ body.single-wporg-pattern {
 		}
 	}
 
+	.pattern__categories a {
+		display: inline-block;
+		margin-right: 1rem;
+
+		&:last-of-type {
+			margin-right: 0;
+		}
+	}
+
+	.pattern__categories-label {
+		margin-right: 1rem;
+		font-weight: 600;
+		font-size: 0.75rem;
+		line-height: 1.3333;
+		text-transform: uppercase;
+	}
+
 	.pattern-actions {
+		padding: 0 1.5rem 2rem;
+		background: $color-white;
+
+		button {
+			margin: 0;
+		}
+
+		@media only screen and (min-width: $breakpoint-large) {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+
+	.pattern-actions__container {
+		padding: 0;
 		display: flex;
 		justify-content: flex-start;
 		align-items: center;
 		flex-wrap: wrap;
 		gap: 0.5em 2em;
-
-		button {
-			margin: 0;
-		}
 
 		@media (max-width: $breakpoint-mobile) {
 			justify-content: center;
@@ -105,20 +141,7 @@ body.single-wporg-pattern {
 	}
 
 	.pattern__meta {
-		padding: 2rem 0;
-		background: $color-gray-light-200;
-
-		> div {
-			max-width: $size__site-main;
-			margin-left: auto;
-			margin-right: auto;
-			display: flex;
-			justify-content: space-between;
-		}
-
-		.pattern-preview__report {
-			text-align: right;
-		}
+		display: flex;
+		justify-content: flex-end;
 	}
-
 }

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -31,6 +31,7 @@ body.single-wporg-pattern {
 		.entry-title {
 			margin-top: 0;
 			line-height: 1.2;
+			font-weight: 600;
 		}
 	}
 

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -25,48 +25,30 @@ $user_has_reported = is_user_logged_in() ? user_has_flagged_pattern() : false;
 			<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 				<header class="entry-header">
 					<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-					<p>A large hero section with an example background image and a heading in the center.</p>
-					<div id="pattern-actions" class="pattern-actions" data-id="<?php the_ID(); ?>">
-						<button class="button button-primary">Copy Pattern</button>
-						<button class="button">Add to favorites</button>
+					<div class="pattern__categories">
+						<?php
+						$categories_list = get_the_term_list( get_the_ID(), 'wporg-pattern-category' );
+						if ( $categories_list ) {
+							printf( '<span class="pattern__categories-label">%s</span>', esc_html__( 'Categories', 'wporg-patterns' ) );
+							echo $categories_list; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						}
+						?>
 					</div>
 				</header><!-- .entry-header -->
 
-				<div class="pattern-preview__container" hidden>
+				<div
+					hidden
+					class="pattern-preview__container"
+					data-post-id="<?php echo intval( get_the_ID() ); ?>"
+					data-logged-in="<?php echo json_encode( is_user_logged_in() ); ?>"
+					data-user-has-reported="<?php echo json_encode( $user_has_reported ); ?>"
+				>
 					<?php echo rawurlencode( wp_json_encode( get_the_content() ) ); ?>
 				</div>
 
-				<div class="pattern__meta">
-					<div>
-						<div class="pattern__categories">
-							<?php
-							$categories_list = get_the_term_list( get_the_ID(), 'wporg-pattern-category', '', ', ' );
-							if ( $categories_list ) {
-								/* translators: 1: list of pattern categories. */
-								printf( esc_html__( 'Categories: %1$s', 'wporg-patterns' ), $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							}
-							?>
-						</div>
-						<div id="pattern-report"
-							class="pattern__report"
-							data-post-id="<?php echo intval( get_the_ID() ); ?>"
-							data-logged-in="<?php echo json_encode( is_user_logged_in() ); ?>"
-							data-user-has-reported="<?php echo json_encode( $user_has_reported ); ?>"
-							">
-							<button class="button">Report this pattern</button>
-						</div>
-					</div>
-				</div>
-
 				<div class="entry-content">
-					<h2>More from this designer</h2>
-					<div class="pattern-grid">
-						<ul>
-							<li>Pattern A</li>
-							<li>Pattern B</li>
-							<li>Pattern C</li>
-						</ul>
-					</div>
+					<h2><?php esc_html_e( 'More from this designer', 'wporg-patterns' ); ?></h2>
+					<div class="pattern-grid"></div>
 				</div><!-- .entry-content -->
 			</article><!-- #post-## -->
 

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -29,7 +29,6 @@ $user_has_reported = is_user_logged_in() ? user_has_flagged_pattern() : false;
 						<?php
 						$categories_list = get_the_term_list( get_the_ID(), 'wporg-pattern-category' );
 						if ( $categories_list ) {
-							printf( '<span class="pattern__categories-label">%s</span>', esc_html__( 'Categories', 'wporg-patterns' ) );
 							echo $categories_list; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						}
 						?>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-success-message.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-success-message.js
@@ -2,17 +2,25 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 
 const CopySuccessMessage = ( { onClick } ) => (
-	<Notice className="pattern-actions__notice" status="success" isDismissible={ false }>
+	<Notice
+		className="pattern-actions__notice"
+		status="success"
+		isDismissible={ false }
+		actions={ [
+			{
+				label: __( 'Learn More', 'wporg-patterns' ),
+				onClick: onClick,
+				variant: 'secondary',
+			},
+		] }
+	>
 		<div>
 			<b>{ __( 'Pattern copied!', 'wporg-patterns' ) }</b>
 			{ __( ' Now you can paste it into any WordPress post or page.', 'wporg-patterns' ) }
 		</div>
-		<Button onClick={ onClick } isSecondary>
-			{ __( 'Learn More', 'wporg-patterns' ) }
-		</Button>
 	</Notice>
 );
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/index.js
@@ -11,17 +11,19 @@ import FavoriteButton from '../favorite-button';
 import CopySuccessMessage from './copy-success-message';
 import CopyGuide from './copy-guide';
 
-const PatternPreviewActions = ( { patternId } ) => {
+const PatternPreviewActions = ( { postId } ) => {
 	const [ showSuccess, setShowSuccess ] = useState( false );
 	const [ showGuide, setShowGuide ] = useState( false );
 
 	return (
-		<>
-			<CopyPatternButton onSuccess={ () => setShowSuccess( true ) } />
-			<FavoriteButton patternId={ patternId } />
-			{ showSuccess && <CopySuccessMessage onClick={ () => setShowGuide( true ) } /> }
-			{ showGuide && <CopyGuide onFinish={ () => setShowGuide( false ) } /> }
-		</>
+		<div className="pattern-actions">
+			<div className="pattern-actions__container">
+				<CopyPatternButton onSuccess={ () => setShowSuccess( true ) } />
+				<FavoriteButton patternId={ postId } />
+				{ showSuccess && <CopySuccessMessage onClick={ () => setShowGuide( true ) } /> }
+				{ showGuide && <CopyGuide onFinish={ () => setShowGuide( false ) } /> }
+			</div>
+		</div>
 	);
 };
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -75,7 +75,7 @@ function PatternPreview( { blockContent } ) {
 					/>
 				) }
 			</div>
-			<div className="pattern-preview__viewport" style={ { width } }>
+			<div className="pattern-preview__viewport" style={ { width: width + 40 } }>
 				<DragHandle
 					label={ __( 'Drag to resize', 'wporg-patterns' ) }
 					className="is-left"

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -54,7 +54,7 @@ function PatternPreview( { blockContent } ) {
 	}, [ showViewportControl, showViewportControlDefault, showViewportControlLarge ] );
 
 	let currentOpt = false;
-	if ( -1 === availableWidths.map( ( opt ) => opt.value ).indexOf( width ) ) {
+	if ( ! availableWidths.some( ( opt ) => opt.value === width ) ) {
 		currentOpt = {
 			/* translators: %s is the width in pixels, ex 600. */
 			label: sprintf( __( 'Current (%spx)', 'wporg-patterns' ), width ),

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -1,10 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useCallback, useState } from '@wordpress/element';
-import { useInstanceId } from '@wordpress/compose';
-import { VisuallyHidden } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useInstanceId, useViewportMatch } from '@wordpress/compose';
+import { SelectControl, VisuallyHidden } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,20 +14,67 @@ import DragHandle from './drag-handle';
 
 /* eslint-disable jsx-a11y/anchor-is-valid -- These are just placeholders. */
 
-const INITIAL_WIDTH = 1200;
+const INITIAL_WIDTH = 960;
 
 function PatternPreview( { blockContent } ) {
+	const showViewportControl = useViewportMatch( 'mobile', '>=' );
+	const showViewportControlDefault = useViewportMatch( 'large', '>=' );
+	const showViewportControlLarge = useViewportMatch( 'wide', '>=' );
+
 	const instanceId = useInstanceId( PatternPreview );
 	const [ width, setWidth ] = useState( window.innerWidth < INITIAL_WIDTH ? window.innerWidth : INITIAL_WIDTH );
-	const onDragChange = useCallback(
-		( delta ) => {
-			setWidth( ( value ) => value + delta );
-		},
-		[ setWidth ]
-	);
+	const onDragChange = useCallback( ( delta ) => setWidth( ( value ) => value + delta ), [ setWidth ] );
+
+	const availableWidths = useMemo( () => {
+		// Less than 480 wide.
+		if ( ! showViewportControl ) {
+			return [];
+		}
+		if ( showViewportControlLarge ) {
+			// More than 1280 wide.
+			return [
+				{ label: 'Full (1200px)', value: 1200 },
+				{ label: 'Default (960px)', value: 960 },
+				{ label: 'Medium (480px)', value: 480 },
+				{ label: 'Narrow (320px)', value: 320 },
+			];
+		} else if ( showViewportControlDefault ) {
+			// Less than 1280, more than 960.
+			return [
+				{ label: 'Default (960px)', value: 960 },
+				{ label: 'Medium (480px)', value: 480 },
+				{ label: 'Narrow (320px)', value: 320 },
+			];
+		}
+		// Less than 960, but larger than 480.
+		return [
+			{ label: __( 'Medium (480px)', 'wporg-patterns' ), value: 480 },
+			{ label: __( 'Narrow (320px)', 'wporg-patterns' ), value: 320 },
+		];
+	}, [ showViewportControl, showViewportControlDefault, showViewportControlLarge ] );
+
+	let currentOpt = false;
+	if ( -1 === availableWidths.map( ( opt ) => opt.value ).indexOf( width ) ) {
+		currentOpt = {
+			/* translators: %s is the width in pixels, ex 600. */
+			label: sprintf( __( 'Current (%spx)', 'wporg-patterns' ), width ),
+			value: width,
+		};
+	}
 
 	return (
 		<>
+			<div className="pattern-preview__size-control">
+				{ showViewportControl && (
+					<SelectControl
+						hideLabelFromVision
+						label={ __( 'Preview Width', 'wporg-patterns' ) }
+						value={ width }
+						options={ currentOpt ? [ currentOpt, ...availableWidths ] : availableWidths }
+						onChange={ ( value ) => setWidth( Number( value ) ) }
+					/>
+				) }
+			</div>
 			<div className="pattern-preview__viewport" style={ { width } }>
 				<DragHandle
 					label={ __( 'Drag to resize', 'wporg-patterns' ) }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import PatternPreview from '../pattern-preview';
+import PatternPreviewActions from '../pattern-preview-actions';
+import ReportPatternButton from '../report-pattern-button';
+
+const Pattern = ( { content, postId, userHasReported, loggedIn } ) => {
+	return (
+		<>
+			<PatternPreviewActions postId={ postId } />
+			<PatternPreview blockContent={ content } />
+			<div className="pattern__meta">
+				<ReportPatternButton
+					userHasReported={ userHasReported === 'true' }
+					loggedIn={ loggedIn === 'true' }
+					postId={ postId }
+				/>
+			</div>
+		</>
+	);
+};
+
+export default Pattern;

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
@@ -6,6 +6,8 @@ import PatternPreviewActions from '../pattern-preview-actions';
 import ReportPatternButton from '../report-pattern-button';
 
 const Pattern = ( { content, postId, userHasReported, loggedIn } ) => {
+	// postId as passed from the HTML dataset is a string.
+	postId = Number( postId ) || 0;
 	return (
 		<>
 			<PatternPreviewActions postId={ postId } />

--- a/public_html/wp-content/themes/pattern-directory/src/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/index.js
@@ -6,50 +6,24 @@ import { render } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import PatternPreview from './components/pattern-preview';
-import PatternPreviewActions from './components/pattern-preview-actions';
-import ReportPatternButton from './components/report-pattern-button';
+import Pattern from './components/pattern';
 import Patterns from './components/patterns';
+
+// Load the grid into the awaiting preview container.
+const gridContainer = document.getElementById( 'patterns__container' );
+if ( gridContainer ) {
+	render( <Patterns />, gridContainer );
+}
 
 // Load the preview into any awaiting preview container.
 const previewContainers = document.querySelectorAll( '.pattern-preview__container' );
 for ( let i = 0; i < previewContainers.length; i++ ) {
 	const container = previewContainers[ i ];
 	const blockContent = JSON.parse( decodeURIComponent( container.innerText ) );
-	// Use `wp.blocks.parse` to convert HTML to block objects (for use in editor), if needed.
+	const props = container.dataset;
 
-	render( <PatternPreview blockContent={ blockContent } />, container, () => {
+	render( <Pattern { ...props } content={ blockContent } />, container, () => {
 		// This callback is called after the render to unhide the container.
 		container.hidden = false;
 	} );
-}
-
-// Load the preview into any awaiting preview container.
-const gridContainer = document.getElementById( 'patterns__container' );
-if ( gridContainer ) {
-	render( <Patterns />, gridContainer );
-}
-
-// Load the pattern preview actions
-const patternActionsContainer = document.getElementById( 'pattern-actions' );
-if ( patternActionsContainer ) {
-	render(
-		<PatternPreviewActions patternId={ Number( patternActionsContainer.dataset.id ) } />,
-		patternActionsContainer
-	);
-}
-
-// Load report button
-const patternReportContainer = document.getElementById( 'pattern-report' );
-if ( patternReportContainer ) {
-	const { loggedIn, postId, userHasReported } = patternReportContainer.dataset;
-
-	render(
-		<ReportPatternButton
-			userHasReported={ userHasReported === 'true' }
-			loggedIn={ loggedIn === 'true' }
-			postId={ postId }
-		/>,
-		patternReportContainer
-	);
 }


### PR DESCRIPTION
This updates the single patterns page to match the design. I moved the PatternPreview, PatternPreviewActions, & ReportPatternButton components into one component called Pattern, which handles all the content in the midsection of the page. This makes the setup script (`src/index.js`) much simpler.

Aside from minor styling fixes to match the design, this also adds the preview width dropdown. For this pass, I just went with a single dropdown, we can add the dialog & unit control later, depending on how it goes in #115.

@shaunandrews I didn't change the drag handle design because I wasn't sure which was the correct one, the little white+blue circles or the longer white+black ones.

### Screenshots

![desktop-default](https://user-images.githubusercontent.com/541093/120695888-e101a380-c479-11eb-8334-529905f6fea9.png)

![desktop-small-preview](https://user-images.githubusercontent.com/541093/120695892-e232d080-c479-11eb-9b84-09246e9d1933.png)

The dropdown removes values larger than the current screen, since they don't work:
<img width="325" src="https://user-images.githubusercontent.com/541093/120695896-e363fd80-c479-11eb-9a7d-6e1f0ca96ba1.png">

The dropdown goes away at 480px wide, since there would only be one option.
<img width="325" src="https://user-images.githubusercontent.com/541093/120695899-e3fc9400-c479-11eb-95e9-e5f5f967a85c.png">

### How to test the changes in this Pull Request:

1. Checkout the branch & build the files, `yarn workspaces run build`
2. View a single pattern
3. Interact with the drag handles & the dropdown, they should work as you expect
4. Try copying, favoriting, and reporting, there should be no functionality change.
