### PR TITLE
Pattern Creator: Set up creating/editing permissions for logged in wp.org users

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -198,14 +198,13 @@ add_filter( 'template_include', __NAMESPACE__ . '\inject_editor_template' );
 function rewrite_for_pattern_editing() {
 	add_rewrite_rule( '^pattern/(\d+)/edit', 'index.php?pagename=new-pattern&' . PATTERN_ID_VAR . '=$matches[1]', 'top' );
 
-	if ( isset( $_GET['post'] ) &&
-		isset( $_GET['action'] ) &&
-		'edit' === $_GET['action'] &&
-		POST_TYPE === get_post_type( $_GET['post'] ) &&
-		! is_admin()
-		) {
-			wp_safe_redirect( home_url( '/pattern/' . absint( $_GET['post'] ) . '/edit' ) );
-			exit;
+	if (
+		'edit' === filter_input( INPUT_GET, 'action' )
+		&& POST_TYPE === get_post_type( filter_input( INPUT_GET, 'post' ) )
+		&& ! is_admin()
+	) {
+		wp_safe_redirect( home_url( '/pattern/' . absint( $_GET['post'] ) . '/edit' ) );
+		exit;
 	}
 }
 add_action( 'init', __NAMESPACE__ . '\rewrite_for_pattern_editing' );

--- a/public_html/wp-content/plugins/pattern-creator/view/editor.php
+++ b/public_html/wp-content/plugins/pattern-creator/view/editor.php
@@ -8,8 +8,6 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 
 get_header();
 
-// @todo Permissions TBD, see https://github.com/WordPress/pattern-directory/issues/30.
-
 $is_logged_in = is_user_logged_in();
 $can_edit     = current_user_can( 'edit_post', get_query_var( PATTERN_ID_VAR ) );
 

--- a/public_html/wp-content/plugins/pattern-creator/view/editor.php
+++ b/public_html/wp-content/plugins/pattern-creator/view/editor.php
@@ -11,9 +11,15 @@ get_header();
 // @todo Permissions TBD, see https://github.com/WordPress/pattern-directory/issues/30.
 
 $is_logged_in = is_user_logged_in();
-$can_edit     = current_user_can( 'edit_post', get_the_ID() );
+$can_edit     = current_user_can( 'edit_post', get_query_var( PATTERN_ID_VAR ) );
 
-if ( is_singular( POST_TYPE ) ) {
+$current_page_query_args = array( 'pagename' => 'new-pattern' );
+if ( get_query_var( PATTERN_ID_VAR ) ) {
+	$current_page_query_args[ PATTERN_ID_VAR ] = get_query_var( PATTERN_ID_VAR );
+}
+$current_page_url = add_query_arg( $current_page_query_args, home_url() );
+
+if ( is_editing_pattern() ) {
 	$page_title   = __( 'Update a Block Pattern', 'wporg-patterns' );
 	$page_content = '';
 	if ( ! $is_logged_in ) {
@@ -32,18 +38,22 @@ if ( is_singular( POST_TYPE ) ) {
 
 	<main id="main" class="site-main col-12" role="main">
 
-		<?php if ( ( is_singular( POST_TYPE ) && $can_edit ) || ( ! is_singular( POST_TYPE ) && $is_logged_in ) ) : ?>
+		<?php if ( ( is_editing_pattern() && $can_edit ) || ( ! is_editing_pattern() && $is_logged_in ) ) : ?>
 			<div id="block-pattern-creator"></div>
 		<?php else : ?>
 			<section class="no-results not-found">
 				<header class="page-header">
 					<h1 class="page-title"><?php echo esc_html( $page_title ); ?></h1>
-				</header><!-- .page-header -->
+				</header>
 
 				<div class="page-content">
 					<p>
 						<?php echo esc_html( $page_content ); ?>
-						<a href="<?php echo esc_url( wp_login_url( get_permalink() ) ); ?>" rel="nofollow"><?php esc_html_e( 'Log in to WordPress.org.', 'wporg-patterns' ); ?></a>
+						<?php if ( ! $is_logged_in ) : ?>
+							<a href="<?php echo esc_url( wp_login_url( $current_page_url ) ); ?>" rel="nofollow">
+								<?php esc_html_e( 'Log in to WordPress.org.', 'wporg-patterns' ); ?>
+							</a>
+						<?php endif; ?>
 					</p>
 				</div>
 			</section>

--- a/public_html/wp-content/plugins/pattern-creator/view/editor.php
+++ b/public_html/wp-content/plugins/pattern-creator/view/editor.php
@@ -10,24 +10,29 @@ get_header();
 
 // @todo Permissions TBD, see https://github.com/WordPress/pattern-directory/issues/30.
 
-$post_type_obj = get_post_type_object( POST_TYPE );
+$is_logged_in = is_user_logged_in();
+$can_edit     = current_user_can( 'edit_post', get_the_ID() );
 
 if ( is_singular( POST_TYPE ) ) {
 	$page_title   = __( 'Update a Block Pattern', 'wporg-patterns' );
-	if ( ! is_user_logged_in() ) {
+	$page_content = '';
+	if ( ! $is_logged_in ) {
 		$page_content = __( 'You need to be logged in to edit this block pattern.', 'wporg-patterns' );
-	} else {
+	} elseif ( ! $can_edit ) {
 		$page_content = __( "You need to be the pattern's author to edit this pattern.", 'wporg-patterns' );
 	}
 } else {
 	$page_title   = __( 'Submit a Block Pattern', 'wporg-patterns' );
-	$page_content = __( 'You need to be logged in to create a block pattern.', 'wporg-patterns' );
+	$page_content = '';
+	if ( ! $is_logged_in ) {
+		$page_content = __( 'You need to be logged in to create a block pattern.', 'wporg-patterns' );
+	}
 }
 ?>
 
 	<main id="main" class="site-main col-12" role="main">
 
-		<?php if ( ( is_singular( POST_TYPE ) && current_user_can( 'edit_post', get_the_ID() ) ) || current_user_can( $post_type_obj->cap->create_posts ) ) : ?>
+		<?php if ( ( is_singular( POST_TYPE ) && $can_edit ) || ( ! is_singular( POST_TYPE ) && $is_logged_in ) ) : ?>
 			<div id="block-pattern-creator"></div>
 		<?php else : ?>
 			<section class="no-results not-found">

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -25,7 +25,7 @@ function register_post_type_data() {
 	register_post_type(
 		POST_TYPE,
 		array(
-			'labels' => array(
+			'labels'          => array(
 				'name'                     => _x( 'Block Pattern', 'post type general name', 'wporg-patterns' ),
 				'singular_name'            => _x( 'Block Pattern', 'post type singular name', 'wporg-patterns' ),
 				'add_new'                  => _x( 'Add New', 'block pattern', 'wporg-patterns' ),
@@ -51,13 +51,13 @@ function register_post_type_data() {
 				'item_scheduled'           => __( 'Block pattern scheduled.', 'wporg-patterns' ),
 				'item_updated'             => __( 'Block pattern updated.', 'wporg-patterns' ),
 			),
-			'description'  => 'Stores publicly shared Block Patterns (predefined block layouts, ready to insert and tweak).',
-			'public'       => true,
-			'show_in_rest' => true,
-			'rewrite'      => array( 'slug' => 'pattern' ),
-			'supports'     => array( 'title', 'editor', 'author', 'custom-fields' ),
+			'description'     => 'Stores publicly shared Block Patterns (predefined block layouts, ready to insert and tweak).',
+			'public'          => true,
+			'show_in_rest'    => true,
+			'rewrite'         => array( 'slug' => 'pattern' ),
+			'supports'        => array( 'title', 'editor', 'author', 'custom-fields' ),
 			'capability_type' => array( 'pattern', 'patterns' ),
-			'map_meta_cap' => true,
+			'map_meta_cap'    => true,
 		)
 	);
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -540,9 +540,26 @@ function get_block_pattern( $post ) {
  * @return array
  */
 function set_pattern_caps( $user_caps ) {
+	// Set corresponding caps for all roles.
+	$cap_args = array(
+		'capability_type' => array( 'pattern', 'patterns' ),
+		'capabilities'    => array(),
+		'map_meta_cap'    => true,
+	);
+	$cap_map = (array) get_post_type_capabilities( (object) $cap_args );
+
+	foreach ( $user_caps as $cap => $bool ) {
+		if ( $bool && isset( $cap_map[ $cap ] ) ) {
+			$user_caps[ $cap_map[ $cap ] ] = true;
+		}
+	}
+
+	// Set caps to allow for front end pattern creation.
 	if ( is_user_logged_in() && ! is_admin() ) {
-		$user_caps['edit_patterns']   = true;
-		$user_caps['create_patterns'] = true;
+		$user_caps['create_patterns']         = true;
+		$user_caps['publish_patterns']        = true;
+		$user_caps['edit_patterns']           = true;
+		$user_caps['edit_published_patterns'] = true;
 	}
 
 	return $user_caps;

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -556,7 +556,6 @@ function set_pattern_caps( $user_caps ) {
 
 	// Set caps to allow for front end pattern creation.
 	if ( is_user_logged_in() && ! is_admin() ) {
-		$user_caps['create_patterns']         = true;
 		$user_caps['publish_patterns']        = true;
 		$user_caps['edit_patterns']           = true;
 		$user_caps['edit_published_patterns'] = true;

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/capabilities-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/capabilities-test.php
@@ -1,0 +1,378 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Tests;
+
+use WP_UnitTestCase;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+
+/**
+ * Test pattern validation.
+ *
+ * @group pattern-directory-capabilities
+ */
+class Capabilities_Test extends WP_UnitTestCase {
+	protected static $user_admin;
+	protected static $user_editor;
+	protected static $user_author;
+	protected static $user_contributor;
+	protected static $user_subscriber;
+	protected static $pattern_id_1;
+	protected static $pattern_id_2;
+	protected static $post_id;
+
+	/**
+	 * For the purposes of these tests, admins and editors have the same capabilities.
+	 */
+	protected $admin_editor_caps = array(
+		'delete_others_patterns', 'delete_patterns', 'delete_private_patterns', 'delete_published_patterns',
+		'edit_others_patterns', 'edit_patterns', 'edit_private_patterns', 'edit_published_patterns',
+		'publish_patterns', 'read_private_patterns',
+	);
+
+	protected $author_caps = array(
+		'delete_patterns', 'delete_published_patterns',
+		'edit_patterns', 'edit_published_patterns',
+		'publish_patterns',
+	);
+
+	protected $contributor_caps = array(
+		'delete_patterns',
+		'edit_patterns',
+	);
+
+	protected $subscriber_caps = array();
+
+	/**
+	 * Set up shared fixtures.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user_admin = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		self::$user_editor = $factory->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+		self::$user_author = $factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+		self::$user_contributor = $factory->user->create(
+			array(
+				'role' => 'contributor',
+			)
+		);
+		self::$user_subscriber = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+
+		self::$pattern_id_1 = $factory->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_author' => self::$user_editor,
+			)
+		);
+		self::$pattern_id_2 = $factory->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_author' => self::$user_subscriber,
+			)
+		);
+		self::$post_id = $factory->post->create();
+	}
+
+	/**
+	 * Clean up shared fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$pattern_id_1, true );
+		wp_delete_post( self::$pattern_id_2, true );
+		wp_delete_post( self::$post_id, true );
+
+		wp_delete_user( self::$user_admin );
+		wp_delete_user( self::$user_editor );
+		wp_delete_user( self::$user_author );
+		wp_delete_user( self::$user_contributor );
+		wp_delete_user( self::$user_subscriber );
+	}
+
+	/**
+	 * Reset state between tests.
+	 */
+	public function tearDown() {
+		unset( $GLOBALS['current_screen'] );
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Simulate the back end environment. Causes is_admin() to return true.
+	 */
+	protected function set_admin_screen() {
+		require_once ABSPATH . '/wp-admin/includes/class-wp-screen.php';
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$GLOBALS['current_screen'] = \WP_Screen::get( POST_TYPE );
+	}
+
+	/**
+	 * Build an array of capabilities and their expected results from capability checks.
+	 *
+	 * @param array $yes_caps
+	 * @param array $all_caps
+	 *
+	 * @return array
+	 */
+	protected function merge_caps( $yes_caps, $all_caps ) {
+		return array_merge(
+			array_fill_keys( $all_caps, false ),
+			array_fill_keys( $yes_caps, true )
+		);
+	}
+
+	/**
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\set_pattern_caps()
+	 */
+	public function test_pattern_caps_admin() {
+		wp_set_current_user( self::$user_admin );
+
+		$caps = $this->merge_caps( $this->admin_editor_caps, $this->admin_editor_caps );
+
+		// Test front end caps.
+		foreach ( $caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on front end for %s', $cap )
+			);
+		}
+
+		// Test back end caps.
+		$this->set_admin_screen();
+		foreach ( $caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on back end for %s', $cap )
+			);
+		}
+	}
+
+	/**
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\set_pattern_caps()
+	 */
+	public function test_pattern_caps_editor() {
+		wp_set_current_user( self::$user_editor );
+
+		$caps = $this->merge_caps( $this->admin_editor_caps, $this->admin_editor_caps );
+
+		// Test front end caps.
+		foreach ( $caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on front end for %s', $cap )
+			);
+		}
+
+		// Test back end caps.
+		$this->set_admin_screen();
+		foreach ( $caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on back end for %s', $cap )
+			);
+		}
+	}
+
+	/**
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\set_pattern_caps()
+	 */
+	public function test_pattern_caps_author() {
+		wp_set_current_user( self::$user_author );
+
+		$caps = $this->merge_caps( $this->author_caps, $this->admin_editor_caps );
+
+		// Test front end caps.
+		foreach ( $caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on front end for %s', $cap )
+			);
+		}
+
+		// Test back end caps.
+		$this->set_admin_screen();
+		foreach ( $caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on back end for %s', $cap )
+			);
+		}
+	}
+
+	/**
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\set_pattern_caps()
+	 */
+	public function test_pattern_caps_contributor() {
+		wp_set_current_user( self::$user_contributor );
+
+		$caps = $this->merge_caps( $this->contributor_caps, $this->admin_editor_caps );
+		$front_end_caps = array_merge(
+			$caps,
+			array(
+				'edit_patterns'           => true,
+				'edit_published_patterns' => true,
+				'publish_patterns'        => true,
+			)
+		);
+
+		// Test front end caps.
+		foreach ( $front_end_caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on front end for %s', $cap )
+			);
+		}
+
+		// Test back end caps.
+		$this->set_admin_screen();
+		foreach ( $caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on back end for %s', $cap )
+			);
+		}
+	}
+
+	/**
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\set_pattern_caps()
+	 */
+	public function test_pattern_caps_subscriber() {
+		wp_set_current_user( self::$user_subscriber );
+
+		$caps = $this->merge_caps( $this->subscriber_caps, $this->admin_editor_caps );
+		$front_end_caps = array_merge(
+			$caps,
+			array(
+				'edit_patterns'           => true,
+				'edit_published_patterns' => true,
+				'publish_patterns'        => true,
+			)
+		);
+
+		// Test front end caps.
+		foreach ( $front_end_caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on front end for %s', $cap )
+			);
+		}
+
+		// Test back end caps.
+		$this->set_admin_screen();
+		foreach ( $caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on back end for %s', $cap )
+			);
+		}
+	}
+
+	/**
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\set_pattern_caps()
+	 */
+	public function test_pattern_caps_logged_out_user() {
+		$caps = $this->merge_caps( array(), $this->admin_editor_caps );
+
+		// Test front end caps.
+		foreach ( $caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on front end for %s', $cap )
+			);
+		}
+
+		// Test back end caps.
+		$this->set_admin_screen();
+		foreach ( $caps as $cap => $expected_result ) {
+			$this->assertEquals(
+				$expected_result,
+				current_user_can( $cap ),
+				sprintf( 'Failed on back end for %s', $cap )
+			);
+		}
+	}
+
+	/**
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\set_pattern_caps()
+	 */
+	public function test_subscriber_edit_other_pattern() {
+		wp_set_current_user( self::$user_subscriber );
+
+		// Test front end.
+		$this->assertFalse(
+			current_user_can( 'edit_post', self::$pattern_id_1 ),
+			'Failed on front end'
+		);
+
+		// Test back end.
+		$this->set_admin_screen();
+		$this->assertFalse(
+			current_user_can( 'edit_post', self::$pattern_id_1 ),
+			'Failed on back end'
+		);
+	}
+
+	/**
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\set_pattern_caps()
+	 */
+	public function test_subscriber_edit_own_pattern() {
+		wp_set_current_user( self::$user_subscriber );
+
+		// Test front end.
+		$this->assertTrue(
+			current_user_can( 'edit_post', self::$pattern_id_2 ),
+			'Failed on front end'
+		);
+
+		// Test back end.
+		$this->set_admin_screen();
+		$this->assertFalse(
+			current_user_can( 'edit_post', self::$pattern_id_2 ),
+			'Failed on back end'
+		);
+	}
+
+	/**
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\set_pattern_caps()
+	 */
+	public function test_subscriber_edit_other_post_type() {
+		wp_set_current_user( self::$user_subscriber );
+
+		// Test front end.
+		$this->assertFalse(
+			current_user_can( 'edit_post', self::$post_id ),
+			'Failed on front end'
+		);
+
+		// Test back end.
+		$this->set_admin_screen();
+		$this->assertFalse(
+			current_user_can( 'edit_post', self::$post_id ),
+			'Failed on back end'
+		);
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -6,7 +6,7 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG_POST_TYPE;
 
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 20 );
 add_action( 'wp_head', __NAMESPACE__ . '\generate_block_editor_styles_html' );
 add_action( 'body_class', __NAMESPACE__ . '\body_class', 10, 2 );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );


### PR DESCRIPTION
Enables logged in wp.org users to create and edit patterns on the front end of the Pattern Directory without having to be an actual member of the patterns site.

First I approached this in the way suggested in #30, modifying the permissions checks in the rest controller for the patterns post type. However, it became apparent that the capability checks that were preventing non-site members from creating patterns were used in other places besides the rest controller, so I decided to switch gears and grant the necessary capabilities in certain limited circumstances. Thus the rest controller is not modified at all here.

This also fixes an issue with the pattern theme's stylesheet that was preventing it from loading correctly when trying to access the New Pattern screen while logged out.

Fixes #30

### How to test the changes in this Pull Request:

1. For testing in the local dev environment, create a new user with the Subscriber role and log into the site as that user. This simulates being a wp.org user who is not a member of the site, but who is logged in.
2. Go to the [New Pattern screen](http://localhost:8888/new-pattern/). The editor should load with no errors in the console or broken XHR requests.
3. Create and publish a new pattern. This should succeed and there should be no console errors.
4. Try going to [WP Admin](http://localhost:8888/wp-admin/) and see if you have access to the Block Pattern menu or any of the screens within it. You shouldn't.
5. Try to find scenarios where the Subscriber user has access that it shouldn't.
5. Now log out and log back in as an admin. You should have full access to block patterns in WP Admin and pattern creation on the front end.

<!-- If you can, add the appropriate [Component] label(s). -->
