### PR TITLE
Create the "My Patterns" page

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -24,6 +24,7 @@
 @import "copy-button";
 @import "favorite-button";
 @import "main-navigation";
+@import "page-my-patterns";
 @import "page";
 @import "pattern-grid-menu";
 @import "pattern-grid";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_page-my-patterns.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_page-my-patterns.scss
@@ -1,0 +1,14 @@
+body.page.my-patterns {
+	.entry-header {
+		margin: 2rem auto 1rem;
+		max-width: 960px;
+		display: flex;
+		align-items: center;
+
+		.entry-title {
+			display: inline-block;
+			margin: 0 2rem 0 0;
+			line-height: 1.2;
+		}
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/css/objects/_buttons.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/objects/_buttons.scss
@@ -8,4 +8,13 @@
 	height: auto;
 	color: color(blue-50);
 	font-weight: 600;
+
+	&:hover {
+		border-color: color(blue-40);
+	}
+
+	&:focus {
+		border-color: color(blue-40);
+		box-shadow: 0 0 3px color(blue-20);
+	}
 }

--- a/public_html/wp-content/themes/pattern-directory/css/objects/_buttons.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/objects/_buttons.scss
@@ -1,7 +1,3 @@
-.button.button {
-	height: auto;
-}
-
 .button.button-outline {
 	box-sizing: border-box;
 	padding: 0.25rem 1rem;

--- a/public_html/wp-content/themes/pattern-directory/css/objects/_buttons.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/objects/_buttons.scss
@@ -1,0 +1,15 @@
+.button.button {
+	height: auto;
+}
+
+.button.button-outline {
+	box-sizing: border-box;
+	padding: 0.25rem 1rem;
+	background: $color-white;
+	border: 1px solid color(gray-10);
+	border-radius: 2px;
+	box-shadow: none;
+	height: auto;
+	color: color(blue-50);
+	font-weight: 600;
+}

--- a/public_html/wp-content/themes/pattern-directory/css/objects/_objects.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/objects/_objects.scss
@@ -6,3 +6,4 @@
 @import "../../../wporg/css/objects/inputs";
 @import "../../../wporg/css/objects/links";
 @import "../../../wporg/css/objects/notices";
+@import "buttons";

--- a/public_html/wp-content/themes/pattern-directory/css/settings/_colors.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/settings/_colors.scss
@@ -29,21 +29,101 @@ $color-gray-light-300: lighten($color-base-gray, 72%);
 $color-gray-light-200: lighten($color-base-gray, 74%);
 $color-gray-light-100: lighten($color-base-gray, 77%);
 
-$color-error-red: #c92c2c;
-$color-alert-red: #d94f4f;
+// New WP 5.7+ Colors
+$colors: (
+	white: #fff,
+	black: #000,
+	gray-0: #f6f7f7,
+	gray-2: #f0f0f1,
+	gray-5: #dcdcde,
+	gray-10: #c3c4c7,
+	gray-20: #a7aaad,
+	gray-30: #8c8f94,
+	gray-40: #787c82,
+	gray-50: #646970,
+	gray-60: #50575e,
+	gray-70: #3c434a,
+	gray-80: #2c3338,
+	gray-90: #1d2327,
+	gray-100: #101517,
+	blue-0: #f0f6fc,
+	blue-5: #c5d9ed,
+	blue-10: #9ec2e6,
+	blue-20: #72aee6,
+	blue-30: #4f94d4,
+	blue-40: #3582c4,
+	blue-50: #2271b1,
+	blue-60: #135e96,
+	blue-70: #0a4b78,
+	blue-80: #043959,
+	blue-90: #01263a,
+	blue-100: #00131c,
+	red-0: #fcf0f1,
+	red-5: #facfd2,
+	red-10: #ffabaf,
+	red-20: #ff8085,
+	red-30: #f86368,
+	red-40: #e65054,
+	red-50: #d63638,
+	red-60: #b32d2e,
+	red-70: #8a2424,
+	red-80: #691c1c,
+	red-90: #451313,
+	red-100: #240a0a,
+	yellow-0: #fcf9e8,
+	yellow-5: #f5e6ab,
+	yellow-10: #f2d675,
+	yellow-20: #f0c33c,
+	yellow-30: #dba617,
+	yellow-40: #bd8600,
+	yellow-50: #996800,
+	yellow-60: #755100,
+	yellow-70: #614200,
+	yellow-80: #4a3200,
+	yellow-90: #362400,
+	yellow-100: #211600,
+	green-0: #edfaef,
+	green-5: #b8e6bf,
+	green-10: #68de7c,
+	green-20: #1ed14b,
+	green-30: #00ba37,
+	green-40: #00a32a,
+	green-50: #008a20,
+	green-60: #007017,
+	green-70: #005c12,
+	green-80: #00450c,
+	green-90: #003008,
+	green-100: #001c05
+);
 
-$color-black: #000;
-$color-white: #fff;
+// Simple function to retreive colors in the $colors map.
+// e.g. `background-color: color(gray-50);`
+@function color($key) {
 
-$color-accent-blue-shade4: #006899;
-$color-accent-green-shade1: #399648;
+	@if map-has-key($colors, $key) {
+
+		@return map-get($colors, $key);
+	}
+
+	@warn "Unknown `#{$key}` in $colors.";
+	@return null;
+}
+
+$color-error-red: color(red-50);
+$color-alert-red: color(red-40);
+
+$color-black: color(black); // stylelint-disable-line color-named
+$color-white: color(white); // stylelint-disable-line color-named
+
+$color-accent-blue-shade4: color(blue-60);
+$color-accent-green-shade1: color(green-60);
 
 // Theme colors
 $color__background-input: $color-gray-light-200;
-$color__text: #555d66;
+$color__text: color(gray-60);
 $color__text-darker: $color-gray-700;
 $color__text-lighter: $color-gray-300;
-$color__text-on-dark: #fff;
+$color__text-on-dark: $color-white;
 $color__text-heading: $color-gray-400;
 $color__text-heading-darker: $color-gray-800;
 $color__link-button: $color-gray-500;

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -10,6 +10,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'wp_head', __NAMESPACE__ . '\generate_block_editor_styles_html' );
 add_action( 'body_class', __NAMESPACE__ . '\body_class', 10, 2 );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );
+add_filter( 'init', __NAMESPACE__ . '\add_rewrite' );
 
 add_filter( 'search_template', __NAMESPACE__ . '\use_index_php_as_template' );
 add_filter( 'archive_template', __NAMESPACE__ . '\use_index_php_as_template' );
@@ -169,6 +170,15 @@ function pre_get_posts( $query ) {
 		$query->set( 'post_status', array( 'publish' ) );
 	}
 }
+
+/**
+ * Add the "My Patterns" status rewrites.
+ * This will redirect `my-patterns/draft`, `my-patterns/pending` etc to use the My Patterns page.
+ */
+function add_rewrite() {
+	add_rewrite_rule( '^my-patterns/[^/]+/?$', 'index.php?pagename=my-patterns', 'top' );
+}
+
 
 /**
  * Use the index.php template for various WordPress views that would otherwise be handled by the parent theme.

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -71,9 +71,10 @@ function enqueue_assets() {
 		wp_add_inline_script(
 			'wporg-pattern-script',
 			sprintf(
-				'var wporgAssetUrl = "%s", wporgSiteUrl = "%s";',
+				'var wporgAssetUrl = "%s", wporgSiteUrl = "%s", wporgLoginUrl = "%s";',
 				esc_url( get_stylesheet_directory_uri() ),
-				esc_url( home_url() )
+				esc_url( home_url() ),
+				esc_url( wp_login_url() )
 			),
 			'before'
 		);

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -8,6 +8,7 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as 
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'wp_head', __NAMESPACE__ . '\generate_block_editor_styles_html' );
+add_action( 'body_class', __NAMESPACE__ . '\body_class', 10, 2 );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );
 
 add_filter( 'search_template', __NAMESPACE__ . '\use_index_php_as_template' );
@@ -126,6 +127,20 @@ function generate_block_editor_styles_html() {
 }
 
 /**
+ * Add a class to body for the My Patterns page.
+ *
+ * @param string[] $classes An array of body class names.
+ * @param string[] $class   An array of additional class names added to the body.
+ */
+function body_class( $classes, $class ) {
+	global $wp_query;
+	if ( 'my-patterns' === $wp_query->get( 'pagename' ) ) {
+		$classes[] = 'my-patterns';
+	}
+	return $classes;
+}
+
+/**
  * Handle queries.
  * - My Patterns and Favories have "subpages" which should still show the root page.
  * - Default & archive views should show patterns, not posts.
@@ -154,6 +169,7 @@ function pre_get_posts( $query ) {
 		$query->set( 'post_status', array( 'publish' ) );
 	}
 }
+
 /**
  * Use the index.php template for various WordPress views that would otherwise be handled by the parent theme.
  */

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -60,6 +60,7 @@
 		"extends": "../../../../.eslintrc.js",
 		"globals": {
 			"wporgAssetUrl": "readonly",
+			"wporgLoginUrl": "readonly",
 			"wporgSiteUrl": "readonly"
 		}
 	},

--- a/public_html/wp-content/themes/pattern-directory/page-my-patterns.php
+++ b/public_html/wp-content/themes/pattern-directory/page-my-patterns.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * The template for displaying My Patterns.
+ *
+ * @package WordPressdotorg\Pattern_Directory\Theme
+ */
+
+namespace WordPressdotorg\Pattern_Directory\Theme;
+
+get_header();
+?>
+
+<main id="main" class="site-main" role="main">
+
+	<div id="my-patterns__container"></div>
+
+</main><!-- #main -->
+
+<?php
+get_footer();

--- a/public_html/wp-content/themes/pattern-directory/page-my-patterns.php
+++ b/public_html/wp-content/themes/pattern-directory/page-my-patterns.php
@@ -12,6 +12,11 @@ get_header();
 
 <main id="main" class="site-main" role="main">
 
+	<header class="entry-header">
+		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+		<a href="<?php echo esc_url( home_url( '/new-pattern' ) ); ?>" class="button button-outline"><?php esc_html_e( 'Create a new pattern', 'wporg-patterns' ); ?></a>
+	</header><!-- .entry-header -->
+
 	<div id="my-patterns__container"></div>
 
 </main><!-- #main -->

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/index.js
@@ -30,12 +30,15 @@ const MyPatterns = () => {
 			</div>
 		);
 	}
+	// Show all patterns regardless of status, but if the current query has a status (the view is draft, for
+	// example), that will override `any`. Lastly, make sure this shows the current user's patterns.
+	const modifiedQuery = { status: 'any', ...query, author: author };
 
 	return (
 		<RouteProvider>
 			<QueryMonitor />
 			<Menu />
-			<PatternGrid query={ { ...query, author } } />
+			<PatternGrid query={ modifiedQuery } />
 		</RouteProvider>
 	);
 };

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/index.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as patternStore } from '../../store';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import Menu from './menu';
+import PatternGrid from '../pattern-grid';
+import QueryMonitor from '../query-monitor';
+import { RouteProvider } from '../../hooks';
+
+const MyPatterns = () => {
+	const query = useSelect( ( select ) => select( patternStore ).getCurrentQuery() );
+	const author = useSelect( ( select ) => select( coreStore ).getCurrentUser()?.id );
+
+	if ( ! author ) {
+		const loginUrl = addQueryArgs( wporgLoginUrl, { redirect_to: window.location } );
+		return (
+			<div className="entry-content">
+				<p>{ __( 'Please log in to view your patterns.', 'wporg-patterns' ) }</p>
+				<a className="button button-primary" href={ loginUrl }>
+					{ __( 'Log in', 'wporg-patterns' ) }
+				</a>
+			</div>
+		);
+	}
+
+	return (
+		<RouteProvider>
+			<QueryMonitor />
+			<Menu />
+			<PatternGrid query={ { ...query, author } } />
+		</RouteProvider>
+	);
+};
+
+export default MyPatterns;

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/menu.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/menu.js
@@ -23,7 +23,7 @@ export default function () {
 		},
 		{
 			value: `${ wporgSiteUrl }/my-patterns/draft/`,
-			slug: 'drafts',
+			slug: 'draft',
 			label: __( 'Drafts', 'wporg-patterns' ),
 		},
 		{

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/menu.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/menu.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Menu from '../menu';
+import { getValueFromPath } from '../../utils';
+import { useRoute } from '../../hooks';
+
+export default function () {
+	const { path, update: updatePath } = useRoute();
+	const view = getValueFromPath( path, 'my-patterns' );
+
+	// @todo Load from an API to get pattern counts.
+	const options = [
+		{
+			value: `${ wporgSiteUrl }/my-patterns/`,
+			slug: 'all',
+			label: __( 'All', 'wporg-patterns' ),
+		},
+		{
+			value: `${ wporgSiteUrl }/my-patterns/draft/`,
+			slug: 'drafts',
+			label: __( 'Drafts', 'wporg-patterns' ),
+		},
+		{
+			value: `${ wporgSiteUrl }/my-patterns/pending/`,
+			slug: 'pending',
+			label: __( 'Pending Review', 'wporg-patterns' ),
+		},
+	];
+
+	return (
+		<nav className="pattern-grid-menu">
+			<Menu
+				label={ __( 'Menu', 'wporg-patterns' ) }
+				current={ view || 'all' }
+				options={ options }
+				onClick={ ( event ) => {
+					event.preventDefault();
+					updatePath( event.target.pathname );
+				} }
+				isLoading={ false }
+			/>
+		</nav>
+	);
+}

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/menu.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/menu.js
@@ -12,7 +12,10 @@ import { useRoute } from '../../hooks';
 
 export default function () {
 	const { path, update: updatePath } = useRoute();
-	const view = getValueFromPath( path, 'my-patterns' );
+	let view = getValueFromPath( path, 'my-patterns' );
+	if ( 'page' === view ) {
+		view = 'all';
+	}
 
 	// @todo Load from an API to get pattern counts.
 	const options = [

--- a/public_html/wp-content/themes/pattern-directory/src/components/query-monitor/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/query-monitor/index.js
@@ -45,7 +45,7 @@ const QueryMonitor = () => {
 			}
 
 			const myPatternStatus = getValueFromPath( path, 'my-patterns' );
-			if ( myPatternStatus ) {
+			if ( myPatternStatus && 'page' !== myPatternStatus ) {
 				_query.status = myPatternStatus;
 			}
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/query-monitor/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/query-monitor/index.js
@@ -20,8 +20,7 @@ const QueryMonitor = () => {
 
 	const query = useSelect(
 		( select ) => {
-			const queryStrings = getQueryArgs( path );
-			let _query = queryStrings;
+			let _query = getQueryArgs( path );
 
 			const categorySlug = getCategoryFromPath( path );
 			if ( categorySlug ) {

--- a/public_html/wp-content/themes/pattern-directory/src/components/query-monitor/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/query-monitor/index.js
@@ -10,7 +10,7 @@ import { getQueryArgs } from '@wordpress/url';
  */
 import { store as patternStore } from '../../store';
 import { useRoute } from '../../hooks';
-import { getCategoryFromPath, getPageFromPath } from '../../utils';
+import { getCategoryFromPath, getPageFromPath, getValueFromPath } from '../../utils';
 
 /**
  * Listens for changes to the path and reconstructs the query object based on the path
@@ -20,32 +20,33 @@ const QueryMonitor = () => {
 
 	const query = useSelect(
 		( select ) => {
-			const { getCategoryBySlug, hasLoadedCategories } = select( patternStore );
-
-			// We need categories loaded before building the query
-			if ( ! hasLoadedCategories() ) {
-				return;
-			}
-
-			const categorySlug = getCategoryFromPath( path );
-			const category = getCategoryBySlug( categorySlug );
-
-			// Default to {} if empty
 			const queryStrings = getQueryArgs( path );
-
 			let _query = queryStrings;
 
-			// If we have a category and it's not the default category
-			if ( category && category.id !== -1 ) {
-				_query = {
-					..._query,
-					'pattern-categories': category.id,
-				};
+			const categorySlug = getCategoryFromPath( path );
+			if ( categorySlug ) {
+				const { getCategoryBySlug, hasLoadedCategories } = select( patternStore );
+				if ( ! hasLoadedCategories() ) {
+					return;
+				}
+
+				const category = getCategoryBySlug( categorySlug );
+				if ( category && category.id !== -1 ) {
+					_query = {
+						..._query,
+						'pattern-categories': category.id,
+					};
+				}
 			}
 
 			const page = getPageFromPath( path );
 			if ( page > 1 ) {
 				_query.page = page;
+			}
+
+			const myPatternStatus = getValueFromPath( path, 'my-patterns' );
+			if ( myPatternStatus ) {
+				_query.status = myPatternStatus;
 			}
 
 			return _query;

--- a/public_html/wp-content/themes/pattern-directory/src/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/index.js
@@ -8,11 +8,18 @@ import { render } from '@wordpress/element';
  */
 import Pattern from './components/pattern';
 import Patterns from './components/patterns';
+import MyPatterns from './components/my-patterns';
 
 // Load the grid into the awaiting preview container.
 const gridContainer = document.getElementById( 'patterns__container' );
 if ( gridContainer ) {
 	render( <Patterns />, gridContainer );
+}
+
+// Load the preview into any awaiting preview container.
+const myGridContainer = document.getElementById( 'my-patterns__container' );
+if ( myGridContainer ) {
+	render( <MyPatterns />, myGridContainer );
 }
 
 // Load the preview into any awaiting preview container.


### PR DESCRIPTION
See #16. This adds a single My Patterns page, and lays some groundwork for the Favorite page.

### Screenshots

![Screen Shot 2021-06-10 at 13 51 57-fullpage](https://user-images.githubusercontent.com/541093/121573956-ca1bfd80-c9f3-11eb-9053-03e2fd23cf32.png)

On the drafts & pending pages, those are highlighted:

<img width="1023" alt="Screen Shot 2021-06-10 at 1 51 41 PM" src="https://user-images.githubusercontent.com/541093/121573969-d0aa7500-c9f3-11eb-8746-530d35a6ca5f.png">

### Notes

This doesn't complete #16, I'm aiming to get there in a series of smaller PRs. Still on my radar:

- Make the Favorites page
- Add the order by dropdown to the menu
- Add the pattern counts to the statuses in the menu
- Update the pattern thumbnail designs

### How to test the changes in this Pull Request:

1. Create a page called "My Patterns", it should have the slug `/my-patterns`.
2. View the page, you should see only patterns by your account
3. Try it logged out (this likely needs some design input, I'll make an issue for it once this merges)
