### PR TITLE
Patterns: Remove `pattern-` from the pattern categories URL structure

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -72,7 +72,7 @@ function register_post_type_data() {
 			'rest_base'         => 'pattern-categories',
 			'show_admin_column' => true,
 			'rewrite'           => array(
-				'slug' => 'pattern-categories',
+				'slug' => 'categories',
 			),
 			'capabilities' => array(
 				'assign_terms' => 'edit_patterns',

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
@@ -21,7 +21,7 @@ const PatternGridMenu = ( { basePath = '', ...props } ) => {
 			patternStore
 		);
 		const query = getQueryFromUrl( path );
-		// Remove pagination, so we don't go from /page/2/ to /pattern-categories/images/page/2/.
+		// Remove pagination, so we don't go from /page/2/ to /categories/images/page/2/.
 		delete query.page;
 		const _options = ( getCategories() || [] ).map( ( cat ) => {
 			return {

--- a/public_html/wp-content/themes/pattern-directory/src/store/selectors.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/selectors.js
@@ -219,7 +219,7 @@ export function isFavorite( state, patternId ) {
  * @return {Object} The query to use when requesting content from the API.
  */
 export function getQueryFromUrl( state, url ) {
-	const params = [ 'pattern-categories', 'author', 'page', 'search' ];
+	const params = [ 'categories', 'author', 'page', 'search' ];
 	const query = getQueryArgs( url );
 
 	const categorySlug = getCategoryFromPath( url );
@@ -275,7 +275,7 @@ export function getUrlFromQuery( state, query = {}, baseUrl = wporgPatternsUrl.s
 		const categories = getCategories( state );
 		const term = categories.find( ( { id } ) => termId === id );
 		if ( term?.slug ) {
-			baseUrl += `/pattern-categories/${ term.slug }`;
+			baseUrl += `/categories/${ term.slug }`;
 		}
 		delete query[ 'pattern-categories' ];
 	}

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/selectors.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/selectors.js
@@ -288,18 +288,15 @@ describe( 'selectors', () => {
 				status: 'draft',
 				page: 2,
 			} );
-			expect( getQueryFromUrl( state, `${ baseUrl }/pattern-categories/header` ) ).toEqual( {
+			expect( getQueryFromUrl( state, `${ baseUrl }/categories/header` ) ).toEqual( {
 				'pattern-categories': 3,
 			} );
-			expect( getQueryFromUrl( state, `${ baseUrl }/pattern-categories/header?page=2` ) ).toEqual( {
+			expect( getQueryFromUrl( state, `${ baseUrl }/categories/header?page=2` ) ).toEqual( {
 				'pattern-categories': 3,
 				page: 2,
 			} );
 			expect(
-				getQueryFromUrl(
-					state,
-					`${ baseUrl }/author/username/pattern-categories/header/?orderby=date&page=3`
-				)
+				getQueryFromUrl( state, `${ baseUrl }/author/username/categories/header/?orderby=date&page=3` )
 			).toEqual( {
 				author_name: 'username',
 				'pattern-categories': 3,
@@ -319,9 +316,9 @@ describe( 'selectors', () => {
 		it( 'should ignore any malformed path segments.', async () => {
 			expect( getQueryFromUrl( state, `${ baseUrl }/page/` ) ).toEqual( {} );
 			expect( getQueryFromUrl( state, `${ baseUrl }/author/page/2` ) ).toEqual( { page: 2 } );
-			expect( getQueryFromUrl( state, `${ baseUrl }/categories/header` ) ).toEqual( {} );
+			expect( getQueryFromUrl( state, `${ baseUrl }/category/header` ) ).toEqual( {} );
 			expect( getQueryFromUrl( state, `${ baseUrl }/foo/bar` ) ).toEqual( {} );
-			expect( getQueryFromUrl( state, `${ baseUrl }/author/pattern-categories/?orderby=date` ) ).toEqual( {
+			expect( getQueryFromUrl( state, `${ baseUrl }/author/categories/?orderby=date` ) ).toEqual( {
 				orderby: 'date',
 			} );
 			expect( getQueryFromUrl( state, `${ baseUrl }/author/page/` ) ).toEqual( {} );
@@ -361,7 +358,7 @@ describe( 'selectors', () => {
 					orderby: 'date',
 					page: 3,
 				} )
-			).toBe( `${ baseUrl }/author/username/pattern-categories/header/page/3/?orderby=date` );
+			).toBe( `${ baseUrl }/author/username/categories/header/page/3/?orderby=date` );
 		} );
 
 		it( 'should add extra object properties as query strings.', async () => {

--- a/public_html/wp-content/themes/pattern-directory/src/utils/query.js
+++ b/public_html/wp-content/themes/pattern-directory/src/utils/query.js
@@ -62,7 +62,7 @@ export const removeQueryString = ( path ) => {
  * as `?category=blog&page=2`, or `/category/blog/?page=2`.
  *
  * @param {string} path A URL path and query string.
- * @param {string} key  The query var to extract, ex: `pattern-categories`, `page`.
+ * @param {string} key  The query var to extract, ex: `categories`, `page`.
  * @return {string} The value of the requested key.
  */
 export const getValueFromPath = ( path, key ) => {
@@ -92,7 +92,7 @@ export const getValueFromPath = ( path, key ) => {
  * @return {string} The category slug.
  */
 export const getCategoryFromPath = ( path ) => {
-	return getValueFromPath( path, 'pattern-categories' );
+	return getValueFromPath( path, 'categories' );
 };
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/src/utils/test/query.js
+++ b/public_html/wp-content/themes/pattern-directory/src/utils/test/query.js
@@ -50,11 +50,11 @@ describe( 'utils', () => {
 		} );
 
 		it( 'should correctly return the category', async () => {
-			expect( getCategoryFromPath( '/pattern-categories/header' ) ).toEqual( 'header' );
-			expect( getCategoryFromPath( '/pattern-categories/header/page/3/' ) ).toEqual( 'header' );
-			expect( getCategoryFromPath( '/?pattern-categories=header' ) ).toEqual( 'header' );
-			expect( getCategoryFromPath( '/?search=test&pattern-categories=header' ) ).toEqual( 'header' );
-			expect( getCategoryFromPath( '/pattern-categories/abc/?pattern-categories=def' ) ).toEqual( 'def' );
+			expect( getCategoryFromPath( '/categories/header' ) ).toEqual( 'header' );
+			expect( getCategoryFromPath( '/categories/header/page/3/' ) ).toEqual( 'header' );
+			expect( getCategoryFromPath( '/?categories=header' ) ).toEqual( 'header' );
+			expect( getCategoryFromPath( '/?search=test&categories=header' ) ).toEqual( 'header' );
+			expect( getCategoryFromPath( '/categories/abc/?categories=def' ) ).toEqual( 'def' );
 		} );
 	} );
 
@@ -64,9 +64,9 @@ describe( 'utils', () => {
 		} );
 
 		it( 'should correctly return the page number', async () => {
-			expect( getPageFromPath( '/pattern-categories/header' ) ).toEqual( 1 );
-			expect( getPageFromPath( '/pattern-categories/header/page/3/' ) ).toEqual( 3 );
-			expect( getPageFromPath( '/pattern-categories=header?page=2' ) ).toEqual( 2 );
+			expect( getPageFromPath( '/categories/header' ) ).toEqual( 1 );
+			expect( getPageFromPath( '/categories/header/page/3/' ) ).toEqual( 3 );
+			expect( getPageFromPath( '/?categories=header&page=2' ) ).toEqual( 2 );
 			expect( getPageFromPath( '/page/4' ) ).toEqual( 4 );
 		} );
 	} );


### PR DESCRIPTION
On the production site, the URL is already `wordpress.org/patterns`, so having the `pattern-categories` as part of the URL is redundant, ex: `https://wordpress.org/patterns/pattern-categories/images/`. We could switch this to just `categories` to remove the extra "patterns", without conflicting with the core `/category/` path.

The API data stays as `pattern-categories`. It makes the change smaller, and also it makes sense to be more verbose in the API request.

### How to test the changes in this Pull Request:

1. Build the branch, you might need to refresh permalinks
2. Try navigating around category pages
3. Go to an author archive and again filter by categories
4. The URLs should all use `/categories/`, not `/pattern-categories/`
