### PR TITLE
Consistency in very similar strings

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/publish-modal/submit.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/publish-modal/submit.js
@@ -96,7 +96,7 @@ export default function SubmitModal( { onSubmit, onClose } ) {
 						value={ description }
 						placeholder={ __( 'Describe the output of pattern', 'wporg-patterns' ) }
 						help={ __(
-							'The description is used to help users of assistive technology better understand the contents of your pattern.',
+							'The description is used to help users of assistive technology understand the content of your pattern.',
 							'wporg-patterns'
 						) }
 						onChange={ setDescription }


### PR DESCRIPTION
Replaces the string to be identical with the one [here](https://github.com/WordPress/pattern-directory/blob/aa775d8caeb2f66946b7bed7ce5300eb18135bcb/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/details.js#L52).

As @ryelle suggested, this PR uses the shorter string alternative. This makes things much easier for translators too.

Fixes #274. Props @tobifjellner.


