### PR TITLE
Theme: Remove loading message for only sorts.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
@@ -18,6 +18,17 @@ import { useRoute } from '../../hooks';
 import { getLoadingMessage, getMessage, getSearchMessage } from './messaging';
 import { store as patternStore } from '../../store';
 
+/**
+ * This checks to see if the query is only being sorted.
+ *
+ * @param {Object} query
+ * @param {string} query.orderby Sorting key, used to determine if there is sorting.
+ * @return {boolean} Set to true if the object is empty with a only sorting parameter.
+ */
+const isOnlySorting = ( query ) => {
+	return Object.keys( query ).length === 1 && query.orderby;
+};
+
 function ContextBar( props ) {
 	const { path } = useRoute();
 	const [ height, setHeight ] = useState();
@@ -54,7 +65,7 @@ function ContextBar( props ) {
 		}
 
 		// We don't show a message when the query is empty.
-		if ( query && ! Object.keys( query ).length ) {
+		if ( ( query && ! Object.keys( query ).length ) || isOnlySorting( query ) ) {
 			setMessage( '' );
 			return;
 		}


### PR DESCRIPTION
This PR makes sure we don't see 'Loading patterns' in the context bar when the user is sorting on the default category. See #329 for background information.

Fixes #329

### Screenshots
N/A

### How to test the changes in this Pull Request:

1. Visit `/`
2. Choose `Favorites` from the dropdown that sorts the results
3. Expect to see the context bar show up and leave after the request is completed.