### PR TITLE
Theme: Increase enqueue action priority

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -47,7 +47,7 @@ function enqueue_assets() {
 	$suffix       = $script_debug ? '' : '.min';
 
 	// Unregister the parent style so that the version & deps defined here are used.
-	wp_dequeue_style( 'wporg-style' );
+	wp_deregister_style( 'wporg-style' );
 	wp_enqueue_style(
 		'wporg-style',
 		get_theme_file_uri( '/css/style.css' ),

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -6,7 +6,7 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG_POST_TYPE;
 
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 20 );
 add_action( 'wp_head', __NAMESPACE__ . '\generate_block_editor_styles_html' );
 add_action( 'body_class', __NAMESPACE__ . '\body_class', 10, 2 );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );
@@ -46,6 +46,8 @@ function enqueue_assets() {
 	$script_debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 	$suffix       = $script_debug ? '' : '.min';
 
+	// Unregister the parent style so that the version & deps defined here are used.
+	wp_dequeue_style( 'wporg-style' );
 	wp_enqueue_style(
 		'wporg-style',
 		get_theme_file_uri( '/css/style.css' ),

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -6,7 +6,7 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG_POST_TYPE;
 
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 20 );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 10 );
 add_action( 'wp_head', __NAMESPACE__ . '\generate_block_editor_styles_html' );
 add_action( 'body_class', __NAMESPACE__ . '\body_class', 10, 2 );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -6,7 +6,7 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG_POST_TYPE;
 
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 10 );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'wp_head', __NAMESPACE__ . '\generate_block_editor_styles_html' );
 add_action( 'body_class', __NAMESPACE__ . '\body_class', 10, 2 );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );


### PR DESCRIPTION
This PR increases the priority for `wp_enqueue_scripts` to make sure:

```
wp_enqueue_style(
  'wporg-style',
  get_theme_file_uri( '/css/style.css' ),
  array( 'dashicons', 'open-sans' ),
  filemtime( __DIR__ . '/css/style.css' )
);
```

is called from the child theme and not the parent. This approach is also consistent with other child themes ([wporg-plugins](https://github.com/WordPress/wordpress.org/blob/9ed80a9c96f4e66810e7a21a2e27b5ac7c3db4b7/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/functions.php#L149)).

## Issue

Since this priority was set to `20`, the [wporg 'wporg-style' declaration](https://github.com/WordPress/wordpress.org/blob/9ed80a9c96f4e66810e7a21a2e27b5ac7c3db4b7/wordpress.org/public_html/wp-content/themes/pub/wporg/functions.php#L110) would run and apply the default cache value of `20200403`. Therefore on the live site, the cache was serving older assets... which is why some styles currently appear broken.

@dd32 Has suggested we update the `wporg` code to use `filemtime` as well, which I think is a good idea.

Note: This problem is only seen on the live site because it uses the `s.w.org` content delivery network.



### How to test the changes in this Pull Request:
- Open up developer tools (or page source)
- Click on Network
- Expect to find a Unix timestamp for the css/style.css file (Ie: pattern-directory/css/style.css?ver=1626659094).
- You should not see `pattern-directory/css/style.css?ver=20200403`
