### PR TITLE
Creator: Reduce the viewport min value.

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -138,7 +138,7 @@ function register_post_type_data() {
 			'auth_callback'     => __NAMESPACE__ . '\can_edit_this_pattern',
 			'show_in_rest'      => array(
 				'schema' => array(
-					'minimum' => 400,
+					'minimum' => 200,
 					'maximum' => 2000,
 				),
 			),


### PR DESCRIPTION
This reduces the minimum value for pattern viewportWidth to `200`. Although this is still somewhat arbitrary and not technically a viewport width (too small in practive), in testing, there may be a use case where an author wants their preview pattern to be large and having a small `viewportWidth` value will crank up the size of the preview.

To find this number I created a simple pattern and tried it with different `viewportWidth`s. Anything under `200` seemed to make the preview a bit too magnified.

Fixes #167

### Screenshots

| 100 | 200 | 300 | 
| --- | --- | --- |
| ![](https://d.pr/i/ja9u5J.png) | ![](https://d.pr/i/UILztd.png)  | ![](https://d.pr/i/N85MkB.png)   | 
| A bit too big to be useful ||

### How to test the changes in this Pull Request:
There isn't anything to test at this point, not until #112 is merge. However, this may not need any testing. :)
