### PR TITLE
Theme: Change "My Favorites" to "Favorites"

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -265,6 +265,10 @@ function rewrite_search_url() {
 		wp_redirect( home_url( '/search/' ) . urlencode( trim( get_query_var( 's' ) ) ) . '/' );
 		exit();
 	}
+	if ( preg_match( '/^my-favorites(.*)/', trim( $_SERVER['REQUEST_URI'], '/' ), $matches ) ) {
+		wp_redirect( home_url( '/favorites/' . $matches[1] . '/' ) );
+		exit();
+	}
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -178,7 +178,7 @@ function pre_get_posts( $query ) {
 	$pagename = $query->get( 'pagename' );
 	if ( $pagename ) {
 		list( $_pagename ) = explode( '/', $pagename );
-		if ( in_array( $_pagename, array( 'my-patterns', 'my-favorites' ) ) ) {
+		if ( in_array( $_pagename, array( 'my-patterns', 'favorites' ) ) ) {
 			// Need to get the page ID because this is set before `pre_get_posts` fires.
 			$page = get_page_by_path( $_pagename );
 			$query->set( 'pagename', $_pagename );
@@ -206,7 +206,7 @@ function pre_get_posts( $query ) {
  */
 function add_rewrite() {
 	add_rewrite_rule( '^my-patterns/[^/]+/?$', 'index.php?pagename=my-patterns', 'top' );
-	add_rewrite_rule( '^my-favorites/.+/?$', 'index.php?pagename=my-favorites', 'top' );
+	add_rewrite_rule( '^favorites/.+/?$', 'index.php?pagename=favorites', 'top' );
 }
 
 

--- a/public_html/wp-content/themes/pattern-directory/header.php
+++ b/public_html/wp-content/themes/pattern-directory/header.php
@@ -32,7 +32,7 @@ get_template_part( 'header', 'wporg' );
 
 						<p class="site-description"><?php esc_html_e( 'Add a beautifully designed, ready to go layout to any WordPress site with a simple copy/paste.', 'wporg-patterns' ); ?></p>
 						<?php get_search_form(); ?>
-						<a class="site-link" href="<?php echo esc_url( home_url( '/my-favorites' ) ); ?>"><?php esc_html_e( 'My favorites', 'wporg-patterns' ); ?></a>
+						<a class="site-link" href="<?php echo esc_url( home_url( '/favorites' ) ); ?>"><?php esc_html_e( 'Favorites', 'wporg-patterns' ); ?></a>
 					</div>
 				<?php else : ?>
 					<div>

--- a/public_html/wp-content/themes/pattern-directory/page-favorites.php
+++ b/public_html/wp-content/themes/pattern-directory/page-favorites.php
@@ -16,7 +16,7 @@ get_header();
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 	</header><!-- .entry-header -->
 
-	<div id="my-favorites__container"></div>
+	<div id="pattern-favorites__container"></div>
 
 </main><!-- #main -->
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
@@ -51,7 +51,7 @@ const MyFavorites = () => {
 	return (
 		<RouteProvider>
 			<QueryMonitor />
-			{ isLoggedIn && <PatternGridMenu basePath="/my-favorites/" query={ query } /> }
+			{ isLoggedIn && <PatternGridMenu basePath="/favorites/" query={ query } /> }
 			{ ! isLoggedIn || isEmpty ? (
 				<>
 					<EmptyHeader isLoggedIn={ isLoggedIn } />

--- a/public_html/wp-content/themes/pattern-directory/src/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/index.js
@@ -25,7 +25,7 @@ if ( myPatternsGridContainer ) {
 }
 
 // Load the preview into any awaiting preview container.
-const myFavsGridContainer = document.getElementById( 'my-favorites__container' );
+const myFavsGridContainer = document.getElementById( 'pattern-favorites__container' );
 if ( myFavsGridContainer ) {
 	render( <MyFavorites />, myFavsGridContainer );
 }


### PR DESCRIPTION
Fixes #332 — Update "My Favorites" to "Favorites", and change the URL from `/my-favorites` to `/favorites`. This changes the links across the site, and the filter links on the favorites page. It also adds a redirect to move people from `/my-favorites/…` to `/favorites/…`.

As soon as this is deployed, the page slug will need to be changed, and permalinks refreshed.

### Screenshots

![header](https://user-images.githubusercontent.com/541093/127169103-9e9c39b6-b46b-45ce-af08-47f85fa54317.png)

![fav-page](https://user-images.githubusercontent.com/541093/127169100-2444445d-e1e6-4b7a-bc1f-f236fe1ac495.png)

### How to test the changes in this Pull Request:

1. On your local site - not sandbox - change the My Favorites page to Favorites, and change the page slug to favorites.
2. Refresh permalinks by visiting Options > Permalinks
3. Try going to `/my-favorites`, it should redirect you to `/favorites`
4. That page should show your favorites
5. Click around, it should only direct you to `/favorites`
6. All labels should now say "Favorites", you shouldn't see any "My Favorites"
