### PR TITLE
Theme: Fix favorite button styles

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -107,12 +107,6 @@
 	text-decoration: none;
 }
 
-// Fixing WordPress.org collision.
-.pattern-grid__favorite-count:active {
-	background: inherit;
-	box-shadow: none;
-}
-
 .pattern-grid__author-avatar img {
 	margin-right: 0.5rem;
 	height: 1rem;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -107,6 +107,12 @@
 	text-decoration: none;
 }
 
+// Fixing WordPress.org collision.
+.pattern-grid__favorite-count:active {
+	background: inherit;
+	box-shadow: none;
+}
+
 .pattern-grid__author-avatar img {
 	margin-right: 0.5rem;
 	height: 1rem;

--- a/public_html/wp-content/themes/pattern-directory/src/components/favorite-button/small.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/favorite-button/small.js
@@ -35,13 +35,14 @@ const FavoriteButtonSmall = ( { className, label, patternId } ) => {
 		}
 	}, [ isFavorite ] );
 
-	const baseClasses = classnames( className, 'pattern-favorite-button-small' );
-	const buttonClasses = classnames( baseClasses, 'button button-link', {
+	const buttonClasses = classnames( className, 'pattern-favorite-button-small', {
+		button: hasPermission,
+		'button-link': hasPermission,
 		'is-favorited': isFavorite,
 	} );
 
 	return ! hasPermission ? (
-		<span className={ baseClasses }>
+		<span className={ buttonClasses }>
 			<IconHeartFilled className="pattern-favorite-button__filled" />
 			<span>{ label }</span>
 		</span>

--- a/public_html/wp-content/themes/pattern-directory/src/components/favorite-button/small.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/favorite-button/small.js
@@ -35,12 +35,13 @@ const FavoriteButtonSmall = ( { className, label, patternId } ) => {
 		}
 	}, [ isFavorite ] );
 
-	const buttonClasses = classnames( className, 'button button-link pattern-favorite-button-small', {
+	const baseClasses = classnames( className, 'pattern-favorite-button-small' );
+	const buttonClasses = classnames( baseClasses, 'button button-link', {
 		'is-favorited': isFavorite,
 	} );
 
 	return ! hasPermission ? (
-		<span className={ buttonClasses }>
+		<span className={ baseClasses }>
 			<IconHeartFilled className="pattern-favorite-button__filled" />
 			<span>{ label }</span>
 		</span>


### PR DESCRIPTION
This fixes an issue seen on the live site. The favorite count button gets a `box-shadow` and a `background` color when `:active`.

### Screenshots
Remove the problem identified in the image by the red arrow.

![](https://d.pr/i/PDlrhM.png)


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
Must be tested in a sandbox or on the live site.

