### PR TITLE
Theme: Update copy and fix i18n issues

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/category-context-bar/messaging.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/category-context-bar/messaging.js
@@ -35,7 +35,7 @@ export const getDefaultMessage = ( count, categoryName ) => {
 export const getLoadingMessage = ( categoryName ) => {
 	return createInterpolateElement(
 		sprintf(
-			/* translators: %1$d: number of patterns. %2$s category name. */
+			/* translators: %s category name. */
 			__( 'Loading <b>%s</b> patterns.', 'wporg-patterns' ),
 			categoryName,
 			'wporg-patterns'

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
@@ -33,7 +33,7 @@ const CopyGuide = ( { onFinish } ) => {
 									</h3>
 									<p>
 										{ __(
-											'Patterns are really just text. And, just like you can copy and paste text, you can copy and paste patterns. Its really easy!',
+											'Patterns are really just text. And, just like you can copy and paste text, you can copy and paste patterns. It's really easy!',
 											'wporg-patterns'
 										) }
 									</p>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
@@ -58,7 +58,7 @@ const CopyGuide = ( { onFinish } ) => {
 											<p>
 												{ createInterpolateElement(
 													__(
-														'Paste the contents of your clipboard by pressing both the <kbd>⌘</kbd> and <kbd>v</kbd> keys, or right-clicking and choose "Paste" from the menu.',
+														'Paste the contents of your clipboard by holding down <kbd>ctrl</kbd> control (Windows) or <kbd>⌘</kbd> command (Mac) and pressing the <kbd>v</kbd> key, or right-clicking and choose “Paste” from the menu.',
 														'wporg-patterns'
 													),
 													{

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
@@ -33,7 +33,7 @@ const CopyGuide = ( { onFinish } ) => {
 									</h3>
 									<p>
 										{ __(
-											'Patterns are really just text. And, just like you can copy and paste text, you can copy and paste patterns. It's really easy!',
+											'Patterns are really just text. And, just like you can copy and paste text, you can copy and paste patterns. It’s really easy!',
 											'wporg-patterns'
 										) }
 									</p>


### PR DESCRIPTION
Some copy updates in the copy pattern instructions modal. Fix a typo - add an apostrophe - in "It's really easy", and add windows directions to the 3rd step. Also fixes the translator note for the category message string.

Fixes #262, fixes #261, fixes #259

Props @nextdoorpanda for the initial fix in the copy instructions, @vlad-timotei for reporting the rest.

### Screenshots

<img width="371" alt="Screen Shot 2021-07-02 at 1 21 58 PM" src="https://user-images.githubusercontent.com/541093/124309284-7dca6600-db38-11eb-8a96-4953b2efa65c.png">

### How to test the changes in this Pull Request:

1. View a single pattern, click copy
2. In the success message, click learn more to see the modal
3. The copy in the modal should make sense
