### PR TITLE
Tools: Create a production-ready theme build, add dev build step for plugins

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/package.json
+++ b/public_html/wp-content/plugins/pattern-creator/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"build": "wp-scripts build",
+		"dev": "NODE_ENV=development wp-scripts build",
 		"format:js": "wp-scripts format src -- --config=../../../../.prettierrc.js",
 		"lint:css": "wp-scripts lint-style style.css src",
 		"lint:js": "wp-scripts lint-js src",

--- a/public_html/wp-content/plugins/pattern-directory/package.json
+++ b/public_html/wp-content/plugins/pattern-directory/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"build": "wp-scripts build pattern-post-type=./src/pattern-post-type.js",
+		"dev": "NODE_ENV=development wp-scripts build pattern-post-type=./src/pattern-post-type.js",
 		"format:js": "wp-scripts format src -- --config=../../../../.prettierrc.js",
 		"lint:css": "wp-scripts lint-style src",
 		"lint:js": "wp-scripts lint-js src",

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -11,7 +11,7 @@
 	},
 	"scripts": {
 		"start": "grunt watch",
-		"build": "grunt build",
+		"build": "NODE_ENV=production grunt build",
 		"build:css": "grunt css",
 		"build:js": "grunt js",
 		"dev": "grunt",
@@ -48,6 +48,7 @@
 		"classnames": "2.3.1",
 		"cssnano": "5.0.5",
 		"grunt": "1.4.1",
+		"grunt-contrib-clean": "2.0.0",
 		"grunt-contrib-watch": "1.1.0",
 		"grunt-sass": "3.1.0",
 		"grunt-sass-globbing": "1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4256,7 +4256,7 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async@^2.5.0, async@^2.6.0, async@^2.6.2:
+async@^2.5.0, async@^2.6.0, async@^2.6.1, async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -7631,6 +7631,14 @@ grunt-cli@~1.4.2:
     liftup "~3.0.1"
     nopt "~4.0.1"
     v8flags "~3.2.0"
+
+grunt-contrib-clean@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/grunt-contrib-clean/-/grunt-contrib-clean-2.0.0.tgz#3be7ca480da4b740aa5e9d863e2f7e8b24f8a68b"
+  integrity sha512-g5ZD3ORk6gMa5ugZosLDQl3dZO7cI3R14U75hTM+dVLVxdMNJCPVmwf9OUt4v4eWgpKKWWoVK9DZc1amJp4nQw==
+  dependencies:
+    async "^2.6.1"
+    rimraf "^2.6.2"
 
 grunt-contrib-watch@1.1.0:
   version "1.1.0"
@@ -12147,7 +12155,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@^2.5.4, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==


### PR DESCRIPTION
See #290 - When testing out that PR, I noticed that the 2 plugin build steps _do_ create production-ready builds, but the theme step does not. 

A refresher-overview of the build process:

Everything is run with `yarn workspaces run build`. This runs the `build` script in each sub-project's package.json:
- In `wporg-pattern-creator` — `wp-scripts build`, runs webpack
- In `wporg-pattern-directory` — `wp-scripts build pattern-post-type=./src/pattern-post-type.js` runs webpack
- In `wporg-pattern-directory-theme` — `grunt build`
  - Grunt builds the css with sass & postcss and the js with webpack, using the config from wp-scripts

The `wp-scripts build` script sets `NODE_ENV=production`, so the webpack step in the plugins already builds the production versions. If we wanted non-prod versions, we could say `NODE_ENV=development wp-scripts build`.

The grunt step does not set `NODE_ENV`, so it did not build production builds, and I'm not totally sure if the `'build' !== process.argv[ 2 ]` was ever set. 

This PR changes how the theme's build step works:

- Added `grunt-contrib-clean` to get rid of previous files and sourcemap files before building
- The CSS check for production uses `NODE_ENV`, just like the webpack step
- The theme's build step sets `NODE_ENV=production`, to mirror behavior in `wp-scripts build`

It also adds `dev` scripts to the plugins which will build the files for development (unminified, with sourcemaps and react debugging on).

### How to test the changes in this Pull Request:

1. Run the build step: `yarn workspaces run build`
2. The files should all be minified, no sourcemaps, check in
  public_html/wp-content/themes/pattern-directory/build
  public_html/wp-content/themes/pattern-directory/css
  public_html/wp-content/plugins/pattern-creator/build
  public_html/wp-content/plugins/pattern-directory/build
3. No functionality on the site should change.
4. Run the dev step: `yarn workspaces run dev`
5. Now the files will be larger, and there will be `.map` files too.

These scripts can also be run on individual workspaces, for example, `yarn workspace wporg-pattern-creator build`