### PR TITLE
Theme: Display patterns by a single author

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -424,8 +424,12 @@ function filter_patterns_collection_params( $query_params ) {
 	}
 
 	$query_params['author_name'] = array(
-		'description' => __( 'Limit result set to patterns by a single author.', 'wporg-patterns' ),
-		'type'        => 'string',
+		'description'       => __( 'Limit result set to patterns by a single author.', 'wporg-patterns' ),
+		'type'              => 'string',
+		'validate_callback' => function( $value ) {
+			$user = get_user_by( 'slug', $value );
+			return (bool) $user;
+		},
 	);
 
 	return $query_params;

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -12,6 +12,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_asse
 add_filter( 'allowed_block_types', __NAMESPACE__ . '\remove_disallowed_blocks', 10, 2 );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\disable_block_directory', 0 );
 add_filter( 'rest_' . POST_TYPE . '_collection_params', __NAMESPACE__ . '\filter_patterns_collection_params' );
+add_filter( 'rest_' . POST_TYPE . '_query', __NAMESPACE__ . '\filter_patterns_rest_query', 10, 2 );
 
 
 /**
@@ -409,7 +410,9 @@ function disable_block_directory() {
 }
 
 /**
- * Filter the collection parameters to set a new default for per_page.
+ * Filter the collection parameters:
+ * - set a new default for per_page.
+ * - add a new parameter, `author_name`, for a user's nicename slug.
  *
  * @param array $query_params JSON Schema-formatted collection parameters.
  * @return array Filtered parameters.
@@ -420,7 +423,32 @@ function filter_patterns_collection_params( $query_params ) {
 		$query_params['per_page']['default'] = 18;
 	}
 
+	$query_params['author_name'] = array(
+		'description' => __( 'Limit result set to patterns by a single author.', 'wporg-patterns' ),
+		'type'        => 'string',
+	);
+
 	return $query_params;
+}
+
+/**
+ * Filter the arguments passed to the pattern query in the API.
+ *
+ * Uses the `author_name` passed in to the API to request patterns by an author slug, not just an ID.
+ *
+ * @param array           $args    Array of arguments to be passed to WP_Query.
+ * @param WP_REST_Request $request The REST API request.
+ */
+function filter_patterns_rest_query( $args, $request ) {
+	if ( isset( $request['author_name'] ) ) {
+		$user = get_user_by( 'slug', $request['author_name'] );
+		if ( $user ) {
+			$args['author'] = $user->ID;
+		} else {
+			$args['post__in'] = array( -1 );
+		}
+	}
+	return $args;
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/src/components/query-monitor/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/query-monitor/index.js
@@ -16,48 +16,48 @@ import { getCategoryFromPath, getPageFromPath, getValueFromPath } from '../../ut
  * Listens for changes to the path and reconstructs the query object based on the path
  */
 const QueryMonitor = () => {
+	const { setCurrentQuery } = useDispatch( patternStore );
 	const { path } = useRoute();
 
-	const query = useSelect(
+	let queryReady = true;
+	const query = getQueryArgs( path );
+	const categorySlug = getCategoryFromPath( path );
+
+	const categoryId = useSelect(
 		( select ) => {
-			let _query = getQueryArgs( path );
-
-			const categorySlug = getCategoryFromPath( path );
 			if ( categorySlug ) {
+				// Don't let the query be set until we have the categories.
+				queryReady = false;
 				const { getCategoryBySlug, hasLoadedCategories } = select( patternStore );
-				if ( ! hasLoadedCategories() ) {
-					return;
-				}
-
-				const category = getCategoryBySlug( categorySlug );
-				if ( category && category.id !== -1 ) {
-					_query = {
-						..._query,
-						'pattern-categories': category.id,
-					};
+				if ( hasLoadedCategories() ) {
+					queryReady = true;
+					const categoryObj = getCategoryBySlug( categorySlug );
+					return categoryObj?.id || false;
 				}
 			}
-
-			const page = getPageFromPath( path );
-			if ( page > 1 ) {
-				_query.page = page;
-			}
-
-			const myPatternStatus = getValueFromPath( path, 'my-patterns' );
-			if ( myPatternStatus && 'page' !== myPatternStatus ) {
-				_query.status = myPatternStatus;
-			}
-
-			return _query;
+			return false;
 		},
-		[ path ]
+		[ categorySlug ]
 	);
+	if ( categoryId ) {
+		query[ 'pattern-categories' ] = categoryId;
+	}
 
-	const { setCurrentQuery } = useDispatch( patternStore );
+	const page = getPageFromPath( path );
+	if ( page > 1 ) {
+		query.page = page;
+	}
+
+	const myPatternStatus = getValueFromPath( path, 'my-patterns' );
+	if ( myPatternStatus && 'page' !== myPatternStatus ) {
+		query.status = myPatternStatus;
+	}
 
 	useEffect( () => {
-		setCurrentQuery( query );
-	}, [ query ] );
+		if ( queryReady ) {
+			setCurrentQuery( query );
+		}
+	}, [ query, queryReady ] );
 
 	return null;
 };

--- a/public_html/wp-content/themes/pattern-directory/src/components/query-monitor/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/query-monitor/index.js
@@ -43,6 +43,11 @@ const QueryMonitor = () => {
 		query[ 'pattern-categories' ] = categoryId;
 	}
 
+	const author = getValueFromPath( path, 'author' );
+	if ( author ) {
+		query.author_name = author;
+	}
+
 	const page = getPageFromPath( path );
 	if ( page > 1 ) {
 		query.page = page;


### PR DESCRIPTION
This PR makes the author archives work. For example, view `/author/ryelle` (or any user on your site), and it should display just their patterns. Pagination and all other pattern-grid functionality should work.

This also adds a parameter to the patterns API to accept an `author_name`. By default the only way to get posts by author uses the author's ID, which is harder/impossible to get client-side for users not registered on _this_ site. Instead, we pass in the author's username, and PHP can get the ID, and their patterns.

For example, this is the request:
`GET /wp-json/wp/v2/wporg-pattern?author_name=wordpressdotorg`

Fixes #191, #163.

Note that `/author/[yourname]` is not the same as `/my-patterns` — the author archive is the public view, and My Patterns is for pattern management

⚠️  Not done in this PR (will be followups, unless anyone thinks they're blockers): empty state for a user with no patterns (#116), invalid username (use 404 from #116).

### Screenshots

Author archives, ex `/author/wordpressdotorg`:

![wporg-author-page](https://user-images.githubusercontent.com/541093/123444855-5a864080-d5a5-11eb-94cb-128170684991.png)

### How to test the changes in this Pull Request:

1. View the home page, click on a username
2. Or, go directly to `yoursite.com/author/[anyone]`
3. The author page should display only patterns by that one author, with pagination if needed

API:

- Test the API directly, by making requests with various `author_name` values. A valid author should return an array, and an invalid username should return an error.