### PR TITLE
Translate term names, and load the correct locale for API & REST-API requests

### DIFF
--- a/bin/i18n.php
+++ b/bin/i18n.php
@@ -106,6 +106,29 @@ function get_taxonomy_terms( $taxonomy ) {
 }
 
 /**
+ * Get data about pages from a REST API endpoint.
+ *
+ * @return array
+ */
+function get_pages() {
+	$endpoint = ENDPOINT_BASE . 'pages' . '?per_page=100';
+
+	$response = Requests::get( $endpoint );
+
+	if ( 200 !== $response->status_code ) {
+		die( 'Could not retrieve page list.' );
+	}
+
+	$pages = json_decode( $response->body, true );
+
+	if ( ! is_array( $pages ) ) {
+		die( 'Pages request returned unexpected data.' );
+	}
+
+	return $pages;
+}
+
+/**
  * Parse a link header from a WP REST API response into an array of prev/next URLs.
  *
  * @param string $link_header
@@ -189,6 +212,20 @@ function main() {
 				$description = addcslashes( $term['description'], "'" );
 				$file_content .= "_x( '{$description}', '$label term description', 'wporg-patterns' );\n";
 			}
+		}
+	}
+
+	if ( 'cli' === php_sapi_name() ) {
+		echo "\n";
+		echo "Retrieving pages...\n";
+	}
+
+	foreach ( get_pages() as $page ) {
+		$title = addcslashes( $page['title']['rendered'], "'" );
+		$file_content .= "_x( '{$title}', 'Page title', 'wporg-patterns' );\n";
+
+		if ( 'cli' === php_sapi_name() ) {
+			echo "$title\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 

--- a/bin/i18n.php
+++ b/bin/i18n.php
@@ -111,7 +111,7 @@ function get_taxonomy_terms( $taxonomy ) {
  * @return array
  */
 function get_pages() {
-	$endpoint = ENDPOINT_BASE . 'pages' . '?per_page=100';
+	$endpoint = ENDPOINT_BASE . 'pages?per_page=100';
 
 	$response = Requests::get( $endpoint );
 

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -18,3 +18,6 @@ _x( 'Broken or Unusable', 'Flag Reasons term name', 'wporg-patterns' );
 _x( 'Copyrighted or Trademark Issue', 'Flag Reasons term name', 'wporg-patterns' );
 _x( 'Other', 'Flag Reasons term name', 'wporg-patterns' );
 _x( 'Rude, Crude, or Inappropriate', 'Flag Reasons term name', 'wporg-patterns' );
+_x( 'My Favorites', 'Page title', 'wporg-patterns' );
+_x( 'My Patterns', 'Page title', 'wporg-patterns' );
+_x( 'New Pattern', 'Page title', 'wporg-patterns' );

--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -100,7 +100,7 @@ function translate_page_title( $title, $post_id = null ) {
 	$post = get_post( $post_id );
 
 	if ( $post && 'page' === $post->post_type ) {
-		$title = translate_with_gettext_context( $post->post_title, 'Page Title', 'wporg-patterns' );
+		$title = translate_with_gettext_context( $post->post_title, 'Page title', 'wporg-patterns' );
 	}
 
 	return $title;

--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -83,7 +83,7 @@ function translate_term( $term ) {
 	}
 
 	$i18n_context = TRANSLATED_TAXONOMIES[ $term->taxonomy ];
-	$term->name   = esc_html( translate_with_gettext_context( html_entity_decode( $term->name ), $i18n_context, 'wporg-patterns' ) );
+	$term->name   = esc_html( translate_with_gettext_context( html_entity_decode( $term->name ), $i18n_context, 'wporg-patterns' ) ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
 
 	return $term;
 }

--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -83,7 +83,7 @@ function translate_term( $term ) {
 	}
 
 	$i18n_context = TRANSLATED_TAXONOMIES[ $term->taxonomy ];
-	$term->name   = esc_html( translate_with_gettext_context( html_entity_decode( $term->name ), $i18n_context, 'wporg-patterns' ) ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+	$term->name   = esc_html( translate_with_gettext_context( html_entity_decode( $term->name ), $i18n_context, 'wporg-patterns' ) ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext
 
 	return $term;
 }

--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -100,7 +100,7 @@ function translate_page_title( $title, $post_id = null ) {
 	$post = get_post( $post_id );
 
 	if ( $post && 'page' === $post->post_type ) {
-		$title = translate_with_gettext_context( $post->post_title, 'Page title', 'wporg-patterns' );
+		$title = translate_with_gettext_context( $post->post_title, 'Page title', 'wporg-patterns' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
 	}
 
 	return $title;

--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -90,6 +90,25 @@ function translate_term( $term ) {
 add_filter( 'get_term', __NAMESPACE__ . '\translate_term' );
 
 /**
+ * Translate the title of pages.
+ *
+ * @param string $title   The current title, ignored.
+ * @param int    $post_id The post_id of the page.
+ * @return string Possibly translated page title.
+ */
+function translate_page_title( $title, $post_id = null ) {
+	$post = get_post( $post_id );
+
+	if ( $post && 'page' === $post->post_type ) {
+		$title = translate_with_gettext_context( $post->post_title, 'Page Title', 'wporg-patterns' );
+	}
+
+	return $title;
+}
+add_filter( 'the_title', __NAMESPACE__ . '\translate_page_title', 1, 2 );
+add_filter( 'single_post_title', __NAMESPACE__ . '\translate_page_title', 1, 2 );
+
+/**
  * Set the correct locale context for API endpoints.
  *
  * For api.wordpress.org requests, the `locale` GET parameter is respected if set. Defaults to en_US otherwise.

--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -12,6 +12,12 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 const GLOTPRESS_PROJECT = 'patterns/core';
 const TRANSLATED_BY_GLOTPRESS_KEY = '_glotpress_translated';
 
+const TRANSLATED_TAXONOMIES = [
+	// Taxonomy => Translation Context, see pattern-directory/bin/i18n.php
+	'wporg-pattern-category'    => 'Categories term name',
+	'wporg-pattern-flag-reason' => 'Flag Reasons term name',
+];
+
 require __DIR__ . '/includes/pattern.php';
 require __DIR__ . '/includes/parser.php';
 require __DIR__ . '/includes/i18n.php';
@@ -59,3 +65,56 @@ function create_or_update_translated_pattern( Pattern $pattern ) {
 
 	return $post_id;
 }
+
+/**
+ * Translate term names into the current site locale.
+ *
+ * @param WP_Term $term The WP_Term object being loaded.
+ */
+function translate_term( $term ) {
+	if (
+		is_admin() ||
+		// Not get_user_locale(), as we respect the displayed site locale.
+		'en_US' === get_locale() ||
+		// Only certain translated taxonomies
+		! isset( TRANSLATED_TAXONOMIES[ $term->taxonomy ] )
+	) {
+		return $term;
+	}
+
+	$i18n_context = TRANSLATED_TAXONOMIES[ $term->taxonomy ];
+	$term->name   = esc_html( translate_with_gettext_context( html_entity_decode( $term->name ), $i18n_context, 'wporg-patterns' ) );
+
+	return $term;
+}
+add_filter( 'get_term', __NAMESPACE__ . '\translate_term' );
+
+/**
+ * Set the correct locale context for API endpoints.
+ *
+ * For api.wordpress.org requests, the `locale` GET parameter is respected if set. Defaults to en_US otherwise.
+ * For REST API requests, the `_locale=user` GET parameter is ignored for authenticated requests, causing the rest to default to the Site locale.
+ */
+function locale( $locale ) {
+	// When being requested through api.wordpress.org, respect the query variable.
+	if (
+		defined( 'WPORG_IS_API' ) &&
+		WPORG_IS_API &&
+		! empty( $_GET['locale'] )
+	) {
+		return $_GET['locale'];
+	}
+
+	// Respect the site locale otherwise for rest api queries.
+	// This is used to prevent `?_locale=user` returning non-translated details on localised sites.
+	if (
+		wp_is_json_request() &&
+		isset( $_GET['_locale'] ) &&
+		'user' === $_GET['_locale']
+	) {
+		$_GET['_locale'] = 'site';
+	}
+
+	return $locale;
+}
+add_filter( 'locale', __NAMESPACE__ . '\locale' );


### PR DESCRIPTION
Translate term names, and load the correct locale for API & REST-API requests.

This PR is to ensure that Term names are properly localised in a variety of places:
 - https://ja.wordpress.org/patterns/ - The Term names in the menu should be localised. This is from the following REST API:
 - https://ja.wordpress.org/patterns/wp-json/wp/v2/pattern-categories?_locale=user Should return Japanese names (Note: Authenticated requests will return the users locale (Which we don't use on WordPress.org), unauthenticated will return Japanese)
 - https://api.wordpress.org/patterns/1.0/?locale=ja&categories - An API request made from an API client, should have the `locale` parameter respected

The translation method for the Term names is straight forward, setting the appropriate locale however is not.

The approach taken here to set the locale feels hacky to me, but I wasn't able to find a better way that reliably worked in all 4 use-cases and returned expected consistent results:
 - REST API, Authenticated, API client sending `_locale=user`
 - REST API, Authenticated, API client NOT setting a locale
 - REST API, Unauthenticated.
 - WordPress.org API requests setting the `locale` parameter.

Additionally, pages titles weren't translated:
 - https://ja.wordpress.org/patterns/my-favorites/ displays English text in the Page header, and in the Blue bar.

See #34, #223

### How to test the changes in this Pull Request:

1. Apply, visit urls metioned.

<!-- If you can, add the appropriate [Component] label(s). -->
