### PR TITLE
Fix visual bugs in pattern previews

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -182,3 +182,23 @@ function bypass_404_page( $preempt, $wp_query ) {
 	}
 	return $preempt;
 }
+
+/**
+ * Get the full, filtered content of a post, ignoring more and noteaser tags and pagination.
+ *
+ * See https://github.com/WordPress/wordcamp.org/blob/442ea26d8e6a1b39f97114e933842b1ec4f8eef9/public_html/wp-content/mu-plugins/blocks/includes/content.php#L21
+ *
+ * @param int|WP_Post $post Post ID or post object.
+ * @return string The full, filtered post content.
+ */
+function get_all_the_content( $post ) {
+	$post = get_post( $post );
+
+	$content = wp_kses_post( $post->post_content );
+
+	/** This filter is documented in wp-includes/post-template.php */
+	$content = apply_filters( 'the_content', $content );
+	$content = str_replace( ']]>', ']]&gt;', $content );
+
+	return $content;
+}

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -8,13 +8,15 @@
  */
 
 namespace WordPressdotorg\Pattern_Directory\Theme;
+use function WordPressdotorg\Pattern_Directory\Theme\get_all_the_content;
 
 get_header();
 
 $user_has_reported = is_user_logged_in() ? user_has_flagged_pattern() : false;
+$block_content = get_all_the_content( get_the_ID() );
 
 ?>
-	<input id="block-data" type="hidden" value="<?php echo rawurlencode( wp_json_encode( get_the_content() ) ); ?>" />
+	<input id="block-data" type="hidden" value="<?php echo rawurlencode( wp_json_encode( $block_content ) ); ?>" />
 	<main id="main" class="site-main col-12" role="main">
 
 		<?php
@@ -42,7 +44,7 @@ $user_has_reported = is_user_logged_in() ? user_has_flagged_pattern() : false;
 					data-logged-in="<?php echo json_encode( is_user_logged_in() ); ?>"
 					data-user-has-reported="<?php echo json_encode( $user_has_reported ); ?>"
 				>
-					<?php echo rawurlencode( wp_json_encode( get_the_content() ) ); ?>
+					<?php echo rawurlencode( wp_json_encode( $block_content ) ); ?>
 				</div>
 
 				<div class="entry-content">

--- a/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
@@ -93,8 +93,21 @@ function setHead( doc, head ) {
 function Iframe( { contentRef, children, head, headHTML, themeSlug, ...props }, ref ) {
 	const [ iframeDocument, setIframeDocument ] = useState();
 
-	headHTML +=
-		'<style>body{pointer-events:none;display: flex;align-items: center;justify-content: center;min-height: 100vh;} body > div {width: 100%}</style>';
+	headHTML += `<style>
+    body{
+        pointer-events:none;
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: center;
+    }
+    .${ BODY_CLASS_NAME } {
+        padding: 0;
+    }
+    body > div {
+        width: 100%
+    }
+    </style>`;
 
 	if ( themeSlug ) {
 		headHTML += `<link rel="stylesheet" href="https://wp-themes.com/wp-content/themes/${ themeSlug }/style.css" media="all" />`;

--- a/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
@@ -94,8 +94,7 @@ function Iframe( { contentRef, children, head, headHTML, themeSlug, ...props }, 
 	const [ iframeDocument, setIframeDocument ] = useState();
 
 	headHTML += `<style>
-    body{
-        pointer-events:none;
+    body {
         display: flex;
         min-height: 100vh;
         align-items: center;
@@ -105,7 +104,9 @@ function Iframe( { contentRef, children, head, headHTML, themeSlug, ...props }, 
         padding: 0;
     }
     body > div {
-        width: 100%
+        width: 100%;
+        max-height: 100%;
+        pointer-events: none;
     }
     </style>`;
 


### PR DESCRIPTION
This fixes a few of the visual bugs flagged in #156.

- Fix the padding on the container to remove the small space on the left/right of full-width content.
- Fix the vertical alignment of the preview so that small patterns stay centered, but tall patterns start at the top and scroll.
- Fix the rendering of patterns in the single view so that all the relevant processing is done, this fixes the link color in #162  and the social icons.

I think the wide/full width issue is due to the Twenty Twenty-One styles, I think it's fixed with the switch to Twenty Nineteen in #164.

### Screenshots

![Screen Shot 2021-06-11 at 17 38 56-fullpage](https://user-images.githubusercontent.com/541093/121751605-82bd6c00-cadc-11eb-8ea9-3bdcfdfcff4f.png)
![Screen Shot 2021-06-11 at 17 40 09-fullpage](https://user-images.githubusercontent.com/541093/121751607-83560280-cadc-11eb-915b-a44b145e254c.png)

### How to test the changes in this Pull Request:

It's easiest to test this with a sandbox - push up the code and check the linked pages in #156. Otherwise, create patterns that replicate the issues, and check that this fixes them.