### PR TITLE
Add in links to get to the interior pages.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
@@ -27,9 +27,9 @@
 
 		.site-link {
 			display: inline-block;
-			margin: $gutter-default / 2 $gutter-default / 2 0 0;
+			margin: $gutter-default $gutter-default / 2 0 0;
 			color: $color-white;
-			font-size: 0.75rem;
+			font-size: 0.8125rem;
 			text-decoration: underline;
 		}
 	}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
@@ -6,19 +6,14 @@
 		display: block;
 		padding: 3.75rem 1rem;
 
-
 		@include breakpoint( $breakpoint-medium ) {
-			display: grid;
-			grid-template-rows: auto 1fr;
-			grid-template-columns: 1fr 25rem;
-
 			background-image: url(../images/masthead-bg.png);
 			background-size: contain;
 			background-repeat: no-repeat;
 			background-position-x: 160%;
 
-			> * {
-				align-self: center;
+			> div {
+				max-width: 50%;
 			}
 		}
 
@@ -27,15 +22,20 @@
 		}
 
 		@include breakpoint( $breakpoint-large ) {
-			grid-template-columns: 1fr 30rem;
 			background-position-x: right;
+		}
+
+		.site-link {
+			display: inline-block;
+			margin: $gutter-default / 2 $gutter-default / 2 0 0;
+			color: $color-white;
+			font-size: 0.75rem;
+			text-decoration: underline;
 		}
 	}
 
 	// Duplicate class for specifity override.
 	.site-title.site-title {
-		grid-column-start: 1;
-		grid-row-start: 1;
 		margin-top: 0;
 		text-align: left;
 		font-size: 3rem;
@@ -43,8 +43,6 @@
 	}
 
 	.site-description {
-		grid-column-start: 1;
-		grid-row-start: 2;
 		margin: 0 0 1.5rem;
 		font-size: 1rem;
 		line-height: $type__line-height;
@@ -53,8 +51,6 @@
 	}
 
 	.pattern-search {
-		grid-column-start: 1;
-		grid-row-start: 3;
 
 		@include breakpoint( $breakpoint-large ) {
 			max-width: 60%;

--- a/public_html/wp-content/themes/pattern-directory/header.php
+++ b/public_html/wp-content/themes/pattern-directory/header.php
@@ -32,8 +32,8 @@ get_template_part( 'header', 'wporg' );
 
 						<p class="site-description"><?php esc_html_e( 'Add a beautifully designed, ready to go layout to any WordPress site with a simple copy/paste.', 'wporg-patterns' ); ?></p>
 						<?php get_search_form(); ?>
-						<a class="site-link" href="<?php echo esc_url( home_url( '/my-favorites' ) ); ?>"><?php esc_html_e( 'My Favorites', 'wporg-patterns' ); ?></a>
-						<a class="site-link" href="<?php echo esc_url( home_url( '/my-patterns' ) ); ?>"><?php esc_html_e( 'My Patterns', 'wporg-patterns' ); ?></a>
+						<a class="site-link" href="<?php echo esc_url( home_url( '/my-favorites' ) ); ?>"><?php esc_html_e( 'My favorites', 'wporg-patterns' ); ?></a>
+						<a class="site-link" href="<?php echo esc_url( home_url( '/my-patterns' ) ); ?>"><?php esc_html_e( 'My patterns', 'wporg-patterns' ); ?></a>
 					</div>
 				<?php else : ?>
 					<div>

--- a/public_html/wp-content/themes/pattern-directory/header.php
+++ b/public_html/wp-content/themes/pattern-directory/header.php
@@ -27,10 +27,14 @@ get_template_part( 'header', 'wporg' );
 		<header id="masthead" class="site-header <?php echo is_home() ? 'home' : ''; ?>" role="banner">
 			<div class="site-branding">
 				<?php if ( is_home() ) : ?>
-					<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo esc_html_x( 'Patterns', 'Site title', 'wporg-patterns' ); ?></a></h1>
+					<div>
+						<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo esc_html_x( 'Patterns', 'Site title', 'wporg-patterns' ); ?></a></h1>
 
-					<p class="site-description"><?php esc_html_e( 'Add a beautifully designed, ready to go layout to any WordPress site with a simple copy/paste.', 'wporg-patterns' ); ?></p>
-					<?php get_search_form(); ?>
+						<p class="site-description"><?php esc_html_e( 'Add a beautifully designed, ready to go layout to any WordPress site with a simple copy/paste.', 'wporg-patterns' ); ?></p>
+						<?php get_search_form(); ?>
+						<a class="site-link" href="<?php echo esc_url( home_url( '/my-favorites' ) ); ?>"><?php esc_html_e( 'My Favorites', 'wporg-patterns' ); ?></a>
+						<a class="site-link" href="<?php echo esc_url( home_url( '/my-patterns' ) ); ?>"><?php esc_html_e( 'My Patterns', 'wporg-patterns' ); ?></a>
+					</div>
 				<?php else : ?>
 					<div>
 						<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">

--- a/public_html/wp-content/themes/pattern-directory/header.php
+++ b/public_html/wp-content/themes/pattern-directory/header.php
@@ -33,7 +33,6 @@ get_template_part( 'header', 'wporg' );
 						<p class="site-description"><?php esc_html_e( 'Add a beautifully designed, ready to go layout to any WordPress site with a simple copy/paste.', 'wporg-patterns' ); ?></p>
 						<?php get_search_form(); ?>
 						<a class="site-link" href="<?php echo esc_url( home_url( '/my-favorites' ) ); ?>"><?php esc_html_e( 'My favorites', 'wporg-patterns' ); ?></a>
-						<a class="site-link" href="<?php echo esc_url( home_url( '/my-patterns' ) ); ?>"><?php esc_html_e( 'My patterns', 'wporg-patterns' ); ?></a>
 					</div>
 				<?php else : ?>
 					<div>


### PR DESCRIPTION
Depends on: #284.

This PR adds 2 links to the header:
- My Favorites
- My Pattern

These links are present regardless if the user is logged in for consistency and since each of the pages detect the user's login state and redirects them to log in that should work.

This diverges from the initial design where the logged-out state doesn't include those links.

I think it's fine if we diverge because otherwise, the user only has 3 suboptimal ways to get to their patterns or favorites:

1. Visit `/` page, select different category, refresh the page.
2. Search for a pattern.
3. View a specific pattern.

Once you do either of those 3 things, the sub nav will show up revealing the links.

## Designs
![](https://d.pr/i/4mzT2d.png)

## Screenshots
This is what is implemented.

![](https://d.pr/i/e0roxQ.png)

### How to test the changes in this Pull Request:

1. Visit `/`
2. Click on both links

