### PR TITLE
Theme: Update data passed from the server to the app

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -73,12 +73,30 @@ function enqueue_assets() {
 
 		wp_add_inline_script(
 			'wporg-pattern-script',
+			sprintf( "var wporgLocale = '%s';", wp_json_encode( get_locale() ) ),
+			'before'
+		);
+
+		wp_add_inline_script(
+			'wporg-pattern-script',
 			sprintf(
-				'var wporgAssetUrl = "%s", wporgSiteUrl = "%s", wporgLoginUrl = "%s", wporgLocale = \'%s\';',
-				esc_url( get_stylesheet_directory_uri() ),
-				esc_url( home_url() ),
-				esc_url( wp_login_url() ),
-				wp_json_encode( get_locale() )
+				"var wporgPatternsData = JSON.parse( decodeURIComponent( '%s' ) )",
+				rawurlencode( wp_json_encode( array(
+					'userId' => get_current_user_id(),
+				) ) ),
+			),
+			'before'
+		);
+
+		wp_add_inline_script(
+			'wporg-pattern-script',
+			sprintf(
+				"var wporgPatternsUrl = JSON.parse( decodeURIComponent( '%s' ) )",
+				rawurlencode( wp_json_encode( array(
+					'assets' => esc_url( get_stylesheet_directory_uri() ),
+					'site' => esc_url( home_url() ),
+					'login' => esc_url( wp_login_url() ),
+				) ) ),
 			),
 			'before'
 		);

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -62,10 +62,9 @@
 	"eslintConfig": {
 		"extends": "../../../../.eslintrc.js",
 		"globals": {
-			"wporgAssetUrl": "readonly",
-			"wporgLoginUrl": "readonly",
-			"wporgSiteUrl": "readonly",
-			"wporgLocale": "readonly"
+			"wporgLocale": "readonly",
+			"wporgPatternsData": "readonly",
+			"wporgPatternsUrl": "readonly"
 		}
 	},
 	"stylelint": {

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -40,7 +40,6 @@ $raw_block_content = get_the_content();
 					hidden
 					class="pattern__container"
 					data-post-id="<?php echo intval( get_the_ID() ); ?>"
-					data-logged-in="<?php echo json_encode( is_user_logged_in() ); ?>"
 					data-user-has-reported="<?php echo json_encode( $user_has_reported ); ?>"
 				></div><!-- .pattern__container -->
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { store as coreStore } from '@wordpress/core-data';
 import { store as patternStore } from '../../store';
 import { useSelect } from '@wordpress/data';
 
@@ -18,10 +17,10 @@ import { RouteProvider } from '../../hooks';
 
 const MyPatterns = () => {
 	const query = useSelect( ( select ) => select( patternStore ).getCurrentQuery() );
-	const author = useSelect( ( select ) => select( coreStore ).getCurrentUser()?.id );
+	const author = wporgPatternsData.userId;
 
 	if ( ! author ) {
-		const loginUrl = addQueryArgs( wporgLoginUrl, { redirect_to: window.location } );
+		const loginUrl = addQueryArgs( wporgPatternsUrl.login, { redirect_to: window.location } );
 		return (
 			<div className="entry-content">
 				<p>{ __( 'Please log in to view your patterns.', 'wporg-patterns' ) }</p>

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/menu.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/menu.js
@@ -20,17 +20,17 @@ export default function () {
 	// @todo Load from an API to get pattern counts.
 	const options = [
 		{
-			value: `${ wporgSiteUrl }/my-patterns/`,
+			value: `${ wporgPatternsUrl.site }/my-patterns/`,
 			slug: 'all',
 			label: __( 'All', 'wporg-patterns' ),
 		},
 		{
-			value: `${ wporgSiteUrl }/my-patterns/draft/`,
+			value: `${ wporgPatternsUrl.site }/my-patterns/draft/`,
 			slug: 'draft',
 			label: __( 'Drafts', 'wporg-patterns' ),
 		},
 		{
-			value: `${ wporgSiteUrl }/my-patterns/pending/`,
+			value: `${ wporgPatternsUrl.site }/my-patterns/pending/`,
 			slug: 'pending',
 			label: __( 'Pending Review', 'wporg-patterns' ),
 		},

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-guide.js
@@ -9,7 +9,7 @@ const CopyPasteImage = () => (
 	// Wrap the image to avoid the UI shift after the GIF loads
 	<div style={ { height: '220px' } }>
 		<img
-			src={ `${ wporgAssetUrl }/images/copy-paste-demo.gif` }
+			src={ `${ wporgPatternsUrl.assets }/images/copy-paste-demo.gif` }
 			alt={ __( 'GIF of copy and pasting.', 'wporg-patterns' ) }
 		/>
 	</div>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
@@ -15,7 +15,7 @@ import PatternThumbnail from '../pattern-thumbnail';
 import ReportPatternButton from '../report-pattern-button';
 import { store as patternStore } from '../../store';
 
-const Pattern = ( { postId, userHasReported, loggedIn } ) => {
+const Pattern = ( { postId, userHasReported } ) => {
 	// postId as passed from the HTML dataset is a string.
 	postId = Number( postId ) || 0;
 	const pattern = useSelect( ( select ) => select( patternStore ).getPattern( postId ), [ postId ] );
@@ -29,11 +29,7 @@ const Pattern = ( { postId, userHasReported, loggedIn } ) => {
 			<div className="pattern-preview__container">
 				<PatternPreview blockContent={ pattern.content.rendered } />
 				<div className="pattern__meta">
-					<ReportPatternButton
-						userHasReported={ userHasReported === 'true' }
-						loggedIn={ loggedIn === 'true' }
-						postId={ postId }
-					/>
+					<ReportPatternButton userHasReported={ userHasReported === 'true' } postId={ postId } />
 				</div>
 			</div>
 			<div className="entry-content">

--- a/public_html/wp-content/themes/pattern-directory/src/components/report-pattern-button/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/report-pattern-button/index.js
@@ -12,10 +12,11 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import ReportPatternModal from '../report-pattern-modal';
 
-const ReportPatternButton = ( { postId, loggedIn, userHasReported } ) => {
+const ReportPatternButton = ( { postId, userHasReported } ) => {
 	const [ showModal, setShowModal ] = useState( false );
 	const [ hasSubmitted, setHasSubmitted ] = useState( false );
 	const alreadySubmitted = userHasReported || hasSubmitted;
+	const isLoggedIn = !! wporgPatternsData.userId;
 
 	if ( alreadySubmitted ) {
 		return (
@@ -26,7 +27,7 @@ const ReportPatternButton = ( { postId, loggedIn, userHasReported } ) => {
 		);
 	}
 
-	if ( ! loggedIn ) {
+	if ( ! isLoggedIn ) {
 		return (
 			<p className="pattern-report-button__copy">
 				<a

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
@@ -8,7 +8,7 @@ import apiPatternFlagReasons from './fixtures/pattern-flag-reasons';
 import { categories, favorites, patternFlagReasons, patterns } from '../reducer';
 
 // Set up the global.
-global.wporgPatternsUrl.site = 'http://localhost:8889/';
+global.wporgPatternsUrl = { site: 'http://localhost:8889/' };
 
 describe( 'state', () => {
 	describe( 'patterns', () => {

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/reducer.js
@@ -8,7 +8,7 @@ import apiPatternFlagReasons from './fixtures/pattern-flag-reasons';
 import { categories, favorites, patternFlagReasons, patterns } from '../reducer';
 
 // Set up the global.
-global.wporgSiteUrl = 'http://localhost:8889/';
+global.wporgPatternsUrl.site = 'http://localhost:8889/';
 
 describe( 'state', () => {
 	describe( 'patterns', () => {

--- a/public_html/wp-content/themes/pattern-directory/src/store/utils.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/utils.js
@@ -53,6 +53,6 @@ export function getAllCategory() {
 		id: -1,
 		slug: '', // Slug matches url
 		name: __( 'All', 'wporg-patterns' ),
-		link: wporgSiteUrl,
+		link: wporgPatternsUrl.site,
 	};
 }


### PR DESCRIPTION
This reorganizes the data passed into the JS app on global variables. All the URLs are now part of an object `wporgPatternsUrl`, the locale stays as `wporgLocale`, and a new variable `wporgPatternsData` is added, which passes in the current user ID. This replaces the user ID passed in on the single pattern container.

See https://github.com/WordPress/pattern-directory/pull/284#discussion_r670674587 for what prompted this. Technically, we can get the current user with `select( coreStore ).getCurrentUser()`, but there is no distinction between the loading state and logged out state. If we provide this value from the server, there is no loading state, so if the ID is 0, they're not logged in.

### Screenshots

There should be no visual changes.

