### PR TITLE
Pattern Translations: Retain original pattern's date in translated patterns

### DIFF
--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -37,8 +37,9 @@ function create_or_update_translated_pattern( Pattern $pattern ) {
 		'post_author'  => $pattern->parent ? get_post( $pattern->parent->ID )->post_author : 0,
 		'post_status'  => $pattern->parent ? get_post( $pattern->parent->ID )->post_status : 'pending',
 		'meta_input'   => [
-			'wpop_description' => $pattern->description,
-			'wpop_locale'      => $pattern->locale,
+			'wpop_description'    => $pattern->description,
+			'wpop_locale'         => $pattern->locale,
+			'wpop_is_translation' => true,
 		],
 	];
 

--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -31,6 +31,7 @@ function create_or_update_translated_pattern( Pattern $pattern ) {
 		'post_type'    => POST_TYPE,
 		'post_title'   => $pattern->title,
 		'post_name'    => $pattern->ID ? $pattern->name : ( $pattern->name . '-' . $pattern->locale ), // TODO: Translate the slug?
+		'post_date'    => $pattern->parent ? get_post( $pattern->parent->ID )->post_date : '',
 		'post_content' => $pattern->html,
 		'post_parent'  => $pattern->parent ? $pattern->parent->ID : 0,
 		'post_author'  => $pattern->parent ? get_post( $pattern->parent->ID )->post_author : 0,


### PR DESCRIPTION
This addresses the issue described in #299 by including the original pattern's `post_date` value in the array that is passed to `wp_insert_post` when creating or updating a translated pattern.

This also adds a `wpop_is_translation` boolean postmeta value to the translated pattern post so that it's easier to differentiate it from other kinds of derived patterns that we may have in the future, like remixes.

Fixes #299

Props dd32, coreymckrill
