### PR TITLE
Prioritise results by requested locale, but return Locale and default (en_US) patterns.

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -17,6 +17,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\disable_block_direc
 add_filter( 'rest_' . POST_TYPE . '_collection_params', __NAMESPACE__ . '\filter_patterns_collection_params' );
 add_filter( 'rest_' . POST_TYPE . '_query', __NAMESPACE__ . '\filter_patterns_rest_query', 10, 2 );
 add_filter( 'user_has_cap', __NAMESPACE__ . '\set_pattern_caps' );
+add_filter( 'posts_orderby', __NAMESPACE__ . '\filter_orderby_locale', 10, 2 );
 
 
 /**
@@ -501,14 +502,12 @@ function filter_patterns_rest_query( $args, $request ) {
 	// Does not limit to only the requested locale, so as to provide results when no translations
 	// exist for the locale, or we do not recognise the locale.
 	if ( $locale ) {
-		$args['meta_query']['wpop_locale'] = array(
+		$args['meta_query']['orderby_locale'] = array(
 			'key'     => 'wpop_locale',
 			'compare' => 'IN',
 			// Order in value determines result order
 			'value'   => array( $locale, 'en_US' ),
 		);
-
-		add_filter( 'posts_orderby', __NAMESPACE__ . '\filter_orderby_locale', 10, 2 );
 	}
 
 	// Use the `author_name` passed in to the API to request patterns by an author slug, not just an ID.
@@ -540,10 +539,10 @@ function filter_patterns_rest_query( $args, $request ) {
 function filter_orderby_locale( $orderby, $query ) {
 	global $wpdb;
 
-	// If this query has the locale meta_query, sort by it.
-	if ( ! empty( $query->query['meta_query']['wpop_locale']['value'] ) ) {
-		$values      = array_reverse( $query->query['meta_query']['wpop_locale']['value'] );
-		$table_alias = $query->meta_query->get_clauses()['wpop_locale']['alias'];
+	// If this query has the orderby_locale meta_query, sort by it.
+	if ( ! empty( $query->meta_query->queries['orderby_locale']['value'] ) ) {
+		$values      = array_reverse( $query->meta_query->queries['orderby_locale']['value'] );
+		$table_alias = $query->meta_query->get_clauses()['orderby_locale']['alias'];
 
 		$field_placeholders = implode( ', ', array_pad( array(), count( $values ), '%s' ) );
 		$locale_orderby     = $wpdb->prepare( "FIELD( {$table_alias}.meta_value, {$field_placeholders} ) DESC", $values ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -184,17 +184,15 @@ function pre_get_posts( $query ) {
 		$query->set( 'post_type', array( POST_TYPE ) );
 		$query->set( 'post_status', array( 'publish' ) );
 
+		// The `orderby_locale` meta_query will be transformed into a query orderby by Pattern_Post_Type\filter_orderby_locale().
 		$query->set( 'meta_query', array(
-			'wpop_locale' => array(
+			'orderby_locale' => array(
 				'key'     => 'wpop_locale',
 				'compare' => 'IN',
 				// Order in value determines result order
 				'value'   => array( get_locale(), 'en_US' ),
 			),
 		) );
-
-		add_filter( 'posts_orderby', '\WordPressdotorg\Pattern_Directory\Pattern_Post_Type\filter_orderby_locale', 10, 2 );
-
 	}
 }
 

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -184,8 +184,17 @@ function pre_get_posts( $query ) {
 		$query->set( 'post_type', array( POST_TYPE ) );
 		$query->set( 'post_status', array( 'publish' ) );
 
-		$query->set( 'meta_key', 'wpop_locale' );
-		$query->set( 'meta_value', get_locale() );
+		$query->set( 'meta_query', array(
+			'wpop_locale' => array(
+				'key'     => 'wpop_locale',
+				'compare' => 'IN',
+				// Order in value determines result order
+				'value'   => array( get_locale(), 'en_US' ),
+			),
+		) );
+
+		add_filter( 'posts_orderby', '\WordPressdotorg\Pattern_Directory\Pattern_Post_Type\filter_orderby_locale', 10, 2 );
+
 	}
 }
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Currently the Pattern directory limits the results to the given locale, this is not ideal in all situations.

Consider:
 - https://ru.wordpress.org/patterns/ currently has no patterns, as none are translated
 - https://cs.wordpress.org/patterns/ currently only has a single partially translated pattern.
 - Results inside Gutenberg reflect the above.
 - https://api.wordpress.org/patterns/1.0/?locale=foo_bar returns no results. The `foo_bar` locale is admittedly not used on any sites, but it's not uncommon to see API requests with it set to `en` or `es` which are equally invalid `WP_Locale` values.

This PR changes the logic from only returning results in the matching locale, to returning in both the local and in en_US, with the localised results first.

No attempt at deduplication is done here, both the Translated and english results would be returned.
This also has the benefit that searching an English phrase would result in matching an english pattern, and not just returning an empty data set if it's not included in the locale translated patterns. Searching for a German phrase on an English or French site would however not return a matching German pattern.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #244

<!-- List out anyone who helped with this task. -->


<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Apply patch
2. Visit URLs mentioned. Perform searches.

<!-- If you can, add the appropriate [Component] label(s). -->
