### PR TITLE
CPT: Update the filter name for block types to fix warning.

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -12,6 +12,7 @@
 
 namespace WordPressdotorg\Pattern_Creator;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+use WP_Block_Editor_Context;
 
 const AUTOSAVE_INTERVAL = 30;
 const IS_EDIT_VAR = 'edit-pattern';
@@ -104,9 +105,11 @@ function enqueue_assets() {
 		$post    = get_post( $post_id );
 	}
 
+	$block_editor_context = new WP_Block_Editor_Context( array( 'post' => $post ) );
+
 	$settings = array(
 		'alignWide'                            => true, // Support wide patterns.
-		'allowedBlockTypes'                    => apply_filters( 'allowed_block_types', true, $post ),
+		'allowedBlockTypes'                    => apply_filters( 'allowed_block_types_all', true, $block_editor_context ),
 		'disablePostFormats'                   => true,
 		'enableCustomFields'                   => false,
 		'titlePlaceholder'                     => __( 'Add pattern title', 'wporg-patterns' ),

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -11,7 +11,7 @@ add_action( 'init', __NAMESPACE__ . '\register_post_type_data' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_fields' );
 add_action( 'init', __NAMESPACE__ . '\register_post_statuses' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_assets' );
-add_filter( 'allowed_block_types', __NAMESPACE__ . '\remove_disallowed_blocks', 10, 2 );
+add_filter( 'allowed_block_types_all', __NAMESPACE__ . '\remove_disallowed_blocks', 10, 2 );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\disable_block_directory', 0 );
 add_filter( 'rest_' . POST_TYPE . '_collection_params', __NAMESPACE__ . '\filter_patterns_collection_params' );
 add_filter( 'rest_' . POST_TYPE . '_query', __NAMESPACE__ . '\filter_patterns_rest_query', 10, 2 );
@@ -406,12 +406,12 @@ function enqueue_editor_assets() {
 /**
  * Restrict the set of blocks allowed in block patterns.
  *
- * @param bool|array $allowed_block_types Array of block type slugs, or boolean to enable/disable all.
- * @param WP_Post    $post                The post resource data.
+ * @param bool|array              $allowed_block_types  Array of block type slugs, or boolean to enable/disable all.
+ * @param WP_Block_Editor_Context $block_editor_context The post resource data.
  *
  * @return bool|array A (possibly) filtered list of block types.
  */
-function remove_disallowed_blocks( $allowed_block_types, $post ) {
+function remove_disallowed_blocks( $allowed_block_types, $block_editor_context ) {
 	$disallowed_block_types = array(
 		// Remove blocks that don't make sense in Block Patterns
 		'core/freeform', // Classic block
@@ -421,7 +421,7 @@ function remove_disallowed_blocks( $allowed_block_types, $post ) {
 		'core/block', // Reusable blocks
 		'core/shortcode',
 	);
-	if ( POST_TYPE === $post->post_type ) {
+	if ( isset( $block_editor_context->post ) && POST_TYPE === $block_editor_context->post->post_type ) {
 		// This can be true if all block types are allowed, so to filter them we
 		// need to get the list of all registered blocks first.
 		if ( true === $allowed_block_types ) {


### PR DESCRIPTION
The filter name has changed from `allowed_block_types` to `allowed_block_types_all`, and the second parameter is now the block context, which includes the current post (if it's a post editor). This update changes the filter we're using to account for that.

Fixes #246

### Screenshots

No visual change.

### How to test the changes in this Pull Request:

1. Have `WP_DEBUG_DISPLAY` set to true on a local env
2. Try to add a pattern in wp-admin
3. It should work fine, no deprecation notice in the header
