### PR TITLE
Theme: Update Pattern Grid menu loading

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
@@ -15,10 +15,19 @@
 		width: calc(100% - #{$gutter-default * 2});
 	}
 
+	.pattern-skeleton__container {
+		flex-wrap: wrap;
+		height: 2.3125rem;
+		align-items: center;
+
+		span {
+			margin-bottom: 0.25rem;
+		}
+	}
+
 	@media only screen and ( min-width: #{$breakpoint-medium + 1} ) {
 		margin: $gutter-default;
 		flex-direction: row;
-		height: 37px; // Stop Layout Shift
 
 		> form {
 			margin: 0;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
@@ -17,6 +17,7 @@
 
 	.pattern-skeleton__container {
 		flex-wrap: wrap;
+		// match nav item text: line height (1.5) * font size (0.875rem) + 1rem of vertical padding.
 		height: 2.3125rem;
 		align-items: center;
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid-menu.scss
@@ -18,6 +18,7 @@
 	@media only screen and ( min-width: #{$breakpoint-medium + 1} ) {
 		margin: $gutter-default;
 		flex-direction: row;
+		height: 37px; // Stop Layout Shift
 
 		> form {
 			margin: 0;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-menu.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-menu.scss
@@ -69,21 +69,4 @@
 		}
 		// End
 	}
-
-	&.is-loading {
-		height: 24px;
-		position: relative;
-	}
-
-	&.is-loading::after {
-		content: "";
-		position: absolute;
-		background: $color-gray-light-200;
-		border-radius: 4px;
-		width: 80%;
-		height: 24px;
-		left: 0;
-		top: calc(50% - 12px);
-		transition: none;
-	}
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/menu/default.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/menu/default.js
@@ -8,20 +8,24 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import MenuSkeleton from './menu-skeleton';
+
 const DefaultMenu = ( { current, isLoading, label = __( 'Main Menu', 'wporg-patterns' ), onClick, options } ) => {
-	if ( ! isLoading && ! options.length ) {
+	if ( isLoading ) {
+		return <MenuSkeleton />;
+	}
+
+	if ( ! options.length ) {
 		return null;
 	}
 
 	return (
 		<>
 			<h2 className="screen-reader-text">{ label }</h2>
-			<ul
-				className={ classnames( {
-					'pattern-menu': true,
-					'is-loading': isLoading,
-				} ) }
-			>
+			<ul className="pattern-menu">
 				{ options.map( ( i ) => (
 					<li key={ i.value }>
 						<a

--- a/public_html/wp-content/themes/pattern-directory/src/components/menu/menu-skeleton.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/menu/menu-skeleton.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { Skeleton, SkeletonWrapper } from '../skeleton';
+
+/**
+ * Module constants
+ */
+const PLACEHOLDER_COUNT = 7;
+
+const MennuSkeleton = () => {
+	return (
+		<SkeletonWrapper style={ { flexDirection: 'row' } }>
+			{ Array( PLACEHOLDER_COUNT )
+				.fill()
+				.map( ( val, idx ) => (
+					<Skeleton key={ idx } height="1.25rem" width="5rem" marginRight="1rem" />
+				) ) }
+		</SkeletonWrapper>
+	);
+};
+
+export default MennuSkeleton;

--- a/public_html/wp-content/themes/pattern-directory/src/components/menu/menu-skeleton.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/menu/menu-skeleton.js
@@ -8,7 +8,7 @@ import { Skeleton, SkeletonWrapper } from '../skeleton';
  */
 const PLACEHOLDER_COUNT = 7;
 
-const MennuSkeleton = () => {
+const MenuSkeleton = () => {
 	return (
 		<SkeletonWrapper style={ { flexDirection: 'row' } }>
 			{ Array( PLACEHOLDER_COUNT )
@@ -20,4 +20,4 @@ const MennuSkeleton = () => {
 	);
 };
 
-export default MennuSkeleton;
+export default MenuSkeleton;


### PR DESCRIPTION
This PR is the last in a series to add loading to the pattern grid and fixes the "jumping" nature of the page. This PR updates the pattern category menu to use the newly introduced loading skeleton and explicitly sets the height to avoid layout shifts on larger displays.

Fixes #101, Related #188

### Screenshots
| Before | After | 
| --- | --- |
| ![](https://d.pr/i/N47tYL.gif) |   ![](https://d.pr/i/CDqsWf.gif)  |
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Visit `/`
2. Observe the menu loading
3. Click on a category
4. Reload the page
5. Expect to see the same experience as seen in the second step.

