### PR TITLE
Theme: Decode search term for language support 

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/category-context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/category-context-bar/index.js
@@ -69,7 +69,7 @@ function CategoryContextBar( { query } ) {
 			setMessage( getDefaultMessage( count, category.name ) );
 		}
 
-		const searchTerm = getSearchTermFromPath( path );
+		const searchTerm = decodeURI( getSearchTermFromPath( path ) );
 		if ( searchTerm.length > 0 ) {
 			setMessage( getSearchMessage( count, searchTerm ) );
 		}

--- a/public_html/wp-content/themes/pattern-directory/src/components/category-context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/category-context-bar/index.js
@@ -69,7 +69,7 @@ function CategoryContextBar( { query } ) {
 			setMessage( getDefaultMessage( count, category.name ) );
 		}
 
-		const searchTerm = decodeURI( getSearchTermFromPath( path ) );
+		const searchTerm = getSearchTermFromPath( path );
 		if ( searchTerm.length > 0 ) {
 			setMessage( getSearchMessage( count, searchTerm ) );
 		}

--- a/public_html/wp-content/themes/pattern-directory/src/utils/query.js
+++ b/public_html/wp-content/themes/pattern-directory/src/utils/query.js
@@ -112,5 +112,5 @@ export const getPageFromPath = ( path ) => {
  * @return {string} The search term.
  */
 export const getSearchTermFromPath = ( path ) => {
-	return getValueFromPath( path, 'search' );
+	return decodeURI( getValueFromPath( path, 'search' ) );
 };

--- a/public_html/wp-content/themes/pattern-directory/src/utils/test/query.js
+++ b/public_html/wp-content/themes/pattern-directory/src/utils/test/query.js
@@ -79,6 +79,8 @@ describe( 'utils', () => {
 		it( 'should correctly return the search term', async () => {
 			expect( getSearchTermFromPath( '/search/header' ) ).toEqual( 'header' );
 			expect( getSearchTermFromPath( '/search/footer/' ) ).toEqual( 'footer' );
+			expect( getSearchTermFromPath( '/search/조선말/' ) ).toEqual( '조선말' );
+			expect( getSearchTermFromPath( '/search/조선말/' ) ).toHaveLength( 3 );
 			expect( getSearchTermFromPath( '/patterns/search/sidebar' ) ).toEqual( 'sidebar' );
 		} );
 	} );


### PR DESCRIPTION
This PR fixes an output issue with Non-ASCII search terms.

Fixes #301

### Screenshots

| Before | After |
| --- | --- |
| ![](https://d.pr/i/sL54OB.png) | ![](https://d.pr/i/XSLLbI.png) |
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

Visit any of the following:
- `/search/%D8%B9%D9%8E%D8%B1%D9%8E/` (Arabic)
- `/search/%E7%94%BB%E5%83%8F` (Japanese)
- `/search/%EC%A1%B0%EC%84%A0%EB%A7%90/` (Korean)

Expect the search term to match the characters in the URL or the search form.


