### PR TITLE
Theme: Fix backwards and forwards navigation state.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/hooks/route.js
+++ b/public_html/wp-content/themes/pattern-directory/src/hooks/route.js
@@ -68,6 +68,10 @@ export function RouteProvider( { children } ) {
 	useEffect( () => {
 		// When the browser modifies the history, update our path.
 		window.addEventListener( 'popstate', setPathOnPop ); // eslint-disable-line @wordpress/no-global-event-listener
+
+		return () => {
+			window.removeEventListener( 'popstate', setPathOnPop ); // eslint-disable-line @wordpress/no-global-event-listener
+		};
 	}, [] );
 
 	return (

--- a/public_html/wp-content/themes/pattern-directory/src/hooks/route.js
+++ b/public_html/wp-content/themes/pattern-directory/src/hooks/route.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createContext, useContext, useState } from '@wordpress/element';
+import { createContext, useContext, useEffect, useState } from '@wordpress/element';
 import { addQueryArgs, getPathAndQueryString, getQueryArgs } from '@wordpress/url';
 
 /**
@@ -57,6 +57,18 @@ export function RouteProvider( { children } ) {
 		window.history.pushState( '', '', newPath );
 		setPath( newPath );
 	};
+
+	/**
+	 * Updates the path to the document location.
+	 */
+	const setPathOnBack = () => {
+		setPath( document.location.href );
+	};
+
+	useEffect( () => {
+		// When the browser modifies the history, update our path.
+		window.addEventListener( 'popstate', setPathOnBack ); // eslint-disable-line @wordpress/no-global-event-listener
+	}, [] );
 
 	return (
 		<StateContext.Provider

--- a/public_html/wp-content/themes/pattern-directory/src/hooks/route.js
+++ b/public_html/wp-content/themes/pattern-directory/src/hooks/route.js
@@ -59,7 +59,7 @@ export function RouteProvider( { children } ) {
 	};
 
 	/**
-	 * Updates the path to the document location.
+	 * Updates the path to the current browser path.
 	 */
 	const setPathOnPop = () => {
 		setPath( document.location.href );

--- a/public_html/wp-content/themes/pattern-directory/src/hooks/route.js
+++ b/public_html/wp-content/themes/pattern-directory/src/hooks/route.js
@@ -61,13 +61,13 @@ export function RouteProvider( { children } ) {
 	/**
 	 * Updates the path to the document location.
 	 */
-	const setPathOnBack = () => {
+	const setPathOnPop = () => {
 		setPath( document.location.href );
 	};
 
 	useEffect( () => {
 		// When the browser modifies the history, update our path.
-		window.addEventListener( 'popstate', setPathOnBack ); // eslint-disable-line @wordpress/no-global-event-listener
+		window.addEventListener( 'popstate', setPathOnPop ); // eslint-disable-line @wordpress/no-global-event-listener
 	}, [] );
 
 	return (


### PR DESCRIPTION
This adds a listener for `onpopstate` to the route hook and updates the path when the user triggers navigation using the browser's navigational tools (Shortcut keys, back/forward button).

Fixes #285

### Screenshots
N/A


### How to test the changes in this Pull Request:

1. Visit `/`
2. Click on multiple categories
2. Click the browser back button
3. Expect to go backwards with the selected category with the applicable result sets.

<!-- If you can, add the appropriate [Component] label(s). -->
