### PR TITLE
Theme: Update the PHP view to reflect the JS content

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -4,10 +4,7 @@
 	max-width: 960px;
 	grid-template-columns: repeat(auto-fill, minmax(225px, 1fr));
 	gap: 1.5rem;
-
-	> * {
-		align-self: baseline;
-	}
+	align-items: start;
 
 	@include breakpoint( $breakpoint-large ) {
 		margin-left: auto;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -166,4 +166,12 @@ body.single-wporg-pattern {
 		width: 2rem;
 		border-radius: 4px;
 	}
+
+	.pattern-code {
+		margin-bottom: 5rem;
+		width: 100%;
+		height: 10rem;
+		resize: vertical;
+		font-family: monospace;
+	}
 }

--- a/public_html/wp-content/themes/pattern-directory/index.php
+++ b/public_html/wp-content/themes/pattern-directory/index.php
@@ -20,8 +20,6 @@ get_header();
 	<main id="main" class="site-main" role="main">
 
 		<div id="patterns__container">
-			<!-- Filter placeholder -->
-
 			<div class="pattern-grid">
 				<?php
 				if ( have_posts() ) :

--- a/public_html/wp-content/themes/pattern-directory/search.php
+++ b/public_html/wp-content/themes/pattern-directory/search.php
@@ -12,7 +12,20 @@ namespace WordPressdotorg\Pattern_Directory\Theme;
 get_header();
 ?> 
 
-<div id="patterns-search__container"></div>
+<div id="patterns-search__container">
+	<div class="pattern-grid">
+		<?php
+		if ( have_posts() ) :
+			/* Start the Loop */
+			while ( have_posts() ) :
+				the_post();
+				get_template_part( 'template-parts/content', 'grid' );
+			endwhile;
+		endif;
+		?>
+	</div>
+</div>
+
 
 <?php
 get_footer();

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -44,6 +44,15 @@ $raw_block_content = get_the_content();
 					data-user-has-reported="<?php echo json_encode( $user_has_reported ); ?>"
 				></div><!-- .pattern__container -->
 
+				<div class="entry-content hide-if-pattern-loaded">
+					<?php the_content(); ?>
+
+					<hr />
+
+					<label for="pattern-code"><?php esc_html_e( 'Pattern Code', 'wporg-patterns' ); ?></label>
+					<textarea id="pattern-code" class="pattern-code"><?php echo esc_attr( $raw_block_content ); ?></textarea>
+				</div>
+
 			</article><!-- #post-## -->
 
 		<?php endwhile; ?>

--- a/public_html/wp-content/themes/pattern-directory/src/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/index.js
@@ -32,6 +32,8 @@ for ( let i = 0; i < previewContainers.length; i++ ) {
 	render( <Pattern { ...props } />, container, () => {
 		// This callback is called after the render to unhide the container.
 		container.hidden = false;
+		const contentToHide = document.querySelectorAll( '.hide-if-pattern-loaded' );
+		contentToHide.forEach( ( elem ) => ( elem.hidden = true ) );
 	} );
 }
 

--- a/public_html/wp-content/themes/pattern-directory/template-parts/content-grid.php
+++ b/public_html/wp-content/themes/pattern-directory/template-parts/content-grid.php
@@ -9,24 +9,13 @@ namespace WordPressdotorg\Pattern_Directory\Theme;
 
 ?>
 
-<div id="post-<?php the_ID(); ?>" <?php post_class( 'pattern-grid__pattern' ); ?>>
-	<?php /* This link only wraps the "preview" container to avoid nesting the buttons inside the link. */ ?>
-	<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
-		<?php the_title( '<span class="screen-reader-text">', '</span>' ); ?>
-		<div class="pattern-grid__preview" style="height:<?php echo esc_attr( rand( 100, 300 ) ); ?>px">
-			Pattern ID: <?php the_ID(); ?>
-		</div>
-	</a>
-	<div class="pattern-grid__actions">
-		<?php the_title( '<h2 class="pattern-grid__title">', '</h2>' ); ?>
-		<button class="button button-link pattern-favorite-button">
-			<svg class="pattern__favorite-outline" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<path fill-rule="evenodd" clip-rule="evenodd" d="M12 4.915c1.09-1.28 2.76-2.09 4.5-2.09 3.08 0 5.5 2.42 5.5 5.5 0 3.777-3.394 6.855-8.537 11.518l-.013.012-1.45 1.32-1.45-1.31-.04-.036C5.384 15.17 2 12.095 2 8.325c0-3.08 2.42-5.5 5.5-5.5 1.74 0 3.41.81 4.5 2.09zm0 13.56l.1-.1c4.76-4.31 7.9-7.16 7.9-10.05 0-2-1.5-3.5-3.5-3.5-1.54 0-3.04.99-3.56 2.36h-1.87c-.53-1.37-2.03-2.36-3.57-2.36-2 0-3.5 1.5-3.5 3.5 0 2.89 3.14 5.74 7.9 10.05l.1.1z" fill="#000"></path>
-			</svg>
-			<svg class="pattern__favorite-filled" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<path d="M11.941 21.175l-1.443-1.32c-5.124-4.67-8.508-7.75-8.508-11.53 0-3.08 2.408-5.5 5.473-5.5 1.732 0 3.394.81 4.478 2.09 1.085-1.28 2.747-2.09 4.478-2.09 3.065 0 5.473 2.42 5.473 5.5 0 3.78-3.383 6.86-8.508 11.54l-1.443 1.31z" fill="#000"></path>
-			</svg>
-		</button>
-		<button class="button button-primary pattern-copy-button is-small"><?php esc_html_e( 'Copy', 'wporg-patterns' ); ?></button>
-	</div>
+<div id="post-<?php the_ID(); ?>" class="pattern-grid__pattern">
+	<div class="pattern-grid__pattern-frame pattern-skeleton" style="padding:56.25% 0 0;"></div>
+	<?php the_title( '<h2 class="pattern-grid__title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' ); ?>
+	<p class="pattern-grid__meta">
+		<a href="https://wordpress.org/patterns/author/wordpressdotorg" class="pattern-grid__author-avatar">
+			<?php echo get_avatar( get_the_author_meta( 'ID' ), 32 ); ?>
+			<?php esc_html( get_the_author() ); ?>
+		</a>
+	</p>
 </div>


### PR DESCRIPTION
Fixes #104 - Updates the PHP templates to match the JS content a bit more. The PHP template is barely more than a skeleton for the JS to load over, the purpose of adding content here is in case the JS is slow to load, or if it's broken (possibly due to using an old browser?). This also helps by giving the page some structure before even the JS loading state loads.

### Screenshots

![all-patterns](https://user-images.githubusercontent.com/541093/125693722-f207cf21-6fa1-4da2-b2d7-ff548d808b32.png)

![category](https://user-images.githubusercontent.com/541093/125693719-89a315a7-7931-4da7-a49a-cf179edd3596.png)

For the single pattern view, I tried out rendering the content on the page, with a textarea to copy the pattern. I'm on the fence about whether this is useful. Otherwise there really isn't much to preview here, the page would be empty.

![single-pattern](https://user-images.githubusercontent.com/541093/125693709-158e7f89-d222-492e-ae76-ef2b9153f801.png)

### How to test the changes in this Pull Request:

1. Turn off JavaScript or change [the filename in this line](https://github.com/WordPress/pattern-directory/blob/274768973f555eaf35856299510e83e3e8510205/public_html/wp-content/themes/pattern-directory/functions.php#L59) to disable loading the JS.
2. Click around through the content
3. Home, archives, search, and single pattern views should all show _something_, though there are no small previews, or pattern actions
4. Re-enable the JS
5. Click around the site again, the serverside generated content shows up for a second before the JS loading state flips on
6. Nothing else should be altered visually or functionally
