### PR TITLE
Theme: Fix missing "page 3" link in pagination

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/utils/get-pagination-list.js
+++ b/public_html/wp-content/themes/pattern-directory/src/utils/get-pagination-list.js
@@ -18,7 +18,7 @@ export default function getPaginationList( length, current = 1 ) {
 		return range;
 	}
 	list.push( ...range.slice( 0, 2 ) );
-	if ( current > 2 && current <= length - 1 ) {
+	if ( current >= 2 && current <= length - 1 ) {
 		list.push( ...range.slice( current - 2, current + 1 ) );
 	}
 	list.push( ...range.slice( -2 ) );

--- a/public_html/wp-content/themes/pattern-directory/src/utils/test/get-pagination-list.js
+++ b/public_html/wp-content/themes/pattern-directory/src/utils/test/get-pagination-list.js
@@ -15,7 +15,7 @@ describe( 'getPageList', () => {
 
 	it( 'should return complex lists', async () => {
 		expect( getPaginationList( 10, 1 ) ).toEqual( [ 1, 2, '…', 9, 10 ] );
-		expect( getPaginationList( 10, 2 ) ).toEqual( [ 1, 2, '…', 9, 10 ] );
+		expect( getPaginationList( 10, 2 ) ).toEqual( [ 1, 2, 3, '…', 9, 10 ] );
 		expect( getPaginationList( 10, 3 ) ).toEqual( [ 1, 2, 3, 4, '…', 9, 10 ] );
 		expect( getPaginationList( 10, 4 ) ).toEqual( [ 1, 2, 3, 4, 5, '…', 9, 10 ] );
 		expect( getPaginationList( 10, 5 ) ).toEqual( [ 1, 2, '…', 4, 5, 6, '…', 9, 10 ] );


### PR DESCRIPTION
Fixes #270 - There was a logic error in the pagination code, which prevented the "page 3" link from showing up when you're on the second page like it should.

### Screenshots

<img width="479" alt="Screen Shot 2021-07-06 at 5 59 41 PM" src="https://user-images.githubusercontent.com/541093/124671745-f22c3e80-de83-11eb-9f71-8cec9fffcb74.png">

### How to test the changes in this Pull Request:

1. Go to a list view with many patterns
2. Click on the second page
3. You should see a link to the 3rd page
