### PR TITLE
Pattern Previews: Use less-opinionated base theme

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -90,11 +90,7 @@ function enqueue_assets() {
  * See https://github.com/WordPress/gutenberg/blob/6ad2a433769a4514fc52083e97aa47a0bc9edf07/lib/client-assets.php#L710
  */
 function generate_block_editor_styles_html() {
-	$handles = array(
-		'wp-block-editor',
-		'wp-block-library',
-		'wp-edit-blocks',
-	);
+	$handles = array( 'wp-block-library' );
 
 	$block_registry = \WP_Block_Type_Registry::get_instance();
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
@@ -9,7 +9,7 @@ import { useMergeRefs } from '@wordpress/compose';
  * The copy was made to remove `tabIndex` and to add the ability to set the iframe's `title`.
  */
 
-const BODY_CLASS_NAME = 'editor-styles-wrapper';
+const BODY_CLASS_NAME = 'pattern-wrapper';
 
 /**
  * Bubbles some event types (keydown, keypress, and dragover) to parent document
@@ -91,17 +91,19 @@ function setHead( doc, head ) {
 }
 
 function Iframe(
-	{ contentRef, children, head, headHTML, bodyStyle = '', themeSlug = 'twentynineteen', ...props },
+	{ contentRef, children, head, headHTML, bodyStyle = '', themeSlug = 'twentytwentyone', ...props },
 	ref
 ) {
 	const [ iframeDocument, setIframeDocument ] = useState();
 
+	headHTML += `<link rel="stylesheet" href="https://wp-themes.com/wp-content/themes/${ themeSlug }/style.css" media="all" />`;
 	headHTML += `<style>
     body {
         display: flex;
         min-height: 100vh;
         align-items: center;
         justify-content: center;
+        background-color: white;
     }
     .${ BODY_CLASS_NAME } {
         padding: 0;
@@ -113,8 +115,6 @@ function Iframe(
         pointer-events: none;
     }
     </style>`;
-
-	headHTML += `<link rel="stylesheet" href="https://wp-themes.com/wp-content/themes/${ themeSlug }/style.css" media="all" />`;
 
 	const setRef = useCallback( ( node ) => {
 		if ( ! node ) {


### PR DESCRIPTION
Fixes #143 - Switch the pattern preview theme styles to use Twenty Twenty-One with a white background as the base CSS. This also removes some other CSS dependencies that are not necessary in this context (non-editable). This brings the number of files loaded per each iframe down to two - `wp-block-library` and the theme styles (see #255).

### Screenshots

![patterns](https://user-images.githubusercontent.com/541093/124490950-b3fa2680-dd80-11eb-8cfe-263515a9a625.png)
![pattern-2](https://user-images.githubusercontent.com/541093/124490951-b492bd00-dd80-11eb-817d-83df3ef2e96f.png)
![pattern-1](https://user-images.githubusercontent.com/541093/124490952-b52b5380-dd80-11eb-9666-8b1ecf4009bd.png)

### How to test the changes in this Pull Request:

1. Check out branch and build with `yarn workspaces run build`, or just look at the screenshots ^
2. View the pattern previews in grid mode
3. They should look as expected - headings are plain sans-serif, no top border. Body text is also sans-serif. Background should be white (unless the pattern uses a background).
4. View single pattern previews
5. They should look as expected, see above
