### PR TITLE
Patterns: Handle empty results and 404 pages

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/404.php
+++ b/public_html/wp-content/themes/pattern-directory/404.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * The template for displaying 404 pages (not found).
+ *
+ * @link https://codex.wordpress.org/Creating_an_Error_404_Page
+ *
+ * @package WordPressdotorg\Pattern_Directory\Theme
+ */
+
+namespace WordPressdotorg\Pattern_Directory\Theme;
+
+get_header(); ?>
+
+	<main id="main" class="site-main col-12" role="main">
+
+		<div class="error-404 not-found">
+			<div class="page-container aligncenter">
+				<header class="page-header">
+					<h1 class="page-title"><?php esc_html_e( 'Oops! This page doesn&rsquo;t exist.', 'wporg-patterns' ); ?></h1>
+				</header><!-- .page-header -->
+
+				<p>
+					<?php
+					printf(
+						/* translators: %1$s: WordPress.org URL, %2$s: Patterns home URL. */
+						__( 'Head to <a href="%1$s">the WordPress.org home</a>, view <a href="%2$s">all block patterns</a>, or try searching.', 'wporg-patterns' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						esc_url( get_home_url() ),
+						esc_url( get_home_url() )
+					);
+					?>
+				</p>
+				<?php get_search_form(); ?>
+			</div><!-- .page-container -->
+		</div><!-- .error-404 -->
+
+	</main><!-- #main -->
+<?php
+
+get_footer();

--- a/public_html/wp-content/themes/pattern-directory/css/components/_404.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_404.scss
@@ -1,0 +1,23 @@
+.error-404 {
+	display: flex;
+	margin: 0 1rem 4rem;
+	min-height: 28rem;
+	justify-content: center;
+	align-items: center;
+	flex-wrap: wrap;
+	/* stylelint-disable-next-line function-url-quotes */
+	background-image: url("data:image/svg+xml,%3Csvg width='1033' height='471' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 366.009h213.878v98.437H253.7v-98.437h60.853v-37.586H253.7V6.264h-49.442L0 332.003v34.006zm213.878-37.586H46.758v-2.908L210.746 63.313h3.132v265.11zM516.115 470.71c96.424 0 153.025-87.027 153.025-235.355C669.14 87.699 612.091 0 516.115 0c-95.977 0-153.026 87.699-153.026 235.355 0 148.328 56.602 235.355 153.026 235.355zm0-37.585c-70.473 0-112.532-72.262-112.532-197.77 0-125.284 42.283-198.44 112.532-198.44 70.248 0 112.531 73.156 112.531 198.44 0 125.508-42.059 197.77-112.531 197.77zM717.732 366.009H931.61v98.437h39.823v-98.437h60.857v-37.586h-60.857V6.264H921.99L717.732 332.003v34.006zm213.878-37.586H764.49v-2.908L928.478 63.313h3.132v265.11z' fill='%23F0F0F1'/%3E%3C/svg%3E%0A");
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: contain;
+
+	.page-title {
+		font-weight: 700;
+		font-size: 2.125rem;
+		text-align: center;
+	}
+
+	.pattern-search {
+		border: 1px solid $color-black;
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -20,6 +20,7 @@
 @import "../../../wporg/css/components/widget-area";
 @import "../../../wporg/css/components/wporg-footer";
 @import "../../../wporg/css/components/wporg-header";
+@import "404";
 @import "category-context-bar";
 @import "copy-button";
 @import "favorite-button";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -1,3 +1,15 @@
+.pattern-grid__empty-header {
+	margin: 2rem auto 4rem;
+	max-width: 960px;
+	text-align: center;
+
+	h2 {
+		margin-top: 0;
+		font-weight: 700;
+		line-height: 1.2;
+	}
+}
+
 .pattern-grid {
 	display: grid;
 	margin: 1.5rem 1.5rem 4rem;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -8,6 +8,12 @@
 		font-weight: 700;
 		line-height: 1.2;
 	}
+
+	p {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 34rem;
+	}
 }
 
 .pattern-grid {

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -13,9 +13,6 @@ add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );
 add_filter( 'init', __NAMESPACE__ . '\add_rewrite' );
 
 add_filter( 'archive_template', __NAMESPACE__ . '\use_index_php_as_template' );
-
-add_filter( 'pre_handle_404', __NAMESPACE__ . '\bypass_404_page', 10, 2 );
-
 add_action( 'template_redirect', __NAMESPACE__ . '\rewrite_search_url' );
 
 /**
@@ -223,21 +220,6 @@ function user_has_flagged_pattern() {
 	$items = new \WP_Query( $args );
 
 	return $items->have_posts();
-}
-
-/**
- * Handle a possible 404 page when viewing patterns, which might happen if the JS pagination is
- * different than the WP default.
- *
- * @param bool     $preempt  Whether to short-circuit default header status handling. Default false.
- * @param WP_Query $wp_query WordPress Query object.
- * @return bool
- */
-function bypass_404_page( $preempt, $wp_query ) {
-	if ( isset( $wp_query->query_vars['post_type'][0] ) && POST_TYPE === $wp_query->query_vars['post_type'][0] ) {
-		return true;
-	}
-	return $preempt;
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/empty-header.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/empty-header.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+function EmptyHeader() {
+	return (
+		<div className="pattern-grid__empty-header">
+			<h2>{ __( 'No favorites here', 'wporg-patterns' ) }</h2>
+			<p>
+				{ createInterpolateElement(
+					__(
+						'You haven’t favorited any patterns yet. Take a look at the <a>block patterns</a> to find some you like, and click the heart to save them.',
+						'wporg-patterns'
+					),
+					{
+						// eslint-disable-next-line jsx-a11y/anchor-has-content -- Content interpolated above.
+						a: <a href={ wporgPatternsUrl.site } />,
+					}
+				) }
+			</p>
+		</div>
+	);
+}
+
+export default EmptyHeader;

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/index.js
@@ -16,8 +16,22 @@ import QueryMonitor from '../query-monitor';
 import { RouteProvider } from '../../hooks';
 
 const MyPatterns = () => {
-	const query = useSelect( ( select ) => select( patternStore ).getCurrentQuery() );
 	const author = wporgPatternsData.userId;
+	const { isEmpty, query } = useSelect( ( select ) => {
+		const { getCurrentQuery, getPatternsByQuery, isLoadingPatternsByQuery } = select( patternStore );
+		const _query = getCurrentQuery() || {};
+
+		// Show all patterns regardless of status, but if the current query has a status (the view is draft, for
+		// example), that will override `any`. Lastly, make sure this shows the current user's patterns.
+		const modifiedQuery = { status: 'any', ..._query, author: author };
+		const isLoading = author && isLoadingPatternsByQuery( modifiedQuery );
+		const posts = author ? getPatternsByQuery( modifiedQuery ) : [];
+
+		return {
+			isEmpty: ! isLoading && ! posts.length,
+			query: modifiedQuery,
+		};
+	} );
 
 	if ( ! author ) {
 		const loginUrl = addQueryArgs( wporgPatternsUrl.login, { redirect_to: window.location } );
@@ -30,17 +44,21 @@ const MyPatterns = () => {
 			</div>
 		);
 	}
-	// Show all patterns regardless of status, but if the current query has a status (the view is draft, for
-	// example), that will override `any`. Lastly, make sure this shows the current user's patterns.
-	const modifiedQuery = { status: 'any', ...query, author: author };
 
 	return (
 		<RouteProvider>
 			<QueryMonitor />
 			<Menu />
-			<PatternGrid query={ modifiedQuery }>
-				{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } /> }
-			</PatternGrid>
+			{ isEmpty ? (
+				<div className="pattern-grid__empty-header">
+					<h2>{ __( 'Nothing found', 'wporg-patterns' ) }</h2>
+					<p>{ __( 'You haven’t created any patterns yet.', 'wporg-patterns' ) }</p>
+				</div>
+			) : (
+				<PatternGrid query={ query }>
+					{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } /> }
+				</PatternGrid>
+			) }
 		</RouteProvider>
 	);
 };

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/grid-skeleton.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/grid-skeleton.js
@@ -42,4 +42,9 @@ const CardSkeleton = () => {
 	);
 };
 
-export default CardSkeleton;
+const GridSkeleton = ( { length = 6 } ) =>
+	Array( length )
+		.fill()
+		.map( ( val, idx ) => <CardSkeleton key={ idx } /> );
+
+export default GridSkeleton;

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
@@ -6,9 +6,9 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import GridSkeleton from './grid-skeleton';
 import Pagination from './pagination';
 import { store as patternStore } from '../../store';
-import CardSkeleton from './card-skeleton';
 
 function PatternGrid( { header, children, query, showPagination = true } ) {
 	const { isLoading, posts, totalPages } = useSelect( ( select ) => {
@@ -27,11 +27,7 @@ function PatternGrid( { header, children, query, showPagination = true } ) {
 		<>
 			{ posts.length ? header : null }
 			<div className="pattern-grid">
-				{ isLoading
-					? Array( 6 )
-							.fill()
-							.map( ( val, idx ) => <CardSkeleton key={ idx } /> )
-					: posts.map( children ) }
+				{ isLoading ? <GridSkeleton length={ query?.per_page } /> : posts.map( children ) }
 			</div>
 			{ showPagination && <Pagination totalPages={ totalPages } currentPage={ query?.page } /> }
 		</>

--- a/public_html/wp-content/themes/pattern-directory/src/components/patterns-search/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/patterns-search/index.js
@@ -7,22 +7,42 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import CategoryContextBar from '../category-context-bar';
+import EmptyHeader from '../patterns/empty-header';
 import PatternGrid from '../pattern-grid';
-import QueryMonitor from '../query-monitor';
 import PatternThumbnail from '../pattern-thumbnail';
+import QueryMonitor from '../query-monitor';
 import { RouteProvider } from '../../hooks';
 import { store as patternStore } from '../../store';
 
 const PatternsSearch = () => {
-	const query = useSelect( ( select ) => select( patternStore ).getCurrentQuery() );
+	const { isEmpty, query } = useSelect( ( select ) => {
+		const { getCurrentQuery, getPatternsByQuery, isLoadingPatternsByQuery } = select( patternStore );
+		const _query = getCurrentQuery();
+		const isLoading = _query && isLoadingPatternsByQuery( _query );
+		const posts = _query ? getPatternsByQuery( _query ) : [];
+
+		return {
+			isEmpty: ! isLoading && ! posts.length,
+			query: _query,
+		};
+	} );
 
 	return (
 		<RouteProvider>
 			<QueryMonitor />
 			<CategoryContextBar query={ query } />
-			<PatternGrid query={ query }>
-				{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
-			</PatternGrid>
+			{ isEmpty ? (
+				<>
+					<EmptyHeader />
+					<PatternGrid query={ { per_page: 6 } } showPagination={ false }>
+						{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
+					</PatternGrid>
+				</>
+			) : (
+				<PatternGrid query={ query }>
+					{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
+				</PatternGrid>
+			) }
 		</RouteProvider>
 	);
 };

--- a/public_html/wp-content/themes/pattern-directory/src/components/patterns/empty-header.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/patterns/empty-header.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+function EmptyHeader() {
+	return (
+		<div className="pattern-grid__empty-header">
+			<h2>{ __( 'No results found', 'wporg-patterns' ) }</h2>
+			<p>
+				{ createInterpolateElement(
+					__(
+						'View <a>all block patterns</a> or browse some of our recent patterns.',
+						'wporg-patterns'
+					),
+					{
+						// eslint-disable-next-line jsx-a11y/anchor-has-content -- Content interpolated above.
+						a: <a href={ wporgPatternsUrl.site } />,
+					}
+				) }
+			</p>
+		</div>
+	);
+}
+
+export default EmptyHeader;

--- a/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import EmptyHeader from './empty-header';
 import PatternGrid from '../pattern-grid';
 import PatternGridMenu from '../pattern-grid-menu';
 import PatternThumbnail from '../pattern-thumbnail';
@@ -16,16 +17,35 @@ import { RouteProvider } from '../../hooks';
 import { store as patternStore } from '../../store';
 
 const Patterns = () => {
-	const query = useSelect( ( select ) => select( patternStore ).getCurrentQuery() );
+	const { isEmpty, query } = useSelect( ( select ) => {
+		const { getCurrentQuery, getPatternsByQuery, isLoadingPatternsByQuery } = select( patternStore );
+		const _query = getCurrentQuery();
+		const isLoading = _query && isLoadingPatternsByQuery( _query );
+		const posts = _query ? getPatternsByQuery( _query ) : [];
+
+		return {
+			isEmpty: ! isLoading && ! posts.length,
+			query: _query,
+		};
+	} );
 
 	return (
 		<RouteProvider>
 			<QueryMonitor />
 			<BreadcrumbMonitor />
 			<PatternGridMenu query={ query } />
-			<PatternGrid query={ query }>
-				{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
-			</PatternGrid>
+			{ isEmpty ? (
+				<>
+					<EmptyHeader />
+					<PatternGrid query={ { per_page: 6 } } showPagination={ false }>
+						{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
+					</PatternGrid>
+				</>
+			) : (
+				<PatternGrid query={ query }>
+					{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
+				</PatternGrid>
+			) }
 		</RouteProvider>
 	);
 };

--- a/public_html/wp-content/themes/pattern-directory/src/store/reducer.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/reducer.js
@@ -130,7 +130,7 @@ export function patternFlagReasons( state = undefined, action ) {
  * @param {Object} action Dispatched action.
  * @return {Object} Updated state.
  */
-export function favorites( state = [], action ) {
+export function favorites( state = null, action ) {
 	const { patternId } = action;
 	switch ( action.type ) {
 		case 'LOAD_FAVORITES':


### PR DESCRIPTION
Fixes #116. This adds the "empty state" and "404 page" styles. When a category or query result is empty, the page should say that, then display 6 recent patterns. If the page is not found, it should display the "404" page template. This template is handled by PHP, so we can remove the `bypass_404_page` filter.

The 404 page in the design also has "404 patterns" on it, but we don't have that category set up, so I've left it empty.

### Screenshots

Empty search result (Japanese site):

<img width="1026" alt="nothing-ja" src="https://user-images.githubusercontent.com/541093/125520557-d3cb2cd3-b164-4cbb-991c-9fb84b3cb61a.png">

A locale with no translated patterns (Korean) will also show the empty state on the homepage, but there are no recent patterns either. Ideally this would be a message to get involved, but that can happen in another PR/post launch.

<img width="998" alt="nothing-ko" src="https://user-images.githubusercontent.com/541093/125520558-8c8ba102-f720-40e0-a65b-2941d327f7e0.png">

The 404 page, for example, `wordpress.org/patterns/error404`:

<img width="1008" alt="404" src="https://user-images.githubusercontent.com/541093/125520551-c72b3342-8b25-4ae6-b1d2-16cac33e5fae.png">

### How to test the changes in this Pull Request:

1. Search for a string that doesn't exist
2. You should see the empty state
3. Go to a page or category that doesn't exist
4. You should see the 404 page
