### PR TITLE
Theme: Fix pattern thumbnail click area.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_favorite-button.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_favorite-button.scss
@@ -5,6 +5,7 @@
 	width: 2.25rem;
 	border-radius: 2px;
 	color: color(gray-60);
+	vertical-align: top;
 
 	svg {
 		position: absolute;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -75,10 +75,6 @@
 		position: absolute;
 		right: 0;
 		bottom: 0;
-		left: 0;
-		display: flex;
-		align-items: center;
-		justify-content: flex-end;
 		padding: 0.375rem;
 		opacity: 0;
 		transform: translateY(6px);

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
@@ -41,10 +41,10 @@ function PatternThumbnail( { pattern, showAvatar } ) {
 						<span>{ statusLabel }</span>
 					</div>
 				) : null }
-				<div className="pattern-grid__actions">
+				<span className="pattern-grid__actions">
 					<FavoriteButton showLabel={ false } patternId={ pattern.id } />
 					<CopyPatternButton isSmall={ true } content={ pattern.pattern_content } />
-				</div>
+				</span>
 			</div>
 
 			<h2 className="pattern-grid__title">


### PR DESCRIPTION
This PR fixes #326, allowing users to click on the thumbnail when the actions are visible, matching user expectation.

Fixes #326

### Screenshots
N/A

### How to test the changes in this Pull Request:

1. Visit `/`
2. Hover over the pattern thumbnail
3. With the actions displayed, click on the lower left hand of the thumbnail.
4. Expect to navigate to the pattern.

