### PR TITLE
Report pattern modal: Sort reason terms by slug for custom sort order

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/report-pattern-modal/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/report-pattern-modal/index.js
@@ -42,7 +42,17 @@ const ReportPatternModal = ( { postId, onClose } ) => {
 		return {
 			isLoading: isLoadingPatternFlagReasons(),
 			mappedReasons: reasons
-				.sort( ( a, b ) => a.id - b.id )
+				.sort( ( a, b ) => {
+					// Using the slug allows us to set a custom order for the terms through the admin UI.
+					switch ( true ) {
+						case a.slug < b.slug:
+							return -1;
+						case a.slug > b.slug:
+							return 1;
+						default:
+							return 0;
+					}
+				} )
 				.map( ( i ) => {
 					// We need to convert id to string to make the RadioControl match the selected item.
 					return { label: i.name, value: i.id.toString() };


### PR DESCRIPTION
It makes the most sense for the "Other" reason to be last in the list, but since it was added first, and we might add other reasons later, sorting by the ID makes it hard to keep it there. Sorting by slug will make this easier because we can customize the slug through the UI to be things like `1-inappropriate`, `2-other` etc.

### Screenshots

**Before**

![reasons-before](https://user-images.githubusercontent.com/916023/124986627-afd44000-dff0-11eb-8767-a4419c7c647b.jpg)


**After**

![reasons-after](https://user-images.githubusercontent.com/916023/124986651-b793e480-dff0-11eb-841d-daf69ff5bab7.jpg)


### How to test the changes in this Pull Request:

1. Add some terms to the [Pattern Flag Reason taxonomy](http://localhost:8888/wp-admin/edit-tags.php?taxonomy=wporg-pattern-flag-reason&post_type=wporg-pattern)
2. Open the Report This Pattern modal on the front end and check their order
3. Try modifying the terms' slugs so they will sort differently