### PR TITLE
Add Build job to create a "production ready" branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build and push to build branch.
+
+on:
+  push:
+    branches:
+      - trunk
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build and Push
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install all dependencies
+        run: npm install && yarn
+
+      - name: Build
+        run: yarn workspaces run build
+    
+      - name: Commit and push
+        # Using a specific hash here instead of a tagged version, for risk mitigation, since this action modifies our repo.
+        uses: actions-js/push@4decc2887d2770f29177082be3c8b04d342f5b64
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: build
+          message: Build: ${{ GITHUB_SHA }})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
              rm package-lock.json
              git add public_html/wp-content/themes/pattern-directory/css/* --force
-             git add public_html/wp-content/plugins/*/build --force
+             git add public_html/wp-content/plugins/pattern-*/build --force
     
       - name: Commit and push
         # Using a specific hash here instead of a tagged version, for risk mitigation, since this action modifies our repo.
@@ -33,4 +33,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: build
+          force: true
           message: "Build: ${{ github.sha }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,23 +8,36 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build and Push
     steps:
       - uses: actions/checkout@v2
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+       run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
       - name: Install all dependencies
         run: |
-             npm install
-             yarn
-             composer install
-
-      - name: Build
-        run: yarn workspaces run build
+          composer install
+          yarn
 
       - name: Ignore .gitignore
         run: |
-             rm package-lock.json
              git add public_html/wp-content/themes/pattern-directory/css/* --force
+             git add public_html/wp-content/themes/pattern-directory/build --force
              git add public_html/wp-content/plugins/pattern-*/build --force
     
       - name: Commit and push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: build
-          message: "Build: ${{ GITHUB_SHA }}"
+          message: "Build: ${{ github.sha }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Ignore .gitignore
         run: |
              git add public_html/wp-content/themes/pattern-directory/css/* --force
-             git add public_html/wp-content/themes/pattern-directory/build --force
+             git add public_html/wp-content/themes/pattern-directory/build --force || exit 0
              git add public_html/wp-content/plugins/pattern-*/build --force
     
       - name: Commit and push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-       run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Ignore .gitignore
         run: |
-             rm package.lock
+             rm package-lock.json
              git add public_html/wp-content/themes/pattern-directory/css/* --force
              git add public_html/wp-content/plugins/*/build --force
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,12 @@ jobs:
 
       - name: Build
         run: yarn workspaces run build
+
+      - name: Ignore .gitignore
+        run: |
+             rm package.lock
+             git add public_html/wp-content/themes/pattern-directory/css/* --force
+             git add public_html/wp-content/plugins/*/build --force
     
       - name: Commit and push
         # Using a specific hash here instead of a tagged version, for risk mitigation, since this action modifies our repo.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: build
-          message: Build: ${{ GITHUB_SHA }})
+          message: "Build: ${{ GITHUB_SHA }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install all dependencies
-        run: npm install && yarn
+        run: |
+             npm install
+             yarn
+             composer install
 
       - name: Build
         run: yarn workspaces run build


### PR DESCRIPTION
While working on #282 I've run into an issue where the GlotPress string extraction/import doesn't have access to the final location for the strings contained within the javascript.

This is because we import the strings directly from this GitHub repo, but, the build json translation files need to reference the file that is enqueued - `build/index.js`, not `src/components/pattern-preview-actions/copy-success-message.js`.

This PR adds an action that runs the build process and pushes the resulting changes to a `build` branch, which can then be used as the base for the GlotPress string extraction. As a bonus, it can also be used as a pre-built set of files for easier deployment back to WordPress.org. 

Things of note:
 - The i18n building added in #275 could be merged into this instead of committing to the trunk branch. I'm not sure if we'd want to run the fetch-from-wp-json on every commit here though.
 - I wasn't quite sure what I was doing, and as a result, I had to `git add .. --force` some things that `.gitignore` ignores, there's probably a better way, but it might also be a shortcoming of the commit action chosen.
 - package-lock.json isn't committed to the repo, but yarn.lock and composer.lock are. I `rm`'d it to keep the branch pushes to just the relevant changes.
 - I haven't added a `cache` step into the workflow yet, as such the install process takes ~2minutes in the action. Caching that would speed it up significantly.
 - I'm not sure if the build commands run here are the correct ones to generate a production-ready set of build files.

See #282