### PR TITLE
Theme: Add a resolver for the `getPattern` selector

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -14,8 +14,6 @@ get_header();
 
 $user_has_reported = is_user_logged_in() ? user_has_flagged_pattern() : false;
 $raw_block_content = get_the_content();
-$parsed_block_content = get_all_the_content( get_the_ID() );
-
 ?>
 	<input id="block-data" type="hidden" value="<?php echo rawurlencode( wp_json_encode( $raw_block_content ) ); ?>" />
 	<main id="main" class="site-main col-12" role="main">
@@ -44,9 +42,7 @@ $parsed_block_content = get_all_the_content( get_the_ID() );
 					data-post-id="<?php echo intval( get_the_ID() ); ?>"
 					data-logged-in="<?php echo json_encode( is_user_logged_in() ); ?>"
 					data-user-has-reported="<?php echo json_encode( $user_has_reported ); ?>"
-				>
-					<?php echo rawurlencode( wp_json_encode( $parsed_block_content ) ); ?>
-				</div>
+				></div>
 
 				<div class="entry-content">
 					<h2><?php esc_html_e( 'More from this designer', 'wporg-patterns' ); ?></h2>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
@@ -1,17 +1,28 @@
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import PatternPreview from '../pattern-preview';
 import PatternPreviewActions from '../pattern-preview-actions';
 import ReportPatternButton from '../report-pattern-button';
+import { store as patternStore } from '../../store';
 
-const Pattern = ( { content, postId, userHasReported, loggedIn } ) => {
+const Pattern = ( { postId, userHasReported, loggedIn } ) => {
 	// postId as passed from the HTML dataset is a string.
 	postId = Number( postId ) || 0;
+	const pattern = useSelect( ( select ) => select( patternStore ).getPattern( postId ), [ postId ] );
+	if ( ! pattern ) {
+		return null;
+	}
+
 	return (
 		<>
 			<PatternPreviewActions postId={ postId } />
-			<PatternPreview blockContent={ content } />
+			<PatternPreview blockContent={ pattern.content.rendered } />
 			<div className="pattern__meta">
 				<ReportPatternButton
 					userHasReported={ userHasReported === 'true' }

--- a/public_html/wp-content/themes/pattern-directory/src/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/index.js
@@ -26,10 +26,9 @@ if ( myGridContainer ) {
 const previewContainers = document.querySelectorAll( '.pattern-preview__container' );
 for ( let i = 0; i < previewContainers.length; i++ ) {
 	const container = previewContainers[ i ];
-	const blockContent = JSON.parse( decodeURIComponent( container.innerText ) );
 	const props = container.dataset;
 
-	render( <Pattern { ...props } content={ blockContent } />, container, () => {
+	render( <Pattern { ...props } />, container, () => {
 		// This callback is called after the render to unhide the container.
 		container.hidden = false;
 	} );

--- a/public_html/wp-content/themes/pattern-directory/src/store/actions.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/actions.js
@@ -15,6 +15,22 @@ export function fetchPatterns( query ) {
 }
 
 /**
+ * Get the action object signalling that a singple pattern has been loaded.
+ *
+ * @param {number} postId The pattern ID.
+ * @param {Object} pattern The pattern as returned from the API.
+ *
+ * @return {Object} Action object.
+ */
+export function loadPattern( postId, pattern ) {
+	return {
+		type: 'LOAD_BLOCK_PATTERN',
+		postId: postId,
+		pattern: pattern,
+	};
+}
+
+/**
  * Get the action object signalling that patterns have been loaded.
  *
  * @param {string} query Search string.

--- a/public_html/wp-content/themes/pattern-directory/src/store/reducer.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/reducer.js
@@ -23,10 +23,17 @@ export function patterns( state = {}, action ) {
 }
 
 function byId( state = {}, action ) {
-	const patternsById = ( action.patterns || [] ).reduce( ( acc, cur ) => ( { ...acc, [ cur.id ]: cur } ), {} );
 	switch ( action.type ) {
-		case 'LOAD_BLOCK_PATTERNS':
+		case 'LOAD_BLOCK_PATTERNS': {
+			const patternsById = ( action.patterns || [] ).reduce(
+				( acc, cur ) => ( { ...acc, [ cur.id ]: cur } ),
+				{}
+			);
 			return { ...state, ...patternsById };
+		}
+		case 'LOAD_BLOCK_PATTERN': {
+			return { ...state, [ action.postId ]: action.pattern };
+		}
 		default:
 			return state;
 	}

--- a/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
@@ -14,6 +14,7 @@ import {
 	fetchPatterns,
 	loadCategories,
 	loadFavorites,
+	loadPattern,
 	loadPatternFlagReasons,
 	loadPatterns,
 	setErrorPatterns,
@@ -63,6 +64,15 @@ export function* getPatternsByQuery( query ) {
 			error: parsedError,
 		} );
 	}
+}
+
+export function* getPattern( postId ) {
+	try {
+		const pattern = yield apiFetch( {
+			path: addQueryArgs( `/wp/v2/wporg-pattern/${ postId }` ),
+		} );
+		yield loadPattern( postId, pattern );
+	} catch ( error ) {}
 }
 
 export function* getCategories() {

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
@@ -125,6 +125,65 @@ describe( 'state', () => {
 		} );
 	} );
 
+	describe( 'pattern', () => {
+		it( 'should store the pattern in state', () => {
+			const state = patterns(
+				{},
+				{
+					type: 'LOAD_BLOCK_PATTERN',
+					postId: apiPatterns[ 0 ].id,
+					pattern: apiPatterns[ 0 ],
+				}
+			);
+
+			expect( state.byId ).toHaveProperty( '31' );
+		} );
+
+		it( 'should store the next page of patterns in state', () => {
+			const state = patterns(
+				{
+					queries: {},
+					byId: { [ apiPatterns[ 0 ].id ]: apiPatterns[ 0 ] },
+				},
+				{
+					type: 'LOAD_BLOCK_PATTERN',
+					postId: apiPatterns[ 1 ].id,
+					pattern: apiPatterns[ 1 ],
+				}
+			);
+
+			expect( state.byId ).toHaveProperty( '31' );
+			expect( state.byId ).toHaveProperty( '25' );
+		} );
+
+		it( 'should not affect the queries', () => {
+			const state = patterns(
+				{
+					queries: {
+						'': {
+							total: 10,
+							totalPages: 2,
+							1: [ 31, 25, 26, 27, 28 ],
+						},
+					},
+					byId: apiPatterns.reduce( ( acc, cur ) => ( { ...acc, [ cur.id ]: cur } ), {} ),
+				},
+				{
+					type: 'LOAD_BLOCK_PATTERN',
+					postId: apiPatternsPage2[ 0 ].id,
+					pattern: apiPatternsPage2[ 0 ],
+				}
+			);
+
+			expect( state.queries[ '' ].total ).toBe( 10 );
+			expect( state.queries[ '' ].totalPages ).toBe( 2 );
+			expect( state.queries[ '' ][ '1' ] ).toHaveLength( 5 );
+			expect( state.byId ).toHaveProperty( '31' );
+			expect( state.byId ).toHaveProperty( '25' );
+			expect( state.byId ).toHaveProperty( '29' );
+		} );
+	} );
+
 	describe( 'categories', () => {
 		it( 'should return null when fetching categories', () => {
 			const state = categories(

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/resolvers.js
@@ -4,7 +4,7 @@
 import apiPatterns from './fixtures/patterns';
 import apiCategories from './fixtures/categories';
 import apiPatternFlagReasons from './fixtures/pattern-flag-reasons';
-import { getCategories, getFavorites, getPatternFlagReasons, getPatternsByQuery } from '../resolvers';
+import { getCategories, getFavorites, getPattern, getPatternFlagReasons, getPatternsByQuery } from '../resolvers';
 
 describe( 'getPatternsByQuery', () => {
 	it( 'yields with the requested patterns & query meta', async () => {
@@ -45,6 +45,28 @@ describe( 'getPatternsByQuery', () => {
 			patterns: apiPatterns,
 			total: 8,
 			totalPages: 2,
+		} );
+	} );
+} );
+
+describe( 'getPattern', () => {
+	const testPattern = apiPatterns[ 0 ];
+
+	it( 'yields with the requested pattern', async () => {
+		const generator = getPattern( testPattern.id );
+
+		// trigger apiFetch
+		const { value: apiFetchAction } = generator.next();
+		expect( apiFetchAction.request ).toEqual( {
+			path: '/wp/v2/wporg-pattern/' + testPattern.id,
+		} );
+
+		// Provide response and trigger action
+		const { value: received } = generator.next( testPattern );
+		expect( received ).toEqual( {
+			type: 'LOAD_BLOCK_PATTERN',
+			postId: testPattern.id,
+			pattern: testPattern,
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds a resolver for the `getPattern` selector, so it can be used outside of query requests. This is useful for the single pattern preview - rather than passing in various pattern meta, we can request the pattern itself via the API. Between #232 and an in-progress PR I have for the "more patterns" section, the `pattern-preview__container` element is getting overloaded.

Now, we can get the pattern data with just a single call:

```js
const pattern = useSelect( ( select ) => select( patternStore ).getPattern( postId ), [ postId ] );
```

And we can use `pattern.title.rendered` or `pattern.author_meta`, etc.

### Screenshots

No visual changes

### How to test the changes in this Pull Request:

1. No UI changes, everything should work the same
2. Tests should pass
