### PR TITLE
Directory: Generate translatable strings for taxonomy terms that appear in the UI

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,0 +1,34 @@
+name: I18n
+
+on:
+  schedule:
+    - cron: '0 6,18 * * *'
+
+jobs:
+  translation-strings:
+    name: Translation strings
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Run translation script
+        run: php ./bin/i18n.php
+
+      - name: Commit and push
+        # Using a specific hash here instead of a tagged version, for risk mitigation, since this action modifies our repo.
+        uses: actions-js/push@4decc2887d2770f29177082be3c8b04d342f5b64
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: trunk
+          message: Update translation strings

--- a/bin/i18n.php
+++ b/bin/i18n.php
@@ -193,7 +193,7 @@ function main() {
 	}
 
 	$path = dirname( __DIR__ ) . '/extra';
-	if ( ! is_readable( $path ) ) {
+	if ( ! is_writeable( $path ) ) {
 		mkdir( $path );
 	}
 

--- a/bin/i18n.php
+++ b/bin/i18n.php
@@ -67,8 +67,8 @@ function get_taxonomy_terms( $taxonomy ) {
 	while ( $page <= $total_pages ) {
 		if ( 'cli' === php_sapi_name() ) {
 			echo sprintf(
-				"Page %d... ",
-				$page
+				'Page %d... ',
+				$page // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			);
 		}
 
@@ -152,7 +152,7 @@ function main() {
 		if ( 'cli' === php_sapi_name() ) {
 			echo sprintf(
 				'%s... ',
-				$taxonomy['name']
+				$taxonomy['name'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			);
 		}
 

--- a/bin/i18n.php
+++ b/bin/i18n.php
@@ -1,0 +1,223 @@
+#!/usr/bin/php
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Bin\I18n;
+
+use Requests;
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+const ENDPOINT_BASE    = 'https://wordpress.org/patterns/wp-json/wp/v2/';
+const VALID_TAXONOMIES = array(
+	'wporg-pattern-category',
+	'wporg-pattern-flag-reason',
+);
+
+/**
+ * Get data about taxonomies from a REST API endpoint.
+ *
+ * @return array
+ */
+function get_taxonomies() {
+	$endpoint = ENDPOINT_BASE . 'taxonomies';
+
+	$response = Requests::get( $endpoint );
+
+	if ( 200 !== $response->status_code ) {
+		die( 'Could not retrieve taxonomy data.' );
+	}
+
+	$taxonomies = json_decode( $response->body, true );
+
+	if ( ! is_array( $taxonomies ) ) {
+		die( 'Taxonomies request returned unexpected data.' );
+	}
+
+	if ( defined( __NAMESPACE__ . '\VALID_TAXONOMIES' ) ) {
+		$taxonomies = array_filter(
+			$taxonomies,
+			function( $tax ) {
+				return in_array( $tax['slug'], VALID_TAXONOMIES, true );
+			}
+		);
+	}
+
+	return $taxonomies;
+}
+
+/**
+ * Get data about a taxonomy's terms from a REST API endpoint.
+ *
+ * @param array $taxonomy
+ *
+ * @return array
+ */
+function get_taxonomy_terms( $taxonomy ) {
+	$endpoint    = ENDPOINT_BASE . $taxonomy['rest_base'] . '?per_page=100';
+	$terms       = array();
+	$page        = 1;
+	$total_pages = 1;
+
+	$response = Requests::get( $endpoint );
+
+	if ( isset( $response->headers['x-wp-totalpages'] ) ) {
+		$total_pages = intval( $response->headers['x-wp-totalpages'] );
+	}
+
+	while ( $page <= $total_pages ) {
+		if ( 'cli' === php_sapi_name() ) {
+			echo sprintf(
+				"Page %d... ",
+				$page
+			);
+		}
+
+		if ( 200 !== $response->status_code ) {
+			die( sprintf(
+				'Could not retrieve terms for %s.',
+				$taxonomy['slug'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			) );
+		}
+
+		$more_terms = json_decode( $response->body, true );
+
+		if ( ! is_array( $terms ) ) {
+			die( sprintf(
+				'Terms request for %s returned unexpected data.',
+				$taxonomy['slug'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			) );
+		}
+
+		$terms = array_merge( $terms, $more_terms );
+
+		$links = array();
+		if ( isset( $response->headers['link'] ) ) {
+			$links = parse_link_header( $response->headers['link'] );
+		}
+
+		if ( ! empty( $links['next'] ) ) {
+			$response = Requests::get( $links['next'] );
+		}
+
+		$page ++;
+	}
+
+	return $terms;
+}
+
+/**
+ * Parse a link header from a WP REST API response into an array of prev/next URLs.
+ *
+ * @param string $link_header
+ *
+ * @return array Associative array of links, with possible keys of next and prev, values are URLs.
+ */
+function parse_link_header( $link_header ) {
+	$links = explode( ',', $link_header );
+
+	return array_reduce(
+		$links,
+		function( $carry, $item ) {
+			$split = explode( ';', trim( $item ) );
+			preg_match( '|<([^<>]+)>|', $split[0], $url );
+			preg_match( '|rel="([^"]+)"|', $split[1], $rel );
+
+			if ( ! empty( $url[1] ) && ! empty( $rel[1] ) ) {
+				$carry[ $rel[1] ] = filter_var( $url[1], FILTER_VALIDATE_URL );
+			}
+
+			return $carry;
+		},
+		array()
+	);
+}
+
+/**
+ * Run the script.
+ */
+function main() {
+	if ( 'cli' === php_sapi_name() ) {
+		echo "\n";
+		echo "Retrieving taxonomies...\n";
+	}
+
+	$taxonomies = get_taxonomies();
+
+	if ( 'cli' === php_sapi_name() ) {
+		echo "Retrieving terms...\n";
+	}
+
+	$terms_by_tax = array();
+	foreach ( $taxonomies as $taxonomy ) {
+		if ( 'cli' === php_sapi_name() ) {
+			echo sprintf(
+				'%s... ',
+				$taxonomy['name']
+			);
+		}
+
+		$terms = get_taxonomy_terms( $taxonomy );
+
+		if ( 'cli' === php_sapi_name() ) {
+			echo "\n";
+		}
+
+		if ( count( $terms ) > 0 ) {
+			$terms_by_tax[ $taxonomy['name'] ] = $terms;
+		}
+
+		unset( $terms );
+	}
+
+	if ( 'cli' === php_sapi_name() ) {
+		echo "\n";
+	}
+
+	$file_content = '';
+	foreach ( $terms_by_tax as $tax_label => $terms ) {
+		$label = addcslashes( $tax_label, "'" );
+
+		foreach ( $terms as $term ) {
+			$name = addcslashes( $term['name'], "'" );
+			$file_content .= "_x( '{$name}', '$label term name', 'wporg-patterns' );\n";
+
+			if ( 'cli' === php_sapi_name() ) {
+				echo "$name\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+
+			if ( $term['description'] ) {
+				$description = addcslashes( $term['description'], "'" );
+				$file_content .= "_x( '{$description}', '$label term description', 'wporg-patterns' );\n";
+			}
+		}
+	}
+
+	$path = dirname( __DIR__ ) . '/extra';
+	if ( ! is_readable( $path ) ) {
+		mkdir( $path );
+	}
+
+	$file_name = 'translation-strings.php';
+	$file_header = <<<HEADER
+<?php
+/**
+ * Generated file for translation strings.
+ *
+ * Used to import additional strings into the pattern-directory translation project.
+ *
+ * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
+ * ⚠️ Do not require or include this file anywhere.
+ */
+
+
+HEADER;
+
+	file_put_contents( $path . '/' . $file_name, $file_header . $file_content );
+
+	if ( 'cli' === php_sapi_name() ) {
+		echo "\n";
+		echo "Done.\n";
+	}
+}
+
+main();

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
 		"wp-coding-standards/wpcs": "2.*",
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"wp-phpunit/wp-phpunit": "^5.4",
-		"phpunit/phpunit": "^7.5.20"
+		"phpunit/phpunit": "^7.5.20",
+		"rmccue/requests": "^1.8.1"
 	},
 	"scripts": {
 		"format": "phpcbf -p",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68539235d5fc1a6d06be1e0e6f366802",
+    "content-hash": "b4e8385f4ab7c64afa3138c5f359889f",
     "packages": [
         {
             "name": "composer/installers",
@@ -178,15 +178,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "10.9.0",
+            "version": "10.9.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/10.9.0"
+                "reference": "tags/10.9.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.10.9.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.10.9.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1278,6 +1278,66 @@
                 "source": "https://github.com/sebastianbergmann/phpunit/tree/7.5.20"
             },
             "time": "2020-01-08T08:45:45+00:00"
+        },
+        {
+            "name": "rmccue/requests",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/Requests.git",
+                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/Requests/zipball/82e6936366eac3af4d836c18b9d8c31028fe4cd5",
+                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php-parallel-lint/php-console-highlighter": "^0.5.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5",
+                "requests/test-server": "dev-master",
+                "squizlabs/php_codesniffer": "^3.5",
+                "wp-coding-standards/wpcs": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Requests": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Ryan McCue",
+                    "homepage": "http://ryanmccue.info"
+                }
+            ],
+            "description": "A HTTP library written in PHP, for human beings.",
+            "homepage": "http://github.com/WordPress/Requests",
+            "keywords": [
+                "curl",
+                "fsockopen",
+                "http",
+                "idna",
+                "ipv6",
+                "iri",
+                "sockets"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/Requests/issues",
+                "source": "https://github.com/WordPress/Requests/tree/v1.8.1"
+            },
+            "time": "2021-06-04T09:56:25+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Generated file for translation strings.
+ *
+ * Used to import additional strings into the pattern-directory translation project.
+ *
+ * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
+ * ⚠️ Do not require or include this file anywhere.
+ */
+
+_x( 'Buttons', 'Categories term name', 'wporg-patterns' );
+_x( 'Columns', 'Categories term name', 'wporg-patterns' );
+_x( 'Gallery', 'Categories term name', 'wporg-patterns' );
+_x( 'Header', 'Categories term name', 'wporg-patterns' );
+_x( 'Images', 'Categories term name', 'wporg-patterns' );
+_x( 'Text', 'Categories term name', 'wporg-patterns' );
+_x( 'Other', 'Flag Reasons term name', 'wporg-patterns' );

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -5,7 +5,7 @@
  * Version: 1.0.0
  * Requires at least: 5.5
  * Author: WordPress Meta Team
- * Text Domain: wporg-pattern-creator
+ * Text Domain: wporg-patterns
  * License: GPL v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  */

--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -3,7 +3,7 @@
  * Plugin Name: Pattern Directory
  * Description: Creates a directory to manage block patterns.
  * Plugin URI:  https://wordpress.org/patterns/
- * Text Domain: wporg-plugins
+ * Text Domain: wporg-patterns
  */
 
 namespace WordPressdotorg\Pattern_Directory;


### PR DESCRIPTION
A GitHub Action workflow that periodically runs a script that pulls in terms from specific taxonomies via the REST API and outputs them to a file within the repository, and then automatically commits changes to that file. This allows the taxonomy term labels to be included in the pot file that gets sent to GlotPress, but the generated file that contains the translation strings is located in a part of the repo that never gets synced to the production server via SVN.

This is the same method used to translate taxonomy terms [on the Learn site](https://github.com/WordPress/learn/pull/205).

Note that the script only pulls in terms for the Categories and Flag Reasons taxonomies. Keywords is not included because it's not clear that those should be translated, or that they will even remain a taxonomy.

Fixes #256 

### How to test the changes in this Pull Request:

You can try out the script that generates the translation file:

1. Run `composer install` to make sure you have the script's Requests dependency
2. Delete the `extra` folder
3. From the repo root run `php bin/i18n.php`
4. The `extra` folder should reappear with the fully formed translation file