### PR TITLE
Theme: Remove animation for category context bar for better rendering

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_category-context-bar.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_category-context-bar.scss
@@ -4,11 +4,7 @@
 	border-radius: 2px;
 	font-size: 0.8125rem;
 	overflow: auto;
-	transition: all 300ms ease-out;
-
-	@media (prefers-reduced-motion) {
-		transition: none;
-	}
+	height: 55px; // Prevent layout shifts
 
 	> div {
 		display: flex;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
@@ -5,7 +5,6 @@
 	flex-direction: column;
 	justify-content: space-between;
 	align-items: center;
-	height: 37px; // Prevent layout shifts
 
 	.pattern-menu {
 		width: 100%;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
@@ -5,6 +5,7 @@
 	flex-direction: column;
 	justify-content: space-between;
 	align-items: center;
+	height: 37px; // Prevent layout shifts
 
 	.pattern-menu {
 		width: 100%;

--- a/public_html/wp-content/themes/pattern-directory/src/components/category-context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/category-context-bar/index.js
@@ -16,8 +16,8 @@ import { store as patternStore } from '../../store';
 
 function CategoryContextBar() {
 	const { path } = useRoute();
-	const [ height, setHeight ] = useState( 0 );
-	const [ message, setMessage ] = useState();
+	const [ height, setHeight ] = useState();
+	const [ message, setMessage ] = useState( getLoadingMessage( 'All' ) );
 	const [ context ] = useState( {
 		title: '',
 		links: [],


### PR DESCRIPTION
Related to #240.

This PR changes the way the `CategoryContextBar` renders on load and its associated animations.

I think this can maybe be improved further but it's hard to figure it out until we get more of the loading pieces together. I think this is an immediate low risk improvement.

### Screenshots
| Before | After |
| --- | --- |
| ![](https://d.pr/i/5dNdm1.gif) | ![](https://d.pr/i/LKfCvL.gif) |

### How to test the changes in this Pull Request:

1. Visit `/`
2. Click categories
3. Expect loading context to exist.

<!-- If you can, add the appropriate [Component] label(s). -->
