### PR TITLE
Favorites: Update empty & logged out views

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_404.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_404.scss
@@ -1,6 +1,6 @@
 .error-404 {
 	display: flex;
-	margin: 0 1rem 4rem;
+	margin: 4rem 1rem;
 	min-height: 28rem;
 	justify-content: center;
 	align-items: center;
@@ -12,6 +12,7 @@
 	background-size: contain;
 
 	.page-title {
+		margin-top: 0;
 		font-weight: 700;
 		font-size: 2.125rem;
 		text-align: center;

--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -37,6 +37,7 @@
 @import "pattern-report-modal";
 @import "pattern-search";
 @import "pattern";
+@import "patterns-favorites";
 @import "site-content";
 @import "site-header";
 @import "site-title";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_patterns-favorites.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_patterns-favorites.scss
@@ -1,0 +1,30 @@
+.pattern-favorites__empty-header {
+	display: flex;
+	justify-content: center;
+	flex-direction: column;
+	margin-top: 4rem;
+	margin-bottom: 4rem;
+	padding-top: 4rem;
+	padding-bottom: 4rem;
+	min-height: 20rem;
+	/* stylelint-disable-next-line function-url-quotes */
+	background-image: url("data:image/svg+xml,%3Csvg width='380' height='348' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M190 39.554C210.629 15.33 242.235 0 275.166 0c58.29 0 104.09 45.8 104.09 104.091 0 71.48-64.241 129.734-161.574 217.995l-.24.217L190 347.285l-27.442-24.793-.747-.678C64.763 233.622.744 175.447.744 104.091.744 45.8 46.544 0 104.835 0 137.766 0 169.371 15.33 190 39.554zm0 256.632l1.893-1.893c90.086-81.569 149.512-135.507 149.512-190.202 0-37.851-28.388-66.24-66.239-66.24-29.146 0-57.534 18.736-67.376 44.665H172.4c-10.031-25.929-38.419-44.665-67.565-44.665-37.851 0-66.24 28.389-66.24 66.24 0 54.695 59.427 108.633 149.513 190.202l1.892 1.893z' fill='%23F0F0F0'/%3E%3C/svg%3E%0A");
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: contain;
+
+	.link-create-account {
+		font-size: 0.875rem;
+	}
+
+	p {
+		margin-top: 0.75rem;
+		margin-bottom: 0;
+	}
+}
+
+.pattern-favorites__grid-title {
+	margin-bottom: 3rem;
+	font-size: 1.375rem;
+	text-align: center;
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_patterns-favorites.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_patterns-favorites.scss
@@ -2,8 +2,7 @@
 	display: flex;
 	justify-content: center;
 	flex-direction: column;
-	margin-top: 4rem;
-	margin-bottom: 4rem;
+	margin: 4rem 1rem;
 	padding-top: 4rem;
 	padding-bottom: 4rem;
 	min-height: 20rem;
@@ -12,6 +11,11 @@
 	background-position: center;
 	background-repeat: no-repeat;
 	background-size: contain;
+
+	@include breakpoint( $breakpoint-large ) {
+		margin-left: auto;
+		margin-right: auto;
+	}
 
 	.link-create-account {
 		font-size: 0.875rem;

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -98,6 +98,7 @@ function enqueue_assets() {
 					'assets' => esc_url( get_stylesheet_directory_uri() ),
 					'site' => esc_url( home_url() ),
 					'login' => esc_url( wp_login_url() ),
+					'register' => esc_url( wp_registration_url() ),
 				) ) ),
 			),
 			'before'

--- a/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
@@ -19,14 +19,33 @@ import { getLoadingMessage, getMessage, getSearchMessage } from './messaging';
 import { store as patternStore } from '../../store';
 
 /**
- * This checks to see if the query is only being sorted.
+ * Check if the query is just the "home" query, and doesn't need a message.
+ *
+ * If the query has no properties, or only "orderby", it is considered a "home" query.
  *
  * @param {Object} query
- * @param {string} query.orderby Sorting key, used to determine if there is sorting.
- * @return {boolean} Set to true if the object is empty with a only sorting parameter.
+ * @return {boolean}
  */
-const isOnlySorting = ( query ) => {
-	return Object.keys( query ).length === 1 && query.orderby;
+const isHomeQuery = ( query ) => {
+	const keys = Object.keys( query || {} );
+	if ( ! keys.length ) {
+		return true;
+	}
+	return keys.length === 1 && keys[ 0 ] === 'orderby';
+};
+
+/**
+ * Check if the query is a valid query.
+ *
+ * @param {Object} query
+ * @return {boolean}
+ */
+const isQueryValid = ( query = {} ) => {
+	// If there is an "include", it should have items.
+	if ( query.hasOwnProperty( 'include' ) ) {
+		return query.include.length > 0;
+	}
+	return true;
 };
 
 function ContextBar( props ) {
@@ -57,13 +76,13 @@ function ContextBar( props ) {
 
 	useDeepCompareEffect( () => {
 		// Show the loading message
-		if ( isLoadingPatterns ) {
+		if ( isQueryValid( query ) && isLoadingPatterns ) {
 			setMessage( getLoadingMessage( { category: category?.name, author: author } ) );
 			return;
 		}
 
 		// We don't show a message when the query is empty.
-		if ( ( query && ! Object.keys( query ).length ) || isOnlySorting( query ) ) {
+		if ( isHomeQuery( query ) ) {
 			setMessage( '' );
 			return;
 		}

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/empty-header.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/empty-header.js
@@ -2,23 +2,40 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 
-function EmptyHeader() {
-	return (
-		<div className="pattern-grid__empty-header">
-			<h2>{ __( 'No favorites here', 'wporg-patterns' ) }</h2>
+function EmptyHeader( { isLoggedIn } ) {
+	const loginUrl = addQueryArgs( wporgPatternsUrl.login, { redirect_to: window.location } );
+	const registerUrl = addQueryArgs( wporgPatternsUrl.register, { redirect_to: window.location } );
+
+	return isLoggedIn ? (
+		<div className="pattern-grid__empty-header pattern-favorites__empty-header">
+			<h2>{ __( 'Collect and view your favorite patterns.', 'wporg-patterns' ) }</h2>
 			<p>
-				{ createInterpolateElement(
-					__(
-						'You haven’t favorited any patterns yet. Take a look at the <a>block patterns</a> to find some you like, and click the heart to save them.',
-						'wporg-patterns'
-					),
-					{
-						// eslint-disable-next-line jsx-a11y/anchor-has-content -- Content interpolated above.
-						a: <a href={ wporgPatternsUrl.site } />,
-					}
+				{ __(
+					'Tap the heart on any pattern to make it as a favorite. All your favorite patterns will appear here.',
+					'wporg-patterns'
 				) }
+			</p>
+		</div>
+	) : (
+		<div className="pattern-grid__empty-header pattern-favorites__empty-header">
+			<h2>{ __( 'Collect and view your favorite patterns.', 'wporg-patterns' ) }</h2>
+			<p>
+				{ __(
+					'Log in to your WordPress.org account and you’ll be able to see all your favorite patterns in one place.',
+					'wporg-patterns'
+				) }
+			</p>
+			<p>
+				<a className="button button-primary button-large" href={ loginUrl }>
+					{ __( 'Log in', 'wporg-patterns' ) }
+				</a>
+			</p>
+			<p>
+				<a className="button-link link-create-account" href={ registerUrl }>
+					{ __( 'Create an account', 'wporg-patterns' ) }
+				</a>
 			</p>
 		</div>
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { store as patternStore } from '../../store';
 import { useSelect } from '@wordpress/data';
 
@@ -44,26 +43,22 @@ const MyFavorites = () => {
 
 	const isLoggedIn = !! wporgPatternsData.userId;
 
-	if ( ! isLoggedIn ) {
-		const loginUrl = addQueryArgs( wporgPatternsUrl.login, { redirect_to: window.location } );
-		return (
-			<div className="entry-content">
-				<p>{ __( 'Please log in to view your favorite patterns.', 'wporg-patterns' ) }</p>
-				<a className="button button-primary" href={ loginUrl }>
-					{ __( 'Log in', 'wporg-patterns' ) }
-				</a>
-			</div>
-		);
-	}
-
 	return (
 		<RouteProvider>
 			<QueryMonitor />
-			<PatternGridMenu basePath="/my-favorites/" query={ query } />
-			{ isEmpty ? (
+			{ isLoggedIn && <PatternGridMenu basePath="/my-favorites/" query={ query } /> }
+			{ ! isLoggedIn || isEmpty ? (
 				<>
-					<EmptyHeader />
-					<PatternGrid query={ { orderby: 'favorites', per_page: 6 } } showPagination={ false }>
+					<EmptyHeader isLoggedIn={ isLoggedIn } />
+					<PatternGrid
+						header={
+							<h2 className="pattern-favorites__grid-title">
+								{ __( 'Here’s a few of our favorite patterns', 'wporg-patterns' ) }
+							</h2>
+						}
+						query={ { orderby: 'favorite_count', per_page: 6 } }
+						showPagination={ false }
+					>
 						{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
 					</PatternGrid>
 				</>

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
@@ -41,6 +41,11 @@ const MyFavorites = () => {
 		};
 	} );
 
+	const mostFavoritedQuery = { orderby: 'favorite_count', per_page: 6 };
+	if ( query[ 'pattern-categories' ] ) {
+		mostFavoritedQuery[ 'pattern-categories' ] = query[ 'pattern-categories' ];
+	}
+
 	const isLoggedIn = !! wporgPatternsData.userId;
 
 	return (
@@ -56,7 +61,7 @@ const MyFavorites = () => {
 								{ __( 'Here’s a few of our favorite patterns', 'wporg-patterns' ) }
 							</h2>
 						}
-						query={ { orderby: 'favorite_count', per_page: 6 } }
+						query={ mostFavoritedQuery }
 						showPagination={ false }
 					>
 						{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
@@ -56,17 +56,22 @@ const MyFavorites = () => {
 		);
 	}
 
-	if ( isEmpty ) {
-		return <EmptyHeader />;
-	}
-
 	return (
 		<RouteProvider>
 			<QueryMonitor />
 			<PatternGridMenu basePath="/my-favorites/" query={ query } />
-			<PatternGrid query={ query }>
-				{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
-			</PatternGrid>
+			{ isEmpty ? (
+				<>
+					<EmptyHeader />
+					<PatternGrid query={ { orderby: 'favorites', per_page: 6 } } showPagination={ false }>
+						{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
+					</PatternGrid>
+				</>
+			) : (
+				<PatternGrid query={ query }>
+					{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
+				</PatternGrid>
+			) }
 		</RouteProvider>
 	);
 };


### PR DESCRIPTION
Fixes #335, Fixes #333, Fixes #330. This updates the Favorites page to always show the pattern menu (when logged in), so that if you end up in an empty section, you can get back to other categories. This also updates the copy and design of the "logged out" and "no favorites" states. Both now show the 6 most favorited patterns, and the header section uses a more interesting design.

### Screenshots

No favorites at all:
![all-empty](https://user-images.githubusercontent.com/541093/127218977-83e40c7e-bcaa-44dc-b44a-e0ba3728f89e.png)

An empty category - since taking this screenshot, this was updated to show the 6 most favorited in the current category.
![empty-cat](https://user-images.githubusercontent.com/541093/127218988-548f80a5-609d-40ec-a9da-39b1b4434be3.png)

Logged out view, now also includes a "register" link:
![logged-out](https://user-images.githubusercontent.com/541093/127218994-8619402b-e1c2-4eff-a2d5-3205b329ed0d.png)

Small screen:
<img src="https://user-images.githubusercontent.com/541093/127219001-78d746ff-7370-48c3-9624-b4d24335667b.png" width="410" />

### How to test the changes in this Pull Request:

1. While logged out, go to `/my-favorites`
2. You should see a nicer page, with the 6 most popular patterns, and a login button
3. Log in, go back to favorites (it should redirect you)
4. If you have favorites, you'll see them
5. Navigate to an empty category, or remove all your favorites
6. You should see a nicer empty state, again with the 6 most popular patterns, which will let you pick some.

