### PR TITLE
Theme: Fix drag handle precision and minimum value

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/drag-handle.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/drag-handle.js
@@ -8,11 +8,13 @@ import { useDrag } from 'react-use-gesture';
  */
 import { LEFT, RIGHT } from '@wordpress/keycodes';
 
-function DragHandle( { label, className, onDragChange, direction = 'left', ...props } ) {
+function DragHandle( { label, className, onDragChange, onDragEnd, direction = 'left', ...props } ) {
 	const dragGestures = useDrag( ( { delta, dragging } ) => {
 		const multiplier = direction === 'left' ? -2 : 2;
 		if ( dragging ) {
-			onDragChange( delta[ 0 ] * multiplier, 'mouse' );
+			onDragChange( delta[ 0 ] * multiplier );
+		} else {
+			onDragEnd();
 		}
 	} );
 
@@ -20,12 +22,12 @@ function DragHandle( { label, className, onDragChange, direction = 'left', ...pr
 		const { keyCode } = event;
 
 		if ( ( direction === 'left' && keyCode === LEFT ) || ( direction === 'right' && keyCode === RIGHT ) ) {
-			onDragChange( 20, 'keyboard' );
+			onDragChange( 20 );
 		} else if (
 			( direction === 'left' && keyCode === RIGHT ) ||
 			( direction === 'right' && keyCode === LEFT )
 		) {
-			onDragChange( -20, 'keyboard' );
+			onDragChange( -20 );
 		}
 	};
 
@@ -36,6 +38,7 @@ function DragHandle( { label, className, onDragChange, direction = 'left', ...pr
 				aria-label={ label }
 				{ ...props }
 				onKeyDown={ onKeyDown }
+				onKeyUp={ onDragEnd }
 				{ ...dragGestures() }
 			/>
 		</div>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/drag-handle.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/drag-handle.js
@@ -12,7 +12,7 @@ function DragHandle( { label, className, onDragChange, direction = 'left', ...pr
 	const dragGestures = useDrag( ( { delta, dragging } ) => {
 		const multiplier = direction === 'left' ? -2 : 2;
 		if ( dragging ) {
-			onDragChange( delta[ 0 ] * multiplier );
+			onDragChange( delta[ 0 ] * multiplier, 'mouse' );
 		}
 	} );
 
@@ -20,12 +20,12 @@ function DragHandle( { label, className, onDragChange, direction = 'left', ...pr
 		const { keyCode } = event;
 
 		if ( ( direction === 'left' && keyCode === LEFT ) || ( direction === 'right' && keyCode === RIGHT ) ) {
-			onDragChange( 20 );
+			onDragChange( 20, 'keyboard' );
 		} else if (
 			( direction === 'left' && keyCode === RIGHT ) ||
 			( direction === 'right' && keyCode === LEFT )
 		) {
-			onDragChange( -20 );
+			onDragChange( -20, 'keyboard' );
 		}
 	};
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -24,10 +24,9 @@ function PatternPreview( { blockContent } ) {
 
 	const instanceId = useInstanceId( PatternPreview );
 	const [ width, setWidth ] = useState( window.innerWidth < INITIAL_WIDTH ? window.innerWidth : INITIAL_WIDTH );
-	const onDragChange = useCallback(
-		( delta ) => setWidth( ( value ) => Math.max( Math.floor( value + delta ), MIN_PREVIEW_WIDTH ) ),
-		[ setWidth ]
-	);
+	const onDragChange = useCallback( ( delta ) => setWidth( ( value ) => Math.floor( value + delta ) ), [
+		setWidth,
+	] );
 
 	const availableWidths = useMemo( () => {
 		// Less than 480 wide.
@@ -59,10 +58,11 @@ function PatternPreview( { blockContent } ) {
 
 	let currentOpt = false;
 	if ( ! availableWidths.some( ( opt ) => opt.value === width ) ) {
+		const displayWidth = Math.max( width, MIN_PREVIEW_WIDTH );
 		currentOpt = {
 			/* translators: %s is the width in pixels, ex 600. */
-			label: sprintf( __( 'Current (%spx)', 'wporg-patterns' ), width ),
-			value: width,
+			label: sprintf( __( 'Current (%spx)', 'wporg-patterns' ), displayWidth ),
+			value: displayWidth,
 		};
 	}
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -24,7 +24,19 @@ function PatternPreview( { blockContent } ) {
 
 	const instanceId = useInstanceId( PatternPreview );
 	const [ width, setWidth ] = useState( window.innerWidth < INITIAL_WIDTH ? window.innerWidth : INITIAL_WIDTH );
-	const onDragChange = useCallback( ( delta ) => setWidth( ( value ) => value + delta ), [ setWidth ] );
+	const onDragChange = useCallback(
+		( delta, source ) =>
+			setWidth( ( value ) => {
+				const newVal = value + delta;
+
+				if ( source === 'keyboard' && delta > 0 ) {
+					return Math.max( newVal, MIN_PREVIEW_WIDTH );
+				}
+
+				return newVal;
+			} ),
+		[ setWidth ]
+	);
 
 	const availableWidths = useMemo( () => {
 		// Less than 480 wide.

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -24,19 +24,13 @@ function PatternPreview( { blockContent } ) {
 
 	const instanceId = useInstanceId( PatternPreview );
 	const [ width, setWidth ] = useState( window.innerWidth < INITIAL_WIDTH ? window.innerWidth : INITIAL_WIDTH );
-	const onDragChange = useCallback(
-		( delta, source ) =>
-			setWidth( ( value ) => {
-				const newVal = value + delta;
+	const onDragChange = useCallback( ( delta ) => setWidth( ( value ) => value + delta ), [ setWidth ] );
 
-				if ( source === 'keyboard' && delta > 0 ) {
-					return Math.max( newVal, MIN_PREVIEW_WIDTH );
-				}
-
-				return newVal;
-			} ),
-		[ setWidth ]
-	);
+	const onDragEnd = () => {
+		if ( width < MIN_PREVIEW_WIDTH ) {
+			setWidth( MIN_PREVIEW_WIDTH );
+		}
+	};
 
 	const availableWidths = useMemo( () => {
 		// Less than 480 wide.
@@ -94,6 +88,7 @@ function PatternPreview( { blockContent } ) {
 					label={ __( 'Drag to resize', 'wporg-patterns' ) }
 					className="is-left"
 					onDragChange={ onDragChange }
+					onDragEnd={ onDragEnd }
 					direction="left"
 					aria-describedby={ `pattern-preview__resize-help-${ instanceId }` }
 				/>
@@ -102,6 +97,7 @@ function PatternPreview( { blockContent } ) {
 					label={ __( 'Drag to resize', 'wporg-patterns' ) }
 					className="is-right"
 					onDragChange={ onDragChange }
+					onDragEnd={ onDragEnd }
 					direction="right"
 					aria-describedby={ `pattern-preview__resize-help-${ instanceId }` }
 				/>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -15,7 +15,7 @@ import DragHandle from './drag-handle';
 /* eslint-disable jsx-a11y/anchor-is-valid -- These are just placeholders. */
 
 const INITIAL_WIDTH = 960;
-const MIN_PREVIEW_WIDTH = 320;
+const MIN_PREVIEW_WIDTH = 280;
 
 function PatternPreview( { blockContent } ) {
 	const showViewportControl = useViewportMatch( 'mobile', '>=' );
@@ -24,9 +24,7 @@ function PatternPreview( { blockContent } ) {
 
 	const instanceId = useInstanceId( PatternPreview );
 	const [ width, setWidth ] = useState( window.innerWidth < INITIAL_WIDTH ? window.innerWidth : INITIAL_WIDTH );
-	const onDragChange = useCallback( ( delta ) => setWidth( ( value ) => Math.floor( value + delta ) ), [
-		setWidth,
-	] );
+	const onDragChange = useCallback( ( delta ) => setWidth( ( value ) => value + delta ), [ setWidth ] );
 
 	const availableWidths = useMemo( () => {
 		// Less than 480 wide.
@@ -58,7 +56,7 @@ function PatternPreview( { blockContent } ) {
 
 	let currentOpt = false;
 	if ( ! availableWidths.some( ( opt ) => opt.value === width ) ) {
-		const displayWidth = Math.max( width, MIN_PREVIEW_WIDTH );
+		const displayWidth = Math.max( Math.floor( width ), MIN_PREVIEW_WIDTH );
 		currentOpt = {
 			/* translators: %s is the width in pixels, ex 600. */
 			label: sprintf( __( 'Current (%spx)', 'wporg-patterns' ), displayWidth ),

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -15,6 +15,7 @@ import DragHandle from './drag-handle';
 /* eslint-disable jsx-a11y/anchor-is-valid -- These are just placeholders. */
 
 const INITIAL_WIDTH = 960;
+const MIN_PREVIEW_WIDTH = 320;
 
 function PatternPreview( { blockContent } ) {
 	const showViewportControl = useViewportMatch( 'mobile', '>=' );
@@ -23,7 +24,10 @@ function PatternPreview( { blockContent } ) {
 
 	const instanceId = useInstanceId( PatternPreview );
 	const [ width, setWidth ] = useState( window.innerWidth < INITIAL_WIDTH ? window.innerWidth : INITIAL_WIDTH );
-	const onDragChange = useCallback( ( delta ) => setWidth( ( value ) => value + delta ), [ setWidth ] );
+	const onDragChange = useCallback(
+		( delta ) => setWidth( ( value ) => Math.max( Math.floor( value + delta ), MIN_PREVIEW_WIDTH ) ),
+		[ setWidth ]
+	);
 
 	const availableWidths = useMemo( () => {
 		// Less than 480 wide.


### PR DESCRIPTION
This PR uses `Math.floor` to round the pixel preview value and `Math.max` to make sure the value never goes below a minimum value. I wasn't sure what the minimum value should be so I chose `320px` which is considered the narrow view and there aren't many devices that should be below that, even though patterns may be used in contexts less than the full device width. 

Alternatively, we could use `280` which appears to be the minimum size the preview window will allow. idk.

Fixes #233

### Screenshots
N/A

### How to test the changes in this Pull Request:

1. Visit any pattern
2. Drag the resize handles and expect to not see decimals.
3. Drag the resize handles downwards and expect to not get below `320px`.

