### PR TITLE
Theme: Enable category browsing inside an author archive

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -188,14 +188,26 @@ function pre_get_posts( $query ) {
 }
 
 /**
- * Add the "My Patterns" status rewrites.
- * This will redirect `my-patterns/draft`, `my-patterns/pending` etc to use the My Patterns page.
+ * Add pattern rewrites.
+ * - Add the category endpoints to author archive URLs, ex: `/author/user/pattern-category/foo`, and `/author/user/pattern-category/foo/page/2`.
+ * - Redirect `my-patterns/draft`, `my-patterns/pending` etc to use the My Patterns page.
+ * - Redirect `my-favorites/pattern-categories/*` to use the My Favorites page.
  */
 function add_rewrite() {
+	add_rewrite_rule(
+		'^author/([^/]+)/pattern-categories/([^/]+)/?$',
+		'index.php?author_name=$matches[1]&wporg-pattern-category=$matches[2]',
+		'top'
+	);
+	add_rewrite_rule(
+		'^author/([^/]+)/pattern-categories/([^/]+)/page/?([0-9]{1,})/?$',
+		'index.php?author_name=$matches[1]&wporg-pattern-category=$matches[2]&paged=$matches[3]',
+		'top'
+	);
+
 	add_rewrite_rule( '^my-patterns/[^/]+/?$', 'index.php?pagename=my-patterns', 'top' );
 	add_rewrite_rule( '^my-favorites/.+/?$', 'index.php?pagename=my-favorites', 'top' );
 }
-
 
 /**
  * Use the index.php template for various WordPress views that would otherwise be handled by the parent theme.

--- a/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
@@ -33,7 +33,10 @@ const Patterns = () => {
 		<RouteProvider>
 			<QueryMonitor />
 			<BreadcrumbMonitor />
-			<PatternGridMenu query={ query } />
+			<PatternGridMenu
+				basePath={ query?.author_name ? `/author/${ query.author_name }/` : '/' }
+				query={ query }
+			/>
 			{ isEmpty ? (
 				<>
 					<EmptyHeader />


### PR DESCRIPTION
Fixes #268.

To do: Add the context bar with the author name.

### Screenshots

<img width="998" alt="Screen Shot 2021-07-16 at 6 41 08 PM" src="https://user-images.githubusercontent.com/541093/126015037-a3fe5a00-aa91-48a4-a0ba-45c1784e80b4.png">

Not sure why the author isn't correctly displayed on the category subpages:
<img width="553" alt="Screen Shot 2021-07-16 at 6 39 33 PM" src="https://user-images.githubusercontent.com/541093/126015011-c529e712-c82e-4aad-bc33-33ce3b627108.png">


### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] label(s). -->
