### PR TITLE
Patterns: Show real favorite counts

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
@@ -2,7 +2,7 @@
 
 namespace WordPressdotorg\Pattern_Directory\Favorites_API;
 
-use function WordPressdotorg\Pattern_Directory\Favorite\{add_favorite, get_favorites, remove_favorite};
+use function WordPressdotorg\Pattern_Directory\Favorite\{add_favorite, get_favorite_count, get_favorites, remove_favorite};
 use WP_Error, WP_REST_Server, WP_REST_Response;
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\init' );
@@ -90,7 +90,8 @@ function create_item( $request ) {
 	$success = add_favorite( $pattern_id );
 
 	if ( $success ) {
-		return new WP_REST_Response( true, 200 );
+		$count = get_favorite_count( $pattern_id );
+		return new WP_REST_Response( $count, 200 );
 	}
 
 	return new WP_Error(
@@ -111,7 +112,8 @@ function delete_item( $request ) {
 	$success = remove_favorite( $pattern_id );
 
 	if ( $success ) {
-		return new WP_REST_Response( true, 200 );
+		$count = get_favorite_count( $pattern_id );
+		return new WP_REST_Response( $count, 200 );
 	}
 
 	return new WP_Error(

--- a/public_html/wp-content/plugins/pattern-directory/includes/favorite.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/favorite.php
@@ -84,3 +84,81 @@ function get_favorites( $user = 0 ) {
 
 	return array_map( 'absint', $favorites );
 }
+
+/**
+ * Get the cached count of how many times this pattern has been favorited.
+ *
+ * @param int|WP_Post $post The pattern to check.
+ * @return integer
+ */
+function get_favorite_count( $post = 0 ) {
+	$post = get_block_pattern( $post );
+	if ( ! $post ) {
+		return false;
+	}
+
+	return absint( get_post_meta( $post->ID, META_KEY, true ) );
+}
+
+/**
+ * Get a count of how many times this pattern has been favorited, directly from the users table.
+ *
+ * @param int|WP_Post $post The pattern to check.
+ * @return integer
+ */
+function get_raw_favorite_count( $post = 0 ) {
+	global $wpdb;
+	$post = get_block_pattern( $post );
+	if ( ! $post ) {
+		return false;
+	}
+	$count = $wpdb->get_var( $wpdb->prepare(
+		"SELECT COUNT(*)
+			FROM {$wpdb->usermeta}
+			WHERE meta_key=%s
+			AND meta_value=%d",
+		META_KEY,
+		$post->ID
+	) );
+
+	return absint( $count );
+}
+
+/**
+ * Update a given post's favorite count cache.
+ *
+ * @param mixed $value The post ID.
+ */
+function update_favorite_cache( $value ) {
+	if ( ! is_numeric( $value ) ) {
+		return;
+	}
+
+	$count = get_raw_favorite_count( $value );
+	update_post_meta( $value, META_KEY, $count );
+}
+
+/**
+ * Trigger the update of favorite count when a user favorites or unfavorites a pattern.
+ *
+ * @param int    $mid         The meta ID.
+ * @param int    $object_id   ID of the object metadata is for.
+ * @param string $meta_key    Metadata key.
+ * @param mixed  $_meta_value Metadata value. Serialized if non-scalar.
+ */
+function trigger_favorite_cache_update( $mid, $object_id, $meta_key, $_meta_value ) {
+	if ( META_KEY !== $meta_key ) {
+		return;
+	}
+
+	// This value can be an array in the delete action, so walk through each unique value and refresh the cache.
+	if ( is_array( $_meta_value ) ) {
+		$_meta_value = array_unique( $_meta_value );
+		array_walk( $_meta_value, __NAMESPACE__ . '\update_favorite_cache' );
+		return;
+	}
+
+	update_favorite_cache( $_meta_value );
+}
+add_action( 'added_user_meta', __NAMESPACE__ . '\trigger_favorite_cache_update', 10, 4 );
+add_action( 'deleted_user_meta', __NAMESPACE__ . '\trigger_favorite_cache_update', 10, 4 );

--- a/public_html/wp-content/plugins/pattern-directory/includes/favorite.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/favorite.php
@@ -3,6 +3,7 @@
 namespace WordPressdotorg\Pattern_Directory\Favorite;
 use function WordPressdotorg\Pattern_Directory\Pattern_Post_Type\get_block_pattern;
 
+// Used for both the post meta (count of favorites) and user meta (list of pattern IDs).
 const META_KEY = 'wporg-pattern-favorites';
 
 /**
@@ -127,26 +128,26 @@ function get_raw_favorite_count( $post = 0 ) {
 /**
  * Update a given post's favorite count cache.
  *
- * @param mixed $value The post ID.
+ * @param mixed $post_id The post ID.
  */
-function update_favorite_cache( $value ) {
-	if ( ! is_numeric( $value ) ) {
+function update_favorite_cache( $post_id ) {
+	$count = get_raw_favorite_count( $post_id );
+	if ( ! is_int( $count ) ) {
 		return;
 	}
 
-	$count = get_raw_favorite_count( $value );
-	update_post_meta( $value, META_KEY, $count );
+	update_post_meta( $post_id, META_KEY, $count );
 }
 
 /**
  * Trigger the update of favorite count when a user favorites or unfavorites a pattern.
  *
  * @param int    $mid         The meta ID.
- * @param int    $object_id   ID of the object metadata is for.
+ * @param int    $user_id     User ID for this metadata.
  * @param string $meta_key    Metadata key.
- * @param mixed  $_meta_value Metadata value. Serialized if non-scalar.
+ * @param mixed  $_meta_value Metadata value. Serialized if non-scalar. Post ID(s).
  */
-function trigger_favorite_cache_update( $mid, $object_id, $meta_key, $_meta_value ) {
+function trigger_favorite_cache_update( $mid, $user_id, $meta_key, $_meta_value ) {
 	if ( META_KEY !== $meta_key ) {
 		return;
 	}

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -4,6 +4,7 @@ namespace WordPressdotorg\Pattern_Directory\Pattern_Post_Type;
 
 use Error, WP_Block_Type_Registry;
 use function WordPressdotorg\Locales\{ get_locales, get_locales_with_english_names, get_locales_with_native_names };
+use function WordPressdotorg\Pattern_Directory\Favorite\get_favorite_count;
 
 const POST_TYPE = 'wporg-pattern';
 
@@ -290,7 +291,7 @@ function register_rest_fields() {
 		'favorite_count',
 		array(
 			'get_callback' => function() {
-				return 1;
+				return get_favorite_count( get_the_ID() );
 			},
 
 			'schema' => array(

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -295,7 +295,8 @@ function register_rest_fields() {
 			},
 
 			'schema' => array(
-				'type'  => 'integer',
+				'type'    => 'integer',
+				'default' => 0,
 			),
 		)
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/store/actions.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/actions.js
@@ -139,14 +139,14 @@ export function loadFavorites( patternIds ) {
  * @return {Object} Action object.
  */
 export function* addFavorite( patternId ) {
-	const success = yield apiFetch( {
+	const result = yield apiFetch( {
 		path: '/wporg/v1/pattern-favorites',
 		method: 'POST',
 		data: { id: patternId },
 	} );
 	// Silently discarding any errors.
-	if ( success === true ) {
-		return { type: 'ADD_FAVORITE', patternId: patternId };
+	if ( 'number' === typeof result ) {
+		return { type: 'ADD_FAVORITE', patternId: patternId, count: result };
 	}
 }
 
@@ -158,13 +158,13 @@ export function* addFavorite( patternId ) {
  * @return {Object} Action object.
  */
 export function* removeFavorite( patternId ) {
-	const success = yield apiFetch( {
+	const result = yield apiFetch( {
 		path: '/wporg/v1/pattern-favorites',
 		method: 'DELETE',
 		data: { id: patternId },
 	} );
 	// Silently discarding any errors.
-	if ( success === true ) {
-		return { type: 'REMOVE_FAVORITE', patternId: patternId };
+	if ( 'number' === typeof result ) {
+		return { type: 'REMOVE_FAVORITE', patternId: patternId, count: result };
 	}
 }

--- a/public_html/wp-content/themes/pattern-directory/src/store/reducer.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/reducer.js
@@ -34,6 +34,11 @@ function byId( state = {}, action ) {
 		case 'LOAD_BLOCK_PATTERN': {
 			return { ...state, [ action.postId ]: action.pattern };
 		}
+		case 'ADD_FAVORITE':
+		case 'REMOVE_FAVORITE': {
+			const updatedPattern = { ...state[ action.patternId ], favorite_count: action.count };
+			return { ...state, [ action.patternId ]: updatedPattern };
+		}
 		default:
 			return state;
 	}

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
@@ -123,6 +123,56 @@ describe( 'state', () => {
 			expect( state.queries[ '' ][ '3' ] ).toHaveLength( 0 );
 			expect( state.byId ).toHaveProperty( '31' );
 		} );
+
+		it( 'should update when favorites are added', () => {
+			const state = patterns(
+				{
+					queries: {
+						'': {
+							total: 10,
+							totalPages: 2,
+							1: [ 31, 25, 26, 27, 28 ],
+						},
+					},
+					byId: apiPatterns.reduce( ( acc, cur ) => ( { ...acc, [ cur.id ]: cur } ), {} ),
+				},
+				{
+					type: 'ADD_FAVORITE',
+					patternId: 31,
+					count: 1,
+				}
+			);
+
+			expect( state.byId ).toHaveProperty( '31' );
+			expect( state.byId[ '31' ] ).toHaveProperty( 'title' );
+			expect( state.byId[ '31' ] ).toHaveProperty( 'favorite_count' );
+			expect( state.byId[ '31' ].favorite_count ).toEqual( 1 );
+		} );
+
+		it( 'should update when favorites are removed', () => {
+			const state = patterns(
+				{
+					queries: {
+						'': {
+							total: 10,
+							totalPages: 2,
+							1: [ 31, 25, 26, 27, 28 ],
+						},
+					},
+					byId: apiPatterns.reduce( ( acc, cur ) => ( { ...acc, [ cur.id ]: cur } ), {} ),
+				},
+				{
+					type: 'REMOVE_FAVORITE',
+					patternId: 31,
+					count: 0,
+				}
+			);
+
+			expect( state.byId ).toHaveProperty( '31' );
+			expect( state.byId[ '31' ] ).toHaveProperty( 'title' );
+			expect( state.byId[ '31' ] ).toHaveProperty( 'favorite_count' );
+			expect( state.byId[ '31' ].favorite_count ).toEqual( 0 );
+		} );
 	} );
 
 	describe( 'pattern', () => {
@@ -238,6 +288,7 @@ describe( 'state', () => {
 			const state = favorites( [ 1, 2, 3 ], {
 				type: 'ADD_FAVORITE',
 				patternId: 5,
+				count: 1,
 			} );
 			expect( state ).toEqual( [ 1, 2, 3, 5 ] );
 		} );
@@ -246,6 +297,7 @@ describe( 'state', () => {
 			const state = favorites( [ 1, 2, 3 ], {
 				type: 'ADD_FAVORITE',
 				patternId: 1,
+				count: 1,
 			} );
 			expect( state ).toEqual( [ 1, 2, 3 ] );
 		} );
@@ -254,6 +306,7 @@ describe( 'state', () => {
 			const state = favorites( [ 1, 2, 3 ], {
 				type: 'REMOVE_FAVORITE',
 				patternId: 3,
+				count: 1,
 			} );
 			expect( state ).toEqual( [ 1, 2 ] );
 		} );
@@ -262,6 +315,7 @@ describe( 'state', () => {
 			const state = favorites( [ 1, 2, 3 ], {
 				type: 'REMOVE_FAVORITE',
 				patternId: 5,
+				count: 1,
 			} );
 			expect( state ).toEqual( [ 1, 2, 3 ] );
 		} );


### PR DESCRIPTION
See #100, follow up to #93/#94. This displays the current number of favorites on a given pattern, using a "cached" value on post meta. The post meta value is updated any time a user favorites or unfavorites that pattern. When adding & removing favorites, the favorite count for the pattern is returned on success, so the value can be updated live after clicking favorite.

I decided to cache/save the value to post meta, since we'll also want to order by favorites in #161.

If there are no issues with this "cache"-ish solution, I also have a bin script that can be run to update the wporg patterns (since people can favorite patterns right now, there might be a few already favorited).

### Screenshots

<img width="336" alt="Screen Shot 2021-07-07 at 6 04 18 PM" src="https://user-images.githubusercontent.com/541093/124834430-c37a9a80-df4d-11eb-8a8c-e3d0b15efff3.png">

### How to test the changes in this Pull Request:

1. Optionally have a site with multiple users
2. Favorite some patterns on either/both users
3. The pattern counts should be updated instantly, and should be correct - if you favorite something with two users, it should show "2 ❤️ "
