### PR TITLE
Replace backtick quotes

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/plugins/viewport-header-control.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/plugins/viewport-header-control.js
@@ -114,7 +114,7 @@ const ViewportHeaderControl = () => {
 				icon={ null }
 				text={ sprintf(
 					/* translators: %s viewport width as css, ie: 100% */
-					__( `Width (%spx)`, 'wporg-patterns' ),
+					__( 'Width (%spx)', 'wporg-patterns' ),
 					viewportWidth
 				) }
 				popoverProps={ {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #260
See [this issue as well](https://github.com/wp-cli/i18n-command/issues/257)

This replaces backquotes with single quotes to allow current version of wp-cli i18n command to correctly extract the string. Also  following the standards of not using template literals in this case. 
