### PR TITLE
Theme: Display other patterns by this author on single page

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -271,7 +271,7 @@ function register_rest_fields() {
 				return array(
 					'name'   => esc_html( get_the_author_meta( 'display_name' ) ),
 					'url'    => esc_url( home_url( '/author/' . get_the_author_meta( 'user_nicename' ) ) ),
-					'avatar' => get_avatar_url( $post['author'], array( 'size' => 36 ) ),
+					'avatar' => get_avatar_url( $post['author'], array( 'size' => 64 ) ),
 				);
 			},
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -144,4 +144,26 @@ body.single-wporg-pattern {
 		display: flex;
 		justify-content: flex-end;
 	}
+
+	.pattern__author-avatar {
+		display: inline-flex;
+		align-items: center;
+		font-size: 1rem;
+		line-height: 1;
+		font-weight: 600;
+		color: color(gray-90);
+		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			text-decoration: underline;
+		}
+	}
+
+	.pattern__author-avatar img {
+		margin-right: 0.75rem;
+		height: 2rem;
+		width: 2rem;
+		border-radius: 4px;
+	}
 }

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -54,7 +54,6 @@ body.single-wporg-pattern {
 
 	.pattern-actions {
 		padding: 0 1.5rem 2rem;
-		background: $color-white;
 
 		button {
 			margin: 0;

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -38,16 +38,12 @@ $raw_block_content = get_the_content();
 
 				<div
 					hidden
-					class="pattern-preview__container"
+					class="pattern__container"
 					data-post-id="<?php echo intval( get_the_ID() ); ?>"
 					data-logged-in="<?php echo json_encode( is_user_logged_in() ); ?>"
 					data-user-has-reported="<?php echo json_encode( $user_has_reported ); ?>"
-				></div>
+				></div><!-- .pattern__container -->
 
-				<div class="entry-content">
-					<h2><?php esc_html_e( 'More from this designer', 'wporg-patterns' ); ?></h2>
-					<div class="pattern-grid"></div>
-				</div><!-- .entry-content -->
 			</article><!-- #post-## -->
 
 		<?php endwhile; ?>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
@@ -10,7 +10,7 @@ import { useSelect } from '@wordpress/data';
 import Pagination from './pagination';
 import { store as patternStore } from '../../store';
 
-function PatternGrid( { before, children, query, showPagination = true } ) {
+function PatternGrid( { header, children, query, showPagination = true } ) {
 	const { isLoading, posts, totalPages } = useSelect( ( select ) => {
 		const { getPatternTotalPagesByQuery, getPatternsByQuery, isLoadingPatternsByQuery } = select(
 			patternStore
@@ -25,7 +25,7 @@ function PatternGrid( { before, children, query, showPagination = true } ) {
 
 	return (
 		<>
-			{ posts.length ? before : null }
+			{ posts.length ? header : null }
 			<div className="pattern-grid">{ isLoading ? <Spinner /> : posts.map( children ) }</div>
 			{ showPagination && <Pagination totalPages={ totalPages } currentPage={ query?.page } /> }
 		</>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
@@ -10,7 +10,7 @@ import { useSelect } from '@wordpress/data';
 import Pagination from './pagination';
 import { store as patternStore } from '../../store';
 
-function PatternGrid( { children, query, showPagination = true } ) {
+function PatternGrid( { before, children, query, showPagination = true } ) {
 	const { isLoading, posts, totalPages } = useSelect( ( select ) => {
 		const { getPatternTotalPagesByQuery, getPatternsByQuery, isLoadingPatternsByQuery } = select(
 			patternStore
@@ -25,6 +25,7 @@ function PatternGrid( { children, query, showPagination = true } ) {
 
 	return (
 		<>
+			{ posts.length ? before : null }
 			<div className="pattern-grid">{ isLoading ? <Spinner /> : posts.map( children ) }</div>
 			{ showPagination && <Pagination totalPages={ totalPages } currentPage={ query?.page } /> }
 		</>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
@@ -10,7 +10,7 @@ import { useSelect } from '@wordpress/data';
 import Pagination from './pagination';
 import { store as patternStore } from '../../store';
 
-function PatternGrid( { query, children } ) {
+function PatternGrid( { children, query, showPagination = true } ) {
 	const { isLoading, posts, totalPages } = useSelect( ( select ) => {
 		const { getPatternTotalPagesByQuery, getPatternsByQuery, isLoadingPatternsByQuery } = select(
 			patternStore
@@ -26,7 +26,7 @@ function PatternGrid( { query, children } ) {
 	return (
 		<>
 			<div className="pattern-grid">{ isLoading ? <Spinner /> : posts.map( children ) }</div>
-			<Pagination totalPages={ totalPages } currentPage={ query?.page } />
+			{ showPagination && <Pagination totalPages={ totalPages } currentPage={ query?.page } /> }
 		</>
 	);
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/author-details.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/author-details.js
@@ -1,7 +1,3 @@
-/**
- * WordPress dependencies
- */
-
 const AuthorDetails = ( { name, url, avatar } ) => {
 	return (
 		<a href={ url } className="pattern__author-avatar">

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/author-details.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/author-details.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+
+const AuthorDetails = ( { name, url, avatar } ) => {
+	return (
+		<a href={ url } className="pattern__author-avatar">
+			<img alt="" src={ avatar } />
+			{ name }
+		</a>
+	);
+};
+
+export default AuthorDetails;

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
@@ -40,7 +40,7 @@ const Pattern = ( { postId, userHasReported, loggedIn } ) => {
 				<PatternGrid
 					query={ { author: pattern.author, per_page: 3, exclude: postId } }
 					showPagination={ false }
-					before={
+					header={
 						<>
 							<h2>{ __( 'More from this designer', 'wporg-patterns' ) }</h2>
 							<AuthorDetails { ...pattern.author_meta } />

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
@@ -1,13 +1,16 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import PatternGrid from '../pattern-grid';
 import PatternPreview from '../pattern-preview';
 import PatternPreviewActions from '../pattern-preview-actions';
+import PatternThumbnail from '../pattern-thumbnail';
 import ReportPatternButton from '../report-pattern-button';
 import { store as patternStore } from '../../store';
 
@@ -22,13 +25,24 @@ const Pattern = ( { postId, userHasReported, loggedIn } ) => {
 	return (
 		<>
 			<PatternPreviewActions postId={ postId } />
-			<PatternPreview blockContent={ pattern.content.rendered } />
-			<div className="pattern__meta">
-				<ReportPatternButton
-					userHasReported={ userHasReported === 'true' }
-					loggedIn={ loggedIn === 'true' }
-					postId={ postId }
-				/>
+			<div className="pattern-preview__container">
+				<PatternPreview blockContent={ pattern.content.rendered } />
+				<div className="pattern__meta">
+					<ReportPatternButton
+						userHasReported={ userHasReported === 'true' }
+						loggedIn={ loggedIn === 'true' }
+						postId={ postId }
+					/>
+				</div>
+			</div>
+			<div className="entry-content">
+				<h2>{ __( 'More from this designer', 'wporg-patterns' ) }</h2>
+				<PatternGrid
+					query={ { author: pattern.author, per_page: 3, exclude: postId } }
+					showPagination={ false }
+				>
+					{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } /> }
+				</PatternGrid>
 			</div>
 		</>
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
@@ -7,6 +7,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import AuthorDetails from './author-details';
 import PatternGrid from '../pattern-grid';
 import PatternPreview from '../pattern-preview';
 import PatternPreviewActions from '../pattern-preview-actions';
@@ -36,10 +37,15 @@ const Pattern = ( { postId, userHasReported, loggedIn } ) => {
 				</div>
 			</div>
 			<div className="entry-content">
-				<h2>{ __( 'More from this designer', 'wporg-patterns' ) }</h2>
 				<PatternGrid
 					query={ { author: pattern.author, per_page: 3, exclude: postId } }
 					showPagination={ false }
+					before={
+						<>
+							<h2>{ __( 'More from this designer', 'wporg-patterns' ) }</h2>
+							<AuthorDetails { ...pattern.author_meta } />
+						</>
+					}
 				>
 					{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } /> }
 				</PatternGrid>

--- a/public_html/wp-content/themes/pattern-directory/src/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/index.js
@@ -23,7 +23,7 @@ if ( myGridContainer ) {
 }
 
 // Load the preview into any awaiting preview container.
-const previewContainers = document.querySelectorAll( '.pattern-preview__container' );
+const previewContainers = document.querySelectorAll( '.pattern__container' );
 for ( let i = 0; i < previewContainers.length; i++ ) {
 	const container = previewContainers[ i ];
 	const props = container.dataset;


### PR DESCRIPTION
This adds the "More from this designer" section to single pattern pages. This displays up to 3 other patterns that are also made by the current pattern's author.

Fixes #234, see #230.

Note, this is based on #236 since it uses the `getPattern` selector.

### Screenshots

User with a lot of patterns, shows the 3 most recent (excluding the current pattern).

<img width="1065" alt="three" src="https://user-images.githubusercontent.com/541093/123693571-384f2580-d826-11eb-8db9-6c368430e759.png">

User with just two published patterns, shows only 1 in "More…"

<img width="1032" alt="one-pattern" src="https://user-images.githubusercontent.com/541093/123693569-37b68f00-d826-11eb-8c60-2c41b9f844e0.png">

User with only 1 pattern, shows an empty section.
<img width="1063" alt="no-patterns" src="https://user-images.githubusercontent.com/541093/123693572-39805280-d826-11eb-9f5e-c7891a22d6bb.png">

### How to test the changes in this Pull Request:

1. Build the branch, `yarn workspaces run build`
2. View a single pattern by an author with multiple published patterns
3. Under the pattern preview, there should be a section "More from this designer"
4. View a single pattern by an author with only one published pattern
5. There's nothing displayed under the pattern preview.

