### PR TITLE
Patterns: Re-enable revisions support for pattern post type

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -55,7 +55,7 @@ function register_post_type_data() {
 			'public'          => true,
 			'show_in_rest'    => true,
 			'rewrite'         => array( 'slug' => 'pattern' ),
-			'supports'        => array( 'title', 'editor', 'author', 'custom-fields' ),
+			'supports'        => array( 'title', 'editor', 'author', 'custom-fields', 'revisions' ),
 			'capability_type' => array( 'pattern', 'patterns' ),
 			'map_meta_cap'    => true,
 		)


### PR DESCRIPTION
Allows us to track changes to patterns.

In #279 it says that the revisions panel is broken in the front end pattern creator UI, but after enabling revisions, I am not seeing the revisions panel on the front end at all, even though it appears normally in the WP Admin block editor. Perhaps nothing more needs to be done here?

Fixes #279

### How to test the changes in this Pull Request:

1. Edit a pattern a few times.
2. Check to see if the revisions panel shows up in the WP Admin block editor.
3. Check to see if the revisions panel shows up in the front end pattern creator.
