### PR TITLE
Patterns List Table: Enhancements for managing translations

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
@@ -7,9 +7,6 @@ use function WordPressdotorg\Locales\get_locales_with_english_names;
 use function WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\get_pattern_ids_with_pending_flags;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG;
-use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\TAX_TYPE as FLAG_REASON;
-use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\PENDING_STATUS;
-use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\RESOLVED_STATUS;
 
 defined( 'WPINC' ) || die();
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
@@ -57,6 +57,7 @@ function pattern_list_table_render_custom_columns( $column_name, $post_id ) {
 				'post_type'   => FLAG,
 				'post_status' => array( 'pending' ),
 				'post_parent' => $current_pattern->ID,
+				'numberposts' => 1,
 			) );
 
 			if ( $flags->found_posts > 0 ) {
@@ -96,9 +97,79 @@ function pattern_list_table_render_custom_columns( $column_name, $post_id ) {
 			$locale_labels = get_locales_with_english_names();
 
 			if ( isset( $locale_labels[ $locale ] ) ) {
-				echo esc_html( $locale_labels[ $locale ] );
+				printf(
+					'<span class="language-label">%s</span>',
+					esc_html( $locale_labels[ $locale ] )
+				);
 			} else {
 				echo '&mdash;';
+			}
+
+			if ( $current_pattern->wpop_is_translation ) {
+				$parent = get_post( $current_pattern->post_parent );
+
+				if ( $parent ) {
+					printf(
+						'<span class="language-context">%s</span>',
+						esc_html__( 'Translation', 'wporg-patterns' )
+					);
+
+					$view_url = add_query_arg(
+						array(
+							'post_type' => PATTERN,
+							'post_id'   => $parent->ID,
+						),
+						admin_url( 'edit.php' )
+					);
+
+					printf(
+						'<a href="%1$s" class="language-context-link">%2$s</a>',
+						esc_url( $view_url ),
+						esc_html__( 'Show original', 'wporg-patterns' )
+					);
+				}
+			} else {
+				printf(
+					'<span class="language-context">%s</span>',
+					esc_html__( 'Original', 'wporg-patterns' )
+				);
+
+				$args = array(
+					'post_type'    => PATTERN,
+					'post_status'  => 'any',
+					'post_parent'  => $current_pattern->ID,
+					'number_posts' => 1,
+					'meta_query'   => array(
+						array(
+							'key'   => 'wpop_is_translation',
+							'value' => 1,
+						),
+					),
+				);
+
+				$translations = new WP_Query( $args );
+				$view_url     = add_query_arg(
+					array(
+						'post_type'      => PATTERN,
+						'is_translation' => true,
+						'post_parent'    => $current_pattern->ID,
+					),
+					admin_url( 'edit.php' )
+				);
+
+				printf(
+					'<a href="%1$s" class="language-context-link">%2$s</a>',
+					esc_url( $view_url ),
+					sprintf(
+						esc_html( _n(
+							'%s translation',
+							'%s translations',
+							$translations->found_posts,
+							'wporg-patterns'
+						) ),
+						esc_html( number_format_i18n( $translations->found_posts ) )
+					)
+				);
 			}
 			break;
 	}
@@ -139,6 +210,22 @@ function pattern_list_table_styles( $which ) {
 			line-height: 1.88888888;
 			text-align: center;
 		}
+
+		.column-language {
+			display: flex;
+			flex-direction: column;
+		}
+
+		.language-label {
+			display: block;
+			margin-bottom: 0.5em;
+		}
+
+		.language-context,
+		.language-context-link {
+			font-size: 0.85em;
+			line-height: 1.3;
+		}
 	</style>
 	<?php
 }
@@ -151,7 +238,8 @@ function pattern_list_table_styles( $which ) {
  * @return array
  */
 function pattern_list_table_views( $views ) {
-	$wants_flagged = filter_input( INPUT_GET, 'has_flags', FILTER_VALIDATE_BOOLEAN );
+	$wants_flagged   = filter_input( INPUT_GET, 'has_flags', FILTER_VALIDATE_BOOLEAN );
+	$wants_originals = 0 === filter_input( INPUT_GET, 'post_parent', FILTER_VALIDATE_INT );
 
 	$url = add_query_arg(
 		array(
@@ -166,11 +254,59 @@ function pattern_list_table_views( $views ) {
 		$extra_attributes = ' class="current" aria-current="page"';
 	}
 
+	$patterns_with_flags = get_pattern_ids_with_pending_flags();
+
 	$views['has_flags'] = sprintf(
 		'<a href="%s"%s>%s</a>',
 		esc_url( $url ),
 		$extra_attributes,
-		esc_html__( 'Has Flags', 'wporg-patterns' )
+		sprintf(
+			/* translators: %s: Number of posts. */
+			_n(
+				'Has Flags <span class="count">(%s)</span>',
+				'Have Flags <span class="count">(%s)</span>',
+				count( $patterns_with_flags ),
+				'wporg-patterns'
+			),
+			number_format_i18n( count( $patterns_with_flags ) )
+		)
+	);
+
+	$url = add_query_arg(
+		array(
+			'post_type'   => PATTERN,
+			'post_parent' => 0,
+		),
+		admin_url( 'edit.php' )
+	);
+
+	$extra_attributes = '';
+	if ( $wants_originals ) {
+		$extra_attributes = ' class="current" aria-current="page"';
+	}
+
+	$args = array(
+		'post_type'   => PATTERN,
+		'post_status' => array( 'draft', 'pending', 'publish' ),
+		'post_parent' => 0,
+		'numberposts' => 1,
+	);
+	$query = new WP_Query( $args );
+
+	$views['originals'] = sprintf(
+		'<a href="%s"%s>%s</a>',
+		esc_url( $url ),
+		$extra_attributes,
+		sprintf(
+			/* translators: %s: Number of posts. */
+			_n(
+				'Original <span class="count">(%s)</span>',
+				'Originals <span class="count">(%s)</span>',
+				$query->found_posts,
+				'wporg-patterns'
+			),
+			number_format_i18n( $query->found_posts )
+		)
 	);
 
 	return $views;
@@ -184,27 +320,49 @@ function pattern_list_table_views( $views ) {
  * @return void
  */
 function handle_pattern_list_table_views( WP_Query $query ) {
-	$wants_flagged = filter_input( INPUT_GET, 'has_flags', FILTER_VALIDATE_BOOLEAN );
+	$wants_flagged      = filter_input( INPUT_GET, 'has_flags', FILTER_VALIDATE_BOOLEAN );
+	$wants_translations = filter_input( INPUT_GET, 'is_translation', FILTER_VALIDATE_BOOLEAN );
+	$post_id            = filter_input( INPUT_GET, 'post_id', FILTER_VALIDATE_INT );
+	$post_parent        = filter_input( INPUT_GET, 'post_parent', FILTER_VALIDATE_INT );
 
-	if ( ! is_admin() || ! $query->is_main_query() || ! $wants_flagged ) {
+	if ( ! is_admin() || ! $query->is_main_query() ) {
 		return;
 	}
 
 	$current_screen = get_current_screen();
 
 	if ( 'edit-' . PATTERN === $current_screen->id ) {
-		$args = array(
-			'orderby' => $query->get( 'orderby', 'date' ),
-			'order'   => $query->get( 'order', 'desc' ),
-		);
+		if ( $wants_flagged ) {
+			$args = array(
+				'orderby' => $query->get( 'orderby', 'date' ),
+				'order'   => $query->get( 'order', 'desc' ),
+			);
 
-		$valid_ids = get_pattern_ids_with_pending_flags( $args );
+			$valid_ids = get_pattern_ids_with_pending_flags( $args );
 
-		if ( empty( $valid_ids ) ) {
-			$valid_ids = false;
+			if ( empty( $valid_ids ) ) {
+				$valid_ids = array( 0 );
+			}
+
+			$query->set( 'post__in', $valid_ids );
 		}
 
-		$query->set( 'post__in', $valid_ids );
+		if ( $wants_translations ) {
+			$meta_query = $query->get( 'meta_query', array() );
+			$meta_query[] = array(
+				'key'   => 'wpop_is_translation',
+				'value' => 1,
+			);
+			$query->set( 'meta_query', $meta_query );
+		}
+
+		if ( false !== $post_id ) {
+			$query->set( 'p', $post_id );
+		}
+
+		if ( false !== $post_parent ) {
+			$query->set( 'post_parent', $post_parent );
+		}
 	}
 }
 


### PR DESCRIPTION
* Adds context in the Language column for whether a pattern post is an original or a translation
* Adds a link in the Language column to list all the translations if it is an original or list the original if it is a translation
* Adds a View to show only originals
* Adds counts to the Has Flags and Originals views


### Screenshots

![1](https://user-images.githubusercontent.com/916023/126561906-9d0363e2-262e-4283-9ba7-4dfa7089da03.jpg)

---

![2](https://user-images.githubusercontent.com/916023/126561932-eebe6a05-d64d-4a3d-9a35-6ed48ed6229f.jpg)


### How to test the changes in this Pull Request:

1. Since all the changes are in one file, it's probably best to upload this to your sandbox so you can see it in action with real data
2. Try clicking the Has Flags and Originals view links
3. Try clicking the "X translations" link on an original
4. Try clicking the "Show original" link on a translation
