### PR TITLE
Stats snapshots for patterns

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -14,6 +14,6 @@ require_once __DIR__ . '/includes/pattern-post-type.php';
 require_once __DIR__ . '/includes/pattern-flag-post-type.php';
 require_once __DIR__ . '/includes/pattern-validation.php';
 require_once __DIR__ . '/includes/search.php';
-require_once __DIR__ . '/includes/admin.php';
 require_once __DIR__ . '/includes/favorite.php';
 require_once __DIR__ . '/includes/stats.php';
+require_once __DIR__ . '/includes/admin.php';

--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -16,3 +16,4 @@ require_once __DIR__ . '/includes/pattern-validation.php';
 require_once __DIR__ . '/includes/search.php';
 require_once __DIR__ . '/includes/admin.php';
 require_once __DIR__ . '/includes/favorite.php';
+require_once __DIR__ . '/includes/stats.php';

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
@@ -4,6 +4,7 @@ namespace WordPressdotorg\Pattern_Directory\Admin\Patterns;
 
 use WP_Post, WP_Query;
 use function WordPressdotorg\Locales\get_locales_with_english_names;
+use function WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\get_pattern_ids_with_pending_flags;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\TAX_TYPE as FLAG_REASON;
@@ -192,34 +193,15 @@ function handle_pattern_list_table_views( WP_Query $query ) {
 		return;
 	}
 
-	global $wpdb;
-
 	$current_screen = get_current_screen();
 
 	if ( 'edit-' . PATTERN === $current_screen->id ) {
-		$orderby = $query->get( 'orderby', 'date' );
-		$order   = $query->get( 'order', 'desc' );
-
-		// For string interpolation.
-		$pattern = PATTERN;
-		$flag    = FLAG;
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$valid_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"
-				SELECT DISTINCT patterns.ID
-				FROM {$wpdb->posts} patterns
-					JOIN {$wpdb->posts} flags ON patterns.ID = flags.post_parent AND flags.post_type = '{$flag}' AND flags.post_status = 'pending'
-				WHERE patterns.post_type = '{$pattern}'
-				ORDER BY %s %s
-				",
-				$orderby,
-				$order
-			)
+		$args = array(
+			'orderby' => $query->get( 'orderby', 'date' ),
+			'order'   => $query->get( 'order', 'desc' ),
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$valid_ids = get_pattern_ids_with_pending_flags( $args );
 
 		if ( empty( $valid_ids ) ) {
 			$valid_ids = false;

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -24,8 +24,8 @@ function add_subpage() {
 
 	add_submenu_page(
 		$parent_slug,
-		__( 'Pattern Stats', 'revisions-extended' ),
-		__( 'Stats', 'revisions-extended' ),
+		__( 'Pattern Stats', 'wporg-patterns' ),
+		__( 'Stats', 'wporg-patterns' ),
 		$post_type_object->cap->edit_posts,
 		PATTERN_POST_TYPE . '-stats',
 		__NAMESPACE__ . '\render_subpage'
@@ -60,7 +60,7 @@ function render_subpage() {
 				<?php foreach ( $schema['properties'] as $field_name => $field_schema ) : ?>
 					<tr>
 						<td>
-							<abbr title="<?php echo esc_attr( $field_schema['description'] ) ?>">
+							<abbr title="<?php echo esc_attr( $field_schema['description'] ); ?>">
 								<?php echo esc_html( $field_name ); ?>
 							</abbr>
 						</td>

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -42,6 +42,7 @@ function render_subpage() {
 	$data           = get_snapshot_data();
 	$snapshot_query = get_snapshots( array(), true );
 	$snapshots      = $snapshot_query->get_posts();
+	$next_snapshot  = wp_get_scheduled_event( PATTERN_POST_TYPE . '_record_snapshot' );
 
 	?>
 	<style>
@@ -110,7 +111,21 @@ function render_subpage() {
 			Snapshots
 		</h2>
 
-		<p>Snapshot frequency is daily at 00:00 UTC.</p>
+		<p>
+			Snapshot frequency should be daily at around 00:00 UTC.
+			<strong>
+				<?php if ( $next_snapshot ) : ?>
+					<?php
+					printf(
+						'The next snapshot will be captured on %s.',
+						wp_date( 'r', $next_snapshot->timestamp )
+					);
+					?>
+				<?php else : ?>
+					No snapshot is currently scheduled.
+				<?php endif; ?>
+			</strong>
+		</p>
 
 		<table class="widefat but-not-too-wide striped">
 			<tbody>

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -68,7 +68,11 @@ function render_subpage() {
 						</td>
 						<td>
 							<?php if ( isset( $data[ $field_name ] ) ) : ?>
-								<?php echo esc_html( $data[ $field_name ] ); ?>
+								<?php if ( is_numeric( $data[ $field_name ] ) ) : ?>
+									<?php echo esc_html( number_format_i18n( $data[ $field_name ] ) ); ?>
+								<?php else : ?>
+									<?php echo esc_html( $data[ $field_name ] ); ?>
+								<?php endif; ?>
 							<?php else : ?>
 								Data missing.
 							<?php endif; ?>

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -118,7 +118,7 @@ function render_subpage() {
 					<?php
 					printf(
 						'The next snapshot will be captured on %s.',
-						wp_date( 'r', $next_snapshot->timestamp )
+						esc_html( wp_date( 'r', $next_snapshot->timestamp ) )
 					);
 					?>
 				<?php else : ?>

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Admin\Stats;
+
+use function WordPressdotorg\Pattern_Directory\Stats\{ get_meta_field_schema, get_snapshot_data };
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN_POST_TYPE;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_action( 'admin_menu', __NAMESPACE__ . '\add_subpage' );
+
+/**
+ * Register an admin page under Block Patterns for viewing stats.
+ *
+ * @return void
+ */
+function add_subpage() {
+	$parent_slug = add_query_arg( 'post_type', PATTERN_POST_TYPE, 'edit.php' );
+
+	$post_type_object = get_post_type_object( PATTERN_POST_TYPE );
+
+	add_submenu_page(
+		$parent_slug,
+		__( 'Pattern Stats', 'revisions-extended' ),
+		__( 'Stats', 'revisions-extended' ),
+		$post_type_object->cap->edit_posts,
+		PATTERN_POST_TYPE . '-stats',
+		__NAMESPACE__ . '\render_subpage'
+	);
+}
+
+/**
+ * Render the stats subpage.
+ *
+ * @return void
+ */
+function render_subpage() {
+	$schema = get_meta_field_schema();
+	$data   = get_snapshot_data();
+
+	?>
+	<div class="wrap">
+		<h1 class="wp-heading-inline">
+			<?php esc_html_e( 'Pattern Stats', 'wporg-patterns' ); ?>
+		</h1>
+
+		<p>
+			This page is a work in progress. Someday there might be charts!
+		</p>
+
+		<h2>
+			Right now:
+		</h2>
+
+		<table class="striped">
+			<tbody>
+				<?php foreach ( $schema['properties'] as $field_name => $field_schema ) : ?>
+					<tr>
+						<td>
+							<abbr title="<?php echo esc_attr( $field_schema['description'] ) ?>">
+								<?php echo esc_html( $field_name ); ?>
+							</abbr>
+						</td>
+						<td>
+							<?php if ( isset( $data[ $field_name ] ) ) : ?>
+								<?php echo esc_html( $data[ $field_name ] ); ?>
+							<?php else : ?>
+								Data missing.
+							<?php endif; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	</div>
+	<?php
+}

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -2,7 +2,7 @@
 
 namespace WordPressdotorg\Pattern_Directory\Admin\Stats;
 
-use function WordPressdotorg\Pattern_Directory\Stats\{ get_meta_field_schema, get_snapshot_data };
+use function WordPressdotorg\Pattern_Directory\Stats\{ get_meta_field_schema, get_snapshot_data, get_snapshots };
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN_POST_TYPE;
 
 defined( 'WPINC' ) || die();
@@ -38,8 +38,10 @@ function add_subpage() {
  * @return void
  */
 function render_subpage() {
-	$schema = get_meta_field_schema();
-	$data   = get_snapshot_data();
+	$schema         = get_meta_field_schema();
+	$data           = get_snapshot_data();
+	$snapshot_query = get_snapshots( array(), true );
+	$snapshots      = $snapshot_query->get_posts();
 
 	?>
 	<div class="wrap">
@@ -52,7 +54,7 @@ function render_subpage() {
 		</p>
 
 		<h2>
-			Right now:
+			Right now
 		</h2>
 
 		<table class="widefat striped">
@@ -75,6 +77,56 @@ function render_subpage() {
 				<?php endforeach; ?>
 			</tbody>
 		</table>
+
+		<h2>
+			Snapshots
+		</h2>
+
+		<p>Snapshot frequency is daily at 00:00 UTC.</p>
+
+		<table class="widefat striped">
+			<tbody>
+				<tr>
+					<td>
+						Number of snapshots
+					</td>
+					<td>
+						<?php echo esc_html( $snapshot_query->found_posts ); ?>
+					</td>
+				</tr>
+				<tr>
+					<td>
+						Earliest snapshot
+					</td>
+					<td>
+						<?php if ( $snapshot_query->found_posts > 0 ) : ?>
+							<?php echo esc_html( reset( $snapshots )->post_title ); ?>
+						<?php else : ?>
+							No data.
+						<?php endif; ?>
+					</td>
+				</tr>
+				<tr>
+					<td>
+						Latest snapshot
+					</td>
+					<td>
+						<?php if ( $snapshot_query->found_posts > 0 ) : ?>
+							<?php echo esc_html( end( $snapshots )->post_title ); ?>
+						<?php else : ?>
+							No data.
+						<?php endif; ?>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<h2>
+			Export
+		</h2>
+		<p>
+			Coming soon! 🎉
+		</p>
 	</div>
 	<?php
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -44,6 +44,16 @@ function render_subpage() {
 	$snapshots      = $snapshot_query->get_posts();
 
 	?>
+	<style>
+		.number {
+			font-weight: 700;
+			text-align: right;
+		}
+
+		.widefat.but-not-too-wide {
+			width: auto;
+		}
+	</style>
 	<div class="wrap">
 		<h1 class="wp-heading-inline">
 			<?php esc_html_e( 'Pattern Stats', 'wporg-patterns' ); ?>
@@ -57,16 +67,30 @@ function render_subpage() {
 			Right now
 		</h2>
 
-		<table class="widefat striped">
+		<table class="widefat but-not-too-wide striped">
+			<thead>
+				<tr>
+					<th>
+						Meta Key
+					</th>
+					<td>
+						Description
+					</td>
+					<td>
+						Value
+					</td>
+				</tr>
+			</thead>
 			<tbody>
 				<?php foreach ( $schema['properties'] as $field_name => $field_schema ) : ?>
 					<tr>
+						<th>
+							<code><?php echo esc_html( $field_name ); ?></code>
+						</th>
 						<td>
-							<abbr title="<?php echo esc_attr( $field_schema['description'] ); ?>">
-								<?php echo esc_html( $field_name ); ?>
-							</abbr>
+							<?php echo esc_html( $field_schema['description'] ); ?>
 						</td>
-						<td>
+						<td class="<?php if ( is_numeric( $data[ $field_name ] ) ) echo 'number'; ?>">
 							<?php if ( isset( $data[ $field_name ] ) ) : ?>
 								<?php if ( is_numeric( $data[ $field_name ] ) ) : ?>
 									<?php echo esc_html( number_format_i18n( $data[ $field_name ] ) ); ?>
@@ -88,7 +112,7 @@ function render_subpage() {
 
 		<p>Snapshot frequency is daily at 00:00 UTC.</p>
 
-		<table class="widefat striped">
+		<table class="widefat but-not-too-wide striped">
 			<tbody>
 				<tr>
 					<td>

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -90,7 +90,7 @@ function render_subpage() {
 						<td>
 							<?php echo esc_html( $field_schema['description'] ); ?>
 						</td>
-						<td class="<?php if ( is_numeric( $data[ $field_name ] ) ) echo 'number'; ?>">
+						<td class="<?php echo ( is_numeric( $data[ $field_name ] ) ) ? 'number' : ''; ?>">
 							<?php if ( isset( $data[ $field_name ] ) ) : ?>
 								<?php if ( is_numeric( $data[ $field_name ] ) ) : ?>
 									<?php echo esc_html( number_format_i18n( $data[ $field_name ] ) ); ?>

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -118,8 +118,8 @@ function render_subpage() {
 					<td>
 						Number of snapshots
 					</td>
-					<td>
-						<?php echo esc_html( $snapshot_query->found_posts ); ?>
+					<td class="number">
+						<?php echo esc_html( number_format_i18n( $snapshot_query->found_posts ) ); ?>
 					</td>
 				</tr>
 				<tr>

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -55,7 +55,7 @@ function render_subpage() {
 			Right now:
 		</h2>
 
-		<table class="striped">
+		<table class="widefat striped">
 			<tbody>
 				<?php foreach ( $schema['properties'] as $field_name => $field_schema ) : ?>
 					<tr>

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin.php
@@ -6,3 +6,4 @@ defined( 'WPINC' ) || die();
 
 require_once __DIR__ . '/admin-flags.php';
 require_once __DIR__ . '/admin-patterns.php';
+require_once __DIR__ . '/admin-stats.php';

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -153,7 +153,7 @@ function check_flag_threshold( $post_ID, $post, $update ) {
  *
  * @param array $args Optional. Query args. 'orderby' and/or 'order'.
  *
- * @return array
+ * @return int[]
  */
 function get_pattern_ids_with_pending_flags( $args = array() ) {
 	global $wpdb;

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -151,11 +151,11 @@ function check_flag_threshold( $post_ID, $post, $update ) {
  *
  * TODO this isn't used anywhere on the front end, but maybe it should be cached?
  *
- * @param array $args Query args. 'orderby' and/or 'order'.
+ * @param array $args Optional. Query args. 'orderby' and/or 'order'.
  *
  * @return array
  */
-function get_pattern_ids_with_pending_flags( $args ) {
+function get_pattern_ids_with_pending_flags( $args = array() ) {
 	global $wpdb;
 
 	$args = wp_parse_args(

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -145,3 +145,49 @@ function check_flag_threshold( $post_ID, $post, $update ) {
 		) );
 	}
 }
+
+/**
+ * Get a list of post IDs for patterns that have pending flags.
+ *
+ * TODO this isn't used anywhere on the front end, but maybe it should be cached?
+ *
+ * @param array $args Query args. 'orderby' and/or 'order'.
+ *
+ * @return array
+ */
+function get_pattern_ids_with_pending_flags( $args ) {
+	global $wpdb;
+
+	$args = wp_parse_args(
+		$args,
+		array(
+			'orderby' => 'date',
+			'order'   => 'desc',
+		)
+	);
+
+	// For string interpolation.
+	$pattern = PATTERN;
+	$flag    = POST_TYPE;
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+	$pattern_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"
+			SELECT DISTINCT patterns.ID
+			FROM {$wpdb->posts} patterns
+				JOIN {$wpdb->posts} flags ON patterns.ID = flags.post_parent
+					AND flags.post_type = '{$flag}'
+				    AND flags.post_status = 'pending'
+			WHERE patterns.post_type = '{$pattern}'
+			ORDER BY %s %s
+			",
+			$args['orderby'],
+			$args['order']
+		)
+	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	return $pattern_ids;
+}

--- a/public_html/wp-content/plugins/pattern-directory/includes/stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/stats.php
@@ -19,8 +19,8 @@ const STATS_POST_TYPE = 'wporg-pattern-stats'; // Must be <= 20 characters.
  */
 add_action( 'init', __NAMESPACE__ . '\register_cpt' );
 add_action( 'init', __NAMESPACE__ . '\register_meta_fields' );
-//add_action( 'init', __NAMESPACE__ . '\schedule_cron_job' );
-//add_action( PATTERN_POST_TYPE . '_record_snapshot', __NAMESPACE__ . '\record_snapshot' );
+add_action( 'init', __NAMESPACE__ . '\schedule_cron_job' );
+add_action( PATTERN_POST_TYPE . '_record_snapshot', __NAMESPACE__ . '\record_snapshot' );
 
 /**
  * Register a post type for storing snapshots.
@@ -141,6 +141,10 @@ function register_meta_fields() {
  * @return void
  */
 function schedule_cron_job() {
+	if ( defined( 'WPORG_SANDBOXED' ) ) {
+		return;
+	}
+
 	if ( wp_next_scheduled( PATTERN_POST_TYPE . '_record_snapshot' ) ) {
 		return;
 	}
@@ -158,6 +162,10 @@ function schedule_cron_job() {
  * @return void
  */
 function record_snapshot() {
+	if ( defined( 'WPORG_SANDBOXED' ) ) {
+		return;
+	}
+
 	$data = get_snapshot_data();
 
 	wp_insert_post(

--- a/public_html/wp-content/plugins/pattern-directory/includes/stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/stats.php
@@ -125,7 +125,7 @@ function get_meta_field_schema() {
 /**
  * Register the post meta fields for the snapshot CPT.
  *
- * return void
+ * @return void
  */
 function register_meta_fields() {
 	$schema = get_meta_field_schema();
@@ -137,6 +137,8 @@ function register_meta_fields() {
 
 /**
  * Schedule the cron job to record a stats snapshot.
+ *
+ * @return void
  */
 function schedule_cron_job() {
 	if ( wp_next_scheduled( PATTERN_POST_TYPE . '_record_snapshot' ) ) {

--- a/public_html/wp-content/plugins/pattern-directory/includes/stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/stats.php
@@ -64,6 +64,18 @@ function get_meta_field_schema() {
 				'default'     => 0,
 				'single'      => true,
 			),
+			'count-patterns_publish-originals'         => array(
+				'description' => __( 'The total number of published original patterns (not translations or remixes).', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'count-patterns_publish-translations'         => array(
+				'description' => __( 'The total number of published pattern translations and remixes.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
 			'count-patterns_unlisted'        => array(
 				'description' => __( 'The total number of unlisted patterns.', 'wporg-patterns' ),
 				'type'        => 'integer',
@@ -229,6 +241,42 @@ function callback_count_patterns_publish() {
 	$patterns_by_status = wp_count_posts( PATTERN_POST_TYPE );
 
 	return $patterns_by_status->publish;
+}
+
+/**
+ * Count the total number of published original patterns (not translations or remixes).
+ *
+ * @return int
+ */
+function callback_count_patterns_publish_originals() {
+	$args = array(
+		'post_type'   => PATTERN_POST_TYPE,
+		'post_status' => 'publish',
+		'post_parent' => 0,
+		'numberposts' => 1,
+	);
+
+	$query = new \WP_Query( $args );
+
+	return $query->found_posts;
+}
+
+/**
+ * Count the total number of published pattern translations and remixes.
+ *
+ * @return int
+ */
+function callback_count_patterns_publish_translations() {
+	$args = array(
+		'post_type'           => PATTERN_POST_TYPE,
+		'post_status'         => 'publish',
+		'post_parent__not_in' => array( 0 ),
+		'numberposts'         => 1,
+	);
+
+	$query = new \WP_Query( $args );
+
+	return $query->found_posts;
 }
 
 /**

--- a/public_html/wp-content/plugins/pattern-directory/includes/stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/stats.php
@@ -355,3 +355,33 @@ function callback_count_users_with_favorite() {
 
 	return count( $user_ids );
 }
+
+/**
+ * Get snapshot posts.
+ *
+ * @param array $args     Optional. Query args to refine the dataset.
+ * @param bool  $wp_query Optional. True to return the WP_Query object instead of an array of post objects.
+ *
+ * @return int[]|\WP_Post[]|\WP_Query
+ */
+function get_snapshots( $args = array(), $wp_query = false ) {
+	$args = wp_parse_args(
+		$args,
+		array(
+			'orderby'        => 'date',
+			'order'          => 'asc',
+			'posts_per_page' => 365,
+		)
+	);
+
+	$args['post_type']   = STATS_POST_TYPE;
+	$args['post_status'] = 'publish';
+
+	$query = new \WP_Query( $args );
+
+	if ( true === $wp_query ) {
+		return $query;
+	}
+
+	return $query->get_posts();
+}

--- a/public_html/wp-content/plugins/pattern-directory/includes/stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/stats.php
@@ -1,0 +1,347 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Stats;
+
+use function WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\get_pattern_ids_with_pending_flags;
+use const WordPressdotorg\Pattern_Directory\Favorite\META_KEY as FAVORITE_META_KEY;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN_POST_TYPE;
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG_POST_TYPE;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Constants.
+ */
+const STATS_POST_TYPE = 'wporg-pattern-stats'; // Must be <= 20 characters.
+
+/**
+ * Actions and filters.
+ */
+add_action( 'init', __NAMESPACE__ . '\register_cpt' );
+add_action( 'init', __NAMESPACE__ . '\register_meta_fields' );
+//add_action( 'init', __NAMESPACE__ . '\schedule_cron_job' );
+//add_action( PATTERN_POST_TYPE . '_record_snapshot', __NAMESPACE__ . '\record_snapshot' );
+
+/**
+ * Register a post type for storing snapshots.
+ *
+ * @return void
+ */
+function register_cpt() {
+	register_post_type(
+		STATS_POST_TYPE,
+		array(
+			'label'           => __( 'Pattern Stats Snapshot', 'wporg-patterns' ),
+			'public'          => false,
+			'show_in_rest'    => false,
+			'capability-type' => STATS_POST_TYPE,
+			'capabilities'    => array(
+				'create_posts' => 'do_not_allow',
+			),
+			'supports'        => array( 'title', 'custom-fields' ),
+		)
+	);
+}
+
+/**
+ * Define the post meta fields for the snapshot CPT.
+ *
+ * @return array
+ */
+function get_meta_field_schema() {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'count-patterns'                 => array(
+				'description' => __( 'The total number of pattern posts.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'count-patterns_publish'         => array(
+				'description' => __( 'The total number of published patterns.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'count-patterns_unlisted'        => array(
+				'description' => __( 'The total number of unlisted patterns.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'count-patterns_favorited'       => array(
+				'description' => __( 'The total number of patterns with at least one favorite.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'count-patterns_flagged-pending' => array(
+				'description' => __( 'The total number of patterns with a pending flag.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'count-favorites'                => array(
+				'description' => __( 'The total number of favorites.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'count-flags'                    => array(
+				'description' => __( 'The total number of flags.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'count-flags_pending'            => array(
+				'description' => __( 'The total number of pending flags.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'count-flags_resolved'           => array(
+				'description' => __( 'The total number of resolved flags.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'count-users_with-favorite'      => array(
+				'description' => __( 'The total number of users with at least one favorited pattern.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+			'elapsed-time'                   => array(
+				'description' => __( 'Number of seconds to generate the snapshot.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => 0,
+				'single'      => true,
+			),
+		),
+	);
+}
+
+/**
+ * Register the post meta fields for the snapshot CPT.
+ *
+ * return void
+ */
+function register_meta_fields() {
+	$schema = get_meta_field_schema();
+
+	foreach ( $schema['properties'] as $field_name => $field_schema ) {
+		register_post_meta( STATS_POST_TYPE, $field_name, $field_schema );
+	}
+}
+
+/**
+ * Schedule the cron job to record a stats snapshot.
+ */
+function schedule_cron_job() {
+	if ( wp_next_scheduled( PATTERN_POST_TYPE . '_record_snapshot' ) ) {
+		return;
+	}
+
+	// Schedule a repeating "single" event to avoid having to create a custom schedule.
+	wp_schedule_single_event(
+		strtotime( 'tomorrow' ), // 00:00 UTC.
+		PATTERN_POST_TYPE . '_record_snapshot'
+	);
+}
+
+/**
+ * Generate a snapshot post.
+ *
+ * @return void
+ */
+function record_snapshot() {
+	$data = get_snapshot_data();
+
+	wp_insert_post(
+		array(
+			'post_type'   => STATS_POST_TYPE,
+			'post_author' => 0,
+			'post_title'  => gmdate( 'Y-m-d' ),
+			'post_status' => 'publish',
+			'meta_input'  => $data,
+		),
+		true
+	);
+}
+
+/**
+ * Generate the data that will be added to a snapshot post as post meta.
+ *
+ * @return array
+ */
+function get_snapshot_data() {
+	$data   = array();
+	$start  = time();
+	$schema = get_meta_field_schema();
+
+	foreach ( array_keys( $schema ) as $field_name ) {
+		if ( 'elapsed-time' === $field_name ) {
+			continue;
+		}
+
+		$func = str_replace( '-', '_', $field_name );
+
+		if ( is_callable( $func ) ) {
+			$data[ $field_name ] = call_user_func( __NAMESPACE__ . "\\callback_$func" );
+		}
+	}
+
+	$elapsed = time() - $start;
+
+	$data['elapsed-time'] = $elapsed;
+
+	return $data;
+}
+
+/**
+ * Count the total number of pattern posts.
+ *
+ * @return int
+ */
+function callback_count_patterns() {
+	$patterns_by_status = (array) wp_count_posts( PATTERN_POST_TYPE );
+
+	return (int) array_sum( $patterns_by_status );
+}
+
+/**
+ * Count the total number of published patterns.
+ *
+ * @return int
+ */
+function callback_count_patterns_publish() {
+	$patterns_by_status = wp_count_posts( PATTERN_POST_TYPE );
+
+	return $patterns_by_status->publish;
+}
+
+/**
+ * Count the total number of unlisted patterns.
+ *
+ * @return int
+ */
+function callback_count_patterns_unlisted() {
+	$patterns_by_status = wp_count_posts( PATTERN_POST_TYPE );
+
+	return $patterns_by_status->unlisted;
+}
+
+/**
+ * Count the total number of patterns with at least one favorite.
+ *
+ * @return int
+ */
+function callback_count_patterns_favorited() {
+	$args = array(
+		'post_type'   => PATTERN_POST_TYPE,
+		'post_status' => 'any',
+		'meta_query'  => array(
+			array(
+				'key'     => FAVORITE_META_KEY,
+				'value'   => 0,
+				'compare' => '>',
+			),
+		),
+		'numberposts' => 1, // We only need the `found_posts` value here.
+	);
+
+	$query = new \WP_Query( $args );
+
+	return $query->found_posts;
+}
+
+/**
+ * Count the total number of patterns with a pending flag.
+ *
+ * @return int
+ */
+function callback_count_patterns_flagged_pending() {
+	$post_ids = get_pattern_ids_with_pending_flags();
+
+	return count( $post_ids );
+}
+
+/**
+ * Count the total number of favorites.
+ *
+ * @return int
+ */
+function callback_count_favorites() {
+	global $wpdb;
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+	$count = $wpdb->get_var( $wpdb->prepare(
+		"
+		SELECT COUNT(*)
+		FROM {$wpdb->usermeta}
+		WHERE meta_key=%s
+		",
+		FAVORITE_META_KEY,
+	) );
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	return absint( $count );
+}
+
+/**
+ * Count the total number of flags.
+ *
+ * @return int
+ */
+function callback_count_flags() {
+	$flags_by_status = (array) wp_count_posts( FLAG_POST_TYPE );
+
+	return (int) array_sum( $flags_by_status );
+}
+
+/**
+ * Count the total number of pending flags.
+ *
+ * @return int
+ */
+function callback_count_flags_pending() {
+	$flags_by_status = wp_count_posts( FLAG_POST_TYPE );
+
+	return $flags_by_status->pending;
+}
+
+/**
+ * Count the total number of resolved flags.
+ *
+ * @return int
+ */
+function callback_count_flags_resolved() {
+	$flags_by_status = wp_count_posts( FLAG_POST_TYPE );
+
+	return $flags_by_status->resolved;
+}
+
+/**
+ * Count the total number of users with at least one favorited pattern.
+ *
+ * @return int
+ */
+function callback_count_users_with_favorite() {
+	global $wpdb;
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+	$user_ids = $wpdb->get_var( $wpdb->prepare(
+		"
+		SELECT DISTINCT user_id
+		FROM {$wpdb->usermeta}
+		WHERE meta_key=%s
+		",
+		FAVORITE_META_KEY,
+	) );
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	return count( $user_ids );
+}

--- a/public_html/wp-content/plugins/pattern-directory/includes/stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/stats.php
@@ -13,6 +13,7 @@ defined( 'WPINC' ) || die();
  * Constants.
  */
 const STATS_POST_TYPE = 'wporg-pattern-stats'; // Must be <= 20 characters.
+const VERSION         = 1; // Must be an integer.
 
 /**
  * Actions and filters.
@@ -45,6 +46,8 @@ function register_cpt() {
 
 /**
  * Define the post meta fields for the snapshot CPT.
+ *
+ * ⚠️ When you change the field schema, make sure you also bump up the VERSION constant at the top of this file.
  *
  * @return array
  */
@@ -130,6 +133,12 @@ function get_meta_field_schema() {
 				'default'     => 0,
 				'single'      => true,
 			),
+			'version'                        => array(
+				'description' => __( 'The version of the snapshot data schema.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'default'     => VERSION,
+				'single'      => true,
+			),
 		),
 	);
 }
@@ -203,10 +212,6 @@ function get_snapshot_data() {
 	$schema   = get_meta_field_schema();
 
 	foreach ( array_keys( $schema['properties'] ) as $field_name ) {
-		if ( 'elapsed-time' === $field_name ) {
-			continue;
-		}
-
 		$func = __NAMESPACE__ . '\\callback_' . str_replace( '-', '_', $field_name );
 
 		if ( is_callable( $func ) ) {
@@ -217,6 +222,7 @@ function get_snapshot_data() {
 	$elapsed_ms = round( microtime( true ) * 1000 ) - $start_ms;
 
 	$data['elapsed-time'] = (int) $elapsed_ms;
+	$data['version']      = VERSION;
 
 	return $data;
 }


### PR DESCRIPTION
Adds functions for gathering stats about patterns and saving them to snapshot posts, similar to what is done on the 5ftf site. A cron job is set up to run at 00:00 UTC daily to save a snapshot (don't worry it won't run on your wporg sandbox).

Also adds a simple, work-in-progress page in WP Admin to view the current stats and some basic info about the number of snapshots that have been created. In later PRs we can add things like exporting snapshots to CSV, showing stats on a public frontend page, and/or making pretty charts.

Fixes #292


### Screenshots

![stats-page](https://user-images.githubusercontent.com/916023/125877358-76c58cc0-9f79-4c04-abef-0fb6eb98e3fa.jpg)


### How to test the changes in this Pull Request:

1. This works best if you load it onto your wporg sandbox, so you can see the real numbers.
2. In WP Admin, find the Stats page under the Block Patterns menu.
3. Try creating, favoriting, or flagging a pattern and see if the numbers change.