### PR TITLE
Turn off full width pattern-grid-menu decendants on desktop.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
@@ -15,7 +15,7 @@
 		width: calc(100% - #{$gutter-default * 2});
 	}
 
-	@media only screen and ( min-width: $breakpoint-medium ) {
+	@media only screen and ( min-width: #{$breakpoint-medium + 1} ) {
 		margin: $gutter-default;
 		flex-direction: row;
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
@@ -6,8 +6,10 @@
 	justify-content: space-between;
 	align-items: center;
 
-	> * {
-		width: 100%;
+	@media only screen and ( max-width: $breakpoint-medium ) {
+		> * {
+			width: 100%;
+		}
 	}
 
 	> form {

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
@@ -6,10 +6,8 @@
 	justify-content: space-between;
 	align-items: center;
 
-	@media only screen and ( max-width: $breakpoint-medium ) {
-		> * {
-			width: 100%;
-		}
+	.pattern-menu {
+		width: 100%;
 	}
 
 	> form {

--- a/public_html/wp-content/themes/pattern-directory/src/components/menu/default.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/menu/default.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ifViewportMatches } from '@wordpress/viewport';
 
 const DefaultMenu = ( { current, isLoading, label = __( 'Main Menu', 'wporg-patterns' ), onClick, options } ) => {
 	if ( ! isLoading && ! options.length ) {
@@ -43,5 +42,4 @@ const DefaultMenu = ( { current, isLoading, label = __( 'Main Menu', 'wporg-patt
 	);
 };
 
-// Will only render if the viewport is >= medium
-export default ifViewportMatches( '>= medium' )( DefaultMenu );
+export default DefaultMenu;

--- a/public_html/wp-content/themes/pattern-directory/src/components/menu/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/menu/index.js
@@ -1,16 +1,17 @@
 /**
+ * WordPress dependencies
+ */
+import { useViewportMatch } from '@wordpress/compose';
+
+/**
  * Internal dependencies
  */
 import DefaultMenu from './default';
 import MobileMenu from './mobile';
 
 const Menu = ( props ) => {
-	return (
-		<>
-			<DefaultMenu { ...props } />
-			<MobileMenu { ...props } />
-		</>
-	);
+	const isMobile = useViewportMatch( 'medium', '<' );
+	return isMobile ? <MobileMenu { ...props } /> : <DefaultMenu { ...props } />;
 };
 
 export default Menu;

--- a/public_html/wp-content/themes/pattern-directory/src/components/menu/mobile.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/menu/mobile.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { ifViewportMatches } from '@wordpress/viewport';
 import { PanelBody } from '@wordpress/components';
 
 const MobileMenu = ( { onClick, options, label = __( 'Browse categories', 'wporg-patterns' ) } ) => {
@@ -36,5 +35,4 @@ const MobileMenu = ( { onClick, options, label = __( 'Browse categories', 'wporg
 	);
 };
 
-// Will only render if the viewport is < medium
-export default ifViewportMatches( '< medium' )( MobileMenu );
+export default MobileMenu;


### PR DESCRIPTION
This PR limits a `width:100%` rule to smaller viewports where it's necessary. 

@ryelle This was introduced in #151 which was in preparation for the work in #152. Can you verify that it doesn't regress anything for that PR?

Fixes #165

### Screenshots
N/A

### How to test the changes in this Pull Request:

1. Load `/`
2. Expect to not see a horizontal navigation bar.
