### PR TITLE
Navigation Menu: Fix spacing around menu and message

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_context-bar.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_context-bar.scss
@@ -1,24 +1,21 @@
 .context-bar {
-	margin: 0 $gutter-default;
+	margin: $gutter-default $gutter-default 0;
 	background: $color-gray-light-300;
 	border-radius: 2px;
 	font-size: 0.8125rem;
 	overflow: auto;
 	height: 55px; // Prevent layout shifts
 
+	@media only screen and ( min-width: $breakpoint-large ) {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: $size__site-main;
+	}
+
 	> div {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-	}
-
-	@media only screen and ( min-width: $breakpoint-medium ) {
-		margin: 0 $gutter-default;
-	}
-
-	@media only screen and ( min-width: $breakpoint-large ) {
-		margin: 0 auto;
-		max-width: $size__site-main;
 	}
 
 	ul {

--- a/public_html/wp-content/themes/pattern-directory/css/components/_context-bar.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_context-bar.scss
@@ -4,7 +4,6 @@
 	border-radius: 2px;
 	font-size: 0.8125rem;
 	overflow: auto;
-	height: 55px; // Prevent layout shifts
 
 	@media only screen and ( min-width: $breakpoint-large ) {
 		margin-left: auto;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_context-bar.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_context-bar.scss
@@ -1,5 +1,8 @@
 .context-bar {
 	margin: $gutter-default $gutter-default 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
 	background: $color-gray-light-300;
 	border-radius: 2px;
 	font-size: 0.8125rem;
@@ -9,12 +12,6 @@
 		margin-left: auto;
 		margin-right: auto;
 		max-width: $size__site-main;
-	}
-
-	> div {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
 	}
 
 	ul {

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-navigation-layout.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-navigation-layout.scss
@@ -1,5 +1,5 @@
 .pattern-navigation-layout {
-	margin: 0 auto;
+	margin: 0 auto $gutter-default;
 	max-width: $size__site-main;
 	display: flex;
 	flex-direction: column;
@@ -7,12 +7,11 @@
 	align-items: center;
 
 	.pattern-navigation-layout__primary {
-		margin-bottom: $gutter-default;
 		width: 100%;
 	}
 
 	.pattern-navigation-layout__secondary {
-		margin: 0 $gutter-default $gutter-default;
+		margin-top: $gutter-default;
 		width: calc(100% - #{$gutter-default * 2});
 	}
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
@@ -8,7 +8,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
-import { useRef, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -36,7 +36,6 @@ function ContextBar( props ) {
 		title: '',
 		links: [],
 	} );
-	const innerRef = useRef( null );
 
 	const { author, category, count, isLoadingPatterns, query } = useSelect(
 		( select ) => {
@@ -90,27 +89,25 @@ function ContextBar( props ) {
 
 	return ! message ? null : (
 		<header className="context-bar">
-			<div ref={ innerRef }>
-				<h2 className="context-bar__copy">
-					<span className={ classes }>
-						<Spinner />
-					</span>
-					<span>{ message }</span>
-				</h2>
-				{ context.links && context.links.length > 0 && (
-					<div className="context-bar__links">
-						<h3 className="context-bar__title">{ context.title }</h3>
+			<h2 className="context-bar__copy">
+				<span className={ classes }>
+					<Spinner />
+				</span>
+				<span>{ message }</span>
+			</h2>
+			{ context.links && context.links.length > 0 && (
+				<div className="context-bar__links">
+					<h3 className="context-bar__title">{ context.title }</h3>
 
-						<ul>
-							{ context.links.map( ( i ) => (
-								<li key={ i.href }>
-									<a href={ i.href }>{ i.label }</a>
-								</li>
-							) ) }
-						</ul>
-					</div>
-				) }
-			</div>
+					<ul>
+						{ context.links.map( ( i ) => (
+							<li key={ i.href }>
+								<a href={ i.href }>{ i.label }</a>
+							</li>
+						) ) }
+					</ul>
+				</div>
+			) }
 		</header>
 	);
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
@@ -8,7 +8,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -31,7 +31,6 @@ const isOnlySorting = ( query ) => {
 
 function ContextBar( props ) {
 	const { path } = useRoute();
-	const [ height, setHeight ] = useState();
 	const [ message, setMessage ] = useState();
 	const [ context ] = useState( {
 		title: '',
@@ -84,18 +83,13 @@ function ContextBar( props ) {
 		}
 	}, [ query, isLoadingPatterns ] );
 
-	useEffect( () => {
-		const _height = message ? innerRef.current.offsetHeight : 0;
-		setHeight( _height );
-	}, [ message ] );
-
 	const classes = classnames( {
 		'context-bar__spinner': true,
 		'context-bar__spinner--is-hidden': ! isLoadingPatterns,
 	} );
 
-	return (
-		<header className="context-bar" style={ { height: `${ height }px` } }>
+	return ! message ? null : (
+		<header className="context-bar">
 			<div ref={ innerRef }>
 				<h2 className="context-bar__copy">
 					<span className={ classes }>


### PR DESCRIPTION
Alternative to #322 - In trunk, the context bar is pushed against the header on search. There is also a double-margin on the homepage (when no message is displayed). This PR fixes both issues by tweaking some margins on the Navigation Layout & ContextBar, and removing the ContextBar when the message is empty (if/when we bring back context links we'll need to update this logic).

### Screenshots

Double-margin below the menu:

| Before | After |
|------|------|
| <img width="979" alt="Screen Shot 2021-07-26 at 12 26 14 PM" src="https://user-images.githubusercontent.com/541093/127024568-c32eb57b-36cd-41af-a939-da24a1facf56.png"> | <img width="988" alt="Screen Shot 2021-07-26 at 12 21 09 PM" src="https://user-images.githubusercontent.com/541093/127024625-d281eaae-33ff-47bc-b30f-0981caf8ecd4.png"> |

No space on search page:

| Before | After |
|------|------|
| <img width="422" alt="Screen Shot 2021-07-26 at 12 27 39 PM" src="https://user-images.githubusercontent.com/541093/127024872-4ba21e3a-1a90-4904-9c85-fceeb7f74c14.png"> | <img width="479" alt="Screen Shot 2021-07-26 at 12 27 52 PM" src="https://user-images.githubusercontent.com/541093/127024870-660558bb-fc08-44d4-9ae7-7506c908243b.png"> |

Margins are correct on small screens too
<img width="503" alt="Screen Shot 2021-07-26 at 12 21 45 PM" src="https://user-images.githubusercontent.com/541093/127024997-7046bb66-3910-44dd-a3de-33945daa4220.png">

<img width="515" alt="Screen Shot 2021-07-26 at 12 21 53 PM" src="https://user-images.githubusercontent.com/541093/127024931-59769034-e5fa-4b7e-b535-70a3b4a44ddd.png">

### How to test the changes in this Pull Request:

1. On the homepage, `/`, there should be the same amount of space above and below the menu.
1. Search for a pattern
2. There should be space above the grey "patterns found" message
3. Try on different screen sizes, the spacing should remain consistent.

