### PR TITLE
Limit front end patterns to site locale

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -73,10 +73,11 @@ function enqueue_assets() {
 		wp_add_inline_script(
 			'wporg-pattern-script',
 			sprintf(
-				'var wporgAssetUrl = "%s", wporgSiteUrl = "%s", wporgLoginUrl = "%s";',
+				'var wporgAssetUrl = "%s", wporgSiteUrl = "%s", wporgLoginUrl = "%s", wporgLocale = \'%s\';',
 				esc_url( get_stylesheet_directory_uri() ),
 				esc_url( home_url() ),
-				esc_url( wp_login_url() )
+				esc_url( wp_login_url() ),
+				wp_json_encode( get_locale() )
 			),
 			'before'
 		);
@@ -164,6 +165,9 @@ function pre_get_posts( $query ) {
 	} else if ( ! $query->get( 'pagename' ) && 'post' === $query->get( 'post_type', 'post' ) ) {
 		$query->set( 'post_type', array( POST_TYPE ) );
 		$query->set( 'post_status', array( 'publish' ) );
+
+		$query->set( 'meta_key', 'wpop_locale' );
+		$query->set( 'meta_value', get_locale() );
 	}
 }
 

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -63,7 +63,8 @@
 		"globals": {
 			"wporgAssetUrl": "readonly",
 			"wporgLoginUrl": "readonly",
-			"wporgSiteUrl": "readonly"
+			"wporgSiteUrl": "readonly",
+			"wporgLocale": "readonly"
 		}
 	},
 	"stylelint": {

--- a/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
@@ -46,7 +46,7 @@ export function* getPatternsByQuery( query ) {
 	try {
 		yield fetchPatterns( queryString );
 		const response = yield apiFetch( {
-			path: addQueryArgs( '/wp/v2/wporg-pattern', query ),
+			path: addQueryArgs( '/wp/v2/wporg-pattern', { ...query, locale: JSON.parse( wporgLocale ) } ),
 			parse: false,
 		} );
 		const { total, totalPages, results } = yield __unstableAwaitPromise( parseResponse( response ) );

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/resolvers.js
@@ -6,6 +6,9 @@ import apiCategories from './fixtures/categories';
 import apiPatternFlagReasons from './fixtures/pattern-flag-reasons';
 import { getCategories, getFavorites, getPattern, getPatternFlagReasons, getPatternsByQuery } from '../resolvers';
 
+// Set up the global.
+global.wporgLocale = '"en_US"';
+
 describe( 'getPatternsByQuery', () => {
 	it( 'yields with the requested patterns & query meta', async () => {
 		const generator = getPatternsByQuery( {} );
@@ -18,7 +21,7 @@ describe( 'getPatternsByQuery', () => {
 		// trigger apiFetch
 		const { value: apiFetchAction } = generator.next();
 		expect( apiFetchAction.request ).toEqual( {
-			path: `/wp/v2/wporg-pattern`,
+			path: `/wp/v2/wporg-pattern?locale=en_US`,
 			parse: false,
 		} );
 


### PR DESCRIPTION
This makes it so that Rosetta sites like `es-mx.wordpress.org/patterns` will only display patterns with a `es_MX` locale.

In the future, we may want to include all locales, but weight translated ones higher (see https://github.com/WordPress/pattern-directory/issues/244#issuecomment-871985952), but this is good enough for the initial launch.

Fixes #273
