### PR TITLE
Theme: Add RTL build step, fix issues in RTL sites

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/Gruntfile.js
+++ b/public_html/wp-content/themes/pattern-directory/Gruntfile.js
@@ -23,6 +23,42 @@ module.exports = function ( grunt ) {
 		return files;
 	};
 
+	const rtlcssPluginSwapDashiconArrows = {
+		name: 'swap-dashicons-left-right-arrows',
+		priority: 10,
+		directives: {
+			control: {},
+			value: [],
+		},
+		processors: [
+			{
+				expr: /content/im,
+				action: function ( prop, value ) {
+					if ( value === '"\\f141"' ) {
+						// replace dashicons-arrow-left with -right.
+						value = '"\\f139"';
+					} else if ( value === '"\\f340"' ) {
+						// replace dashicons-arrow-left-alt with -right-alt.
+						value = '"\\f344"';
+					} else if ( value === '"\\f341"' ) {
+						// replace dashicons-arrow-left-alt2 with -right-alt2.
+						value = '"\\f345"';
+					} else if ( value === '"\\f139"' ) {
+						// replace dashicons-arrow-right with -left.
+						value = '"\\f141"';
+					} else if ( value === '"\\f344"' ) {
+						// replace dashicons-arrow-right-alt with -left-alt.
+						value = '"\\f340"';
+					} else if ( value === '"\\f345"' ) {
+						// replace dashicons-arrow-right-alt2 with -left-alt2.
+						value = '"\\f341"';
+					}
+					return { prop, value };
+				},
+			},
+		],
+	};
+
 	grunt.initConfig( {
 		postcss: {
 			options: {
@@ -42,7 +78,7 @@ module.exports = function ( grunt ) {
 			},
 			rtl: {
 				options: {
-					processors: [ require( 'rtlcss' )() ],
+					processors: [ require( 'rtlcss' )( null, [ rtlcssPluginSwapDashiconArrows ] ) ],
 				},
 				src: 'css/style.css',
 				dest: 'css/style-rtl.css',

--- a/public_html/wp-content/themes/pattern-directory/Gruntfile.js
+++ b/public_html/wp-content/themes/pattern-directory/Gruntfile.js
@@ -1,4 +1,4 @@
-module.exports = function( grunt ) {
+module.exports = function ( grunt ) {
 	const isChild = 'wporg' !== grunt.file.readJSON( 'package.json' ).name;
 	const defaultWebpackConfig = require( '@wordpress/scripts/config/webpack.config' );
 
@@ -6,7 +6,7 @@ module.exports = function( grunt ) {
 		const files = {};
 		const components = [ 'settings', 'tools', 'generic', 'base', 'objects', 'components', 'utilities' ];
 
-		components.forEach( function( component ) {
+		components.forEach( function ( component ) {
 			const paths = [
 				'../wporg/css/' + component + '/**/*.scss',
 				'!../wporg/css/' + component + '/_' + component + '.scss',
@@ -39,6 +39,13 @@ module.exports = function( grunt ) {
 			},
 			dist: {
 				src: 'css/style.css',
+			},
+			rtl: {
+				options: {
+					processors: [ require( 'rtlcss' )() ],
+				},
+				src: 'css/style.css',
+				dest: 'css/style-rtl.css',
 			},
 		},
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
@@ -53,10 +53,14 @@
 }
 
 .pattern-preview__drag-handle.is-left {
+
+	/*!rtl:ignore*/
 	left: 0;
 }
 
 .pattern-preview__drag-handle.is-right {
+
+	/*!rtl:ignore*/
 	right: 0;
 }
 

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -55,6 +55,7 @@
 		"lodash": "4.17.21",
 		"postcss": "8.3.0",
 		"react-use-gesture": "9.1.3",
+		"rtlcss": "3.2.1",
 		"sass": "1.34.1"
 	},
 	"eslintConfig": {

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { isRTL } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
 
 /**
@@ -40,7 +41,7 @@ function PatternThumbnail( { className, html } ) {
 		maxWidth: 'none',
 		height: `${ getCardFrameHeight( VIEWPORT_WIDTH ) }px`,
 		transform: `scale(${ frameScale })`,
-		transformOrigin: 'top left',
+		transformOrigin: isRTL() ? 'top right' : 'top left',
 		pointerEvents: 'none',
 	};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7076,6 +7076,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 findup-sync@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
@@ -9353,6 +9361,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -10511,6 +10526,13 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
+
 p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
@@ -11190,6 +11212,15 @@ postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^8.2.4:
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.5.tgz#982216b113412bc20a86289e91eb994952a5b709"
+  integrity sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==
+  dependencies:
+    colorette "^1.2.2"
+    nanoid "^3.1.23"
+    source-map-js "^0.6.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -12131,6 +12162,17 @@ rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
+
+rtlcss@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/rtlcss/-/rtlcss-3.2.1.tgz#654e55ea2f46991f9738d952ba77ba0aa94a670d"
+  integrity sha512-S9bh35JXwPIhfun7nFu/HjlNrwELL5nvTJqA1suLfbnqY/mauIL5sBkrJNHziVppX9PA2rJ7NV82+RtzB71mJA==
+  dependencies:
+    chalk "^4.1.0"
+    find-up "^5.0.0"
+    mkdirp "^1.0.4"
+    postcss "^8.2.4"
+    strip-json-comments "^3.1.1"
 
 run-async@^2.4.0:
   version "2.4.1"


### PR DESCRIPTION
Fixes #257 — this ports over the `rtlcss` task from [the `wporg` parent theme](https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/themes/pub/wporg/Gruntfile.js#L89), but switches from the `grunt-rtlcss` wrapper to using `rtlcss` in postcss. The version of `rtlcss` in `grunt-rtlcss` is outdated (2.x), while using `rtlcss` as a postcss processor means we can stick with `rtlcss` 3.x (and PostCSS 8.x).

This also ports over the dashicons arrow-swapping code, but it isn't necessary for the site right now - I only added it for consistency with the other sites.

In addition to generating the RTL CSS, I fixed some display issues in RTL

- The iframe alignment needs to use `top right` when the site is RTL
- The drag handles should not be swapped, otherwise the drag direction is reversed

We could use a different image for RTL, since the X lines up well on LTR, but not here. I don't think we have a good way to _translate_ this image, but at least swapping LTR/RTL would be nice.

<img width="424" alt="rtl-ar-modal-img" src="https://user-images.githubusercontent.com/541093/124501128-02162680-dd8f-11eb-9952-1b143fb4d864.png">

This left-aligned modal title seems to be a gutenberg bug.

<img width="450" alt="rtl-ar-modal-x" src="https://user-images.githubusercontent.com/541093/124501129-02aebd00-dd8f-11eb-851a-dd5c0ff762f6.png">

### Screenshots

![rtl-ar-single](https://user-images.githubusercontent.com/541093/124501067-e6ab1b80-dd8e-11eb-9fca-e8813b1afb0b.png)
![rtl-ar-grid](https://user-images.githubusercontent.com/541093/124501071-e743b200-dd8e-11eb-965c-3aaf4cfdf4db.png)

### How to test the changes in this Pull Request:

1. Check out branch and build with `yarn && yarn workspaces run build` (note the `yarn`, need to install new deps)
2. Switch your site to an RTL language, ex Arabic or Hebrew
3. Navigate through the frontend, it should have style, and nothing should look broken

Note, this doesn't add RTL support to the pattern creator, so that's still a bit janky - can be done post-launch, when we restart work on the creator.
