### PR TITLE
Pattern preview: Show scaled down large-screen preview on smaller screens

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-preview.scss
@@ -20,11 +20,11 @@
 	max-width: 100vw;
 	min-width: 320px;
 
-	.pattern-preview__viewport-iframe {
+	.components-sandbox {
 		background: $color-white;
-		border: 1px solid $color-gray-light-400;
+		border: 0;
+		box-shadow: 0 0 0 1px $color-gray-light-400;
 		vertical-align: middle;
-		max-width: 100vw;
 	}
 
 	&:focus-within .pattern-preview__resize-help {
@@ -90,5 +90,17 @@
 
 	&:focus {
 		box-shadow: 0 1px 0 #0073aa, 0 0 2px 1px #33b3db;
+	}
+}
+
+.pattern-preview__canvas {
+	margin: 0 auto;
+	overflow: hidden;
+
+	.components-sandbox {
+		width: var(--wporg-pattern-preview--width) !important;
+		max-width: none !important;
+		transform: scale(var(--wporg-pattern-preview--scale)) !important;
+		transform-origin: top left;
 	}
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
@@ -1,29 +1,64 @@
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import Iframe from '../iframe';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { SandBox } from '@wordpress/components';
 
-function Canvas( { html } ) {
-	const style = {
-		width: '100%',
-		height: '50vh',
-		minHeight: '600px',
-		overflowY: 'auto',
+const HTML_CLASS_NAME = 'pattern-wrapper';
+
+const tt1StyleOverrides = `
+body {
+	background-color: white !important;
+}`;
+
+function Canvas( { html, themeSlug = 'twentytwentyone', width } ) {
+	const wrapperRef = useRef();
+	const [ frameScale, setFrameScale ] = useState( 1 );
+
+	const handleOnResize = useCallback( () => {
+		if ( ! wrapperRef.current ) {
+			return;
+		}
+		if ( wrapperRef.current.clientWidth < width ) {
+			const newScale = wrapperRef.current.clientWidth / width;
+			setFrameScale( newScale );
+		} else {
+			setFrameScale( 1 );
+		}
+	}, [ width ] );
+
+	// Trigger recalculation when preview `width` changes & set up a listener
+	// for when the viewport width changes.
+	useEffect( () => {
+		handleOnResize();
+
+		/* eslint-disable @wordpress/no-global-event-listener -- These are global events. */
+		window.addEventListener( 'resize', handleOnResize );
+		return () => {
+			window.removeEventListener( 'resize', handleOnResize );
+		};
+		/* eslint-enable @wordpress/no-global-event-listener */
+	}, [ width ] );
+
+	const cssProperties = {
+		'--wporg-pattern-preview--width': `${ width }px`,
+		'--wporg-pattern-preview--scale': frameScale,
 	};
 
+	const styleLinkTags =
+		window.__editorStyles.html +
+		`<link rel="stylesheet" href="https://wp-themes.com/wp-content/themes/${ themeSlug }/style.css" media="all" />`;
+
 	return (
-		<div>
-			<Iframe
-				className="pattern-preview__viewport-iframe"
-				style={ style }
-				headHTML={ window.__editorStyles.html }
-			>
-				<div
-					dangerouslySetInnerHTML={ {
-						__html: html,
-					} }
-				/>
-			</Iframe>
+		<div ref={ wrapperRef } className="pattern-preview__canvas" style={ cssProperties }>
+			<SandBox
+				html={ styleLinkTags + html }
+				scale={ frameScale }
+				styles={ [ tt1StyleOverrides ] }
+				title={ __( 'Pattern preview', 'wporg-patterns' ) }
+				type={ HTML_CLASS_NAME }
+			/>
 		</div>
 	);
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { useInstanceId, useViewportMatch } from '@wordpress/compose';
 import { SelectControl, VisuallyHidden } from '@wordpress/components';
 
@@ -18,10 +18,7 @@ const INITIAL_WIDTH = 960;
 const MIN_PREVIEW_WIDTH = 280;
 
 function PatternPreview( { blockContent } ) {
-	const showViewportControl = useViewportMatch( 'mobile', '>=' );
-	const showViewportControlDefault = useViewportMatch( 'large', '>=' );
-	const showViewportControlLarge = useViewportMatch( 'wide', '>=' );
-
+	const showDragControls = useViewportMatch( 'mobile', '>=' );
 	const instanceId = useInstanceId( PatternPreview );
 	const [ width, setWidth ] = useState( window.innerWidth < INITIAL_WIDTH ? window.innerWidth : INITIAL_WIDTH );
 	const onDragChange = useCallback( ( delta ) => setWidth( ( value ) => value + delta ), [ setWidth ] );
@@ -32,33 +29,12 @@ function PatternPreview( { blockContent } ) {
 		}
 	};
 
-	const availableWidths = useMemo( () => {
-		// Less than 480 wide.
-		if ( ! showViewportControl ) {
-			return [];
-		}
-		if ( showViewportControlLarge ) {
-			// More than 1280 wide.
-			return [
-				{ label: __( 'Full (1200px)', 'wporg-patterns' ), value: 1200 },
-				{ label: __( 'Default (960px)', 'wporg-patterns' ), value: 960 },
-				{ label: __( 'Medium (480px)', 'wporg-patterns' ), value: 480 },
-				{ label: __( 'Narrow (320px)', 'wporg-patterns' ), value: 320 },
-			];
-		} else if ( showViewportControlDefault ) {
-			// Less than 1280, more than 960.
-			return [
-				{ label: __( 'Default (960px)', 'wporg-patterns' ), value: 960 },
-				{ label: __( 'Medium (480px)', 'wporg-patterns' ), value: 480 },
-				{ label: __( 'Narrow (320px)', 'wporg-patterns' ), value: 320 },
-			];
-		}
-		// Less than 960, but larger than 480.
-		return [
-			{ label: __( 'Medium (480px)', 'wporg-patterns' ), value: 480 },
-			{ label: __( 'Narrow (320px)', 'wporg-patterns' ), value: 320 },
-		];
-	}, [ showViewportControl, showViewportControlDefault, showViewportControlLarge ] );
+	const availableWidths = [
+		{ label: __( 'Full (1200px)', 'wporg-patterns' ), value: 1200 },
+		{ label: __( 'Default (960px)', 'wporg-patterns' ), value: 960 },
+		{ label: __( 'Medium (480px)', 'wporg-patterns' ), value: 480 },
+		{ label: __( 'Narrow (320px)', 'wporg-patterns' ), value: 320 },
+	];
 
 	let currentOpt = false;
 	if ( ! availableWidths.some( ( opt ) => opt.value === width ) ) {
@@ -73,40 +49,44 @@ function PatternPreview( { blockContent } ) {
 	return (
 		<>
 			<div className="pattern-preview__size-control">
-				{ showViewportControl && (
-					<SelectControl
-						hideLabelFromVision
-						label={ __( 'Preview Width', 'wporg-patterns' ) }
-						value={ width }
-						options={ currentOpt ? [ currentOpt, ...availableWidths ] : availableWidths }
-						onChange={ ( value ) => setWidth( Number( value ) ) }
-					/>
-				) }
+				<SelectControl
+					hideLabelFromVision
+					label={ __( 'Preview Width', 'wporg-patterns' ) }
+					value={ width }
+					options={ currentOpt ? [ currentOpt, ...availableWidths ] : availableWidths }
+					onChange={ ( value ) => setWidth( Number( value ) ) }
+				/>
 			</div>
 			<div className="pattern-preview__viewport" style={ { width: width + 40 } }>
-				<DragHandle
-					label={ __( 'Drag to resize', 'wporg-patterns' ) }
-					className="is-left"
-					onDragChange={ onDragChange }
-					onDragEnd={ onDragEnd }
-					direction="left"
-					aria-describedby={ `pattern-preview__resize-help-${ instanceId }` }
-				/>
+				{ showDragControls && (
+					<DragHandle
+						label={ __( 'Drag to resize', 'wporg-patterns' ) }
+						className="is-left"
+						onDragChange={ onDragChange }
+						onDragEnd={ onDragEnd }
+						direction="left"
+						aria-describedby={ `pattern-preview__resize-help-${ instanceId }` }
+					/>
+				) }
 				<Canvas html={ blockContent } />
-				<DragHandle
-					label={ __( 'Drag to resize', 'wporg-patterns' ) }
-					className="is-right"
-					onDragChange={ onDragChange }
-					onDragEnd={ onDragEnd }
-					direction="right"
-					aria-describedby={ `pattern-preview__resize-help-${ instanceId }` }
-				/>
-				<VisuallyHidden
-					id={ `pattern-preview__resize-help-${ instanceId }` }
-					className="pattern-preview__resize-help"
-				>
-					{ __( 'Use left and right arrow keys to resize the preview.', 'wporg-patterns' ) }
-				</VisuallyHidden>
+				{ showDragControls && (
+					<DragHandle
+						label={ __( 'Drag to resize', 'wporg-patterns' ) }
+						className="is-right"
+						onDragChange={ onDragChange }
+						onDragEnd={ onDragEnd }
+						direction="right"
+						aria-describedby={ `pattern-preview__resize-help-${ instanceId }` }
+					/>
+				) }
+				{ showDragControls && (
+					<VisuallyHidden
+						id={ `pattern-preview__resize-help-${ instanceId }` }
+						className="pattern-preview__resize-help"
+					>
+						{ __( 'Use left and right arrow keys to resize the preview.', 'wporg-patterns' ) }
+					</VisuallyHidden>
+				) }
 			</div>
 		</>
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/index.js
@@ -38,7 +38,7 @@ function PatternPreview( { blockContent } ) {
 
 	let currentOpt = false;
 	if ( ! availableWidths.some( ( opt ) => opt.value === width ) ) {
-		const displayWidth = Math.max( Math.floor( width ), MIN_PREVIEW_WIDTH );
+		const displayWidth = Math.max( Math.floor( width ), MIN_PREVIEW_WIDTH ) - 40;
 		currentOpt = {
 			/* translators: %s is the width in pixels, ex 600. */
 			label: sprintf( __( 'Current (%spx)', 'wporg-patterns' ), displayWidth ),
@@ -68,7 +68,7 @@ function PatternPreview( { blockContent } ) {
 						aria-describedby={ `pattern-preview__resize-help-${ instanceId }` }
 					/>
 				) }
-				<Canvas html={ blockContent } />
+				<Canvas html={ blockContent } width={ width } />
 				{ showDragControls && (
 					<DragHandle
 						label={ __( 'Drag to resize', 'wporg-patterns' ) }


### PR DESCRIPTION
Fixes #122. Currently, you can only preview a pattern at your native viewport width or smaller. If you're on a phone, you can't see what the pattern would look like on a monitor. This PR updates the logic for the dropdown and drag handles, and scales down the pattern preview so it's visible on any screen size.

Now, the size dropdown is always visible, while the drag handles disappear below 480px.

⚠️  This is still in progress, but I'm having trouble with it. @StevenDufresne maybe you can help? Feel free to comment or commit.

I've swapped out the forked `iframe` component to use [the `SandBox` component](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/sandbox) from `@wordpress/components`. This seems more in line with our intention, and could replace our forked component (maybe). It loads in the given HTML, then resets the height and width on the `iframe` so that the content is fully visible. This is great normally, because we want the whole pattern to be visible.

To make the scaling work, I'm taking the requested width (full 1200, default 960, etc) and the container width (basically viewport width), and dividing container / request, so if you request 1200px preview on a 600px phone, it should scale by 0.5. Then I pass that to the CSS via custom properties (so that we can override the set width on the iframe, since we can't pass down those styles).

This is where the problem is. The width is correctly scaled down, so ex, in "full 1200 preview" on a 600px screen, a pattern is rendered at 1200w x 800h, the iframe scales down 0.5. A max-width on the container constrains it to 600px width, but the height is still 800px, so there's a huge empty space below the preview. It seems like the container still expects the content to be 1200x800, and the max-width prevents the horizontal overflow, but nothing catches the height.

<img src="https://user-images.githubusercontent.com/541093/127399927-20ce0ecc-635d-4da8-98ea-1bca8ccac7b2.png" width="640" />

### Screenshots

Looks great when the preview size is smaller the the viewport!

![Screen Shot 2021-07-28 at 17 16 36](https://user-images.githubusercontent.com/541093/127399631-74849a33-ec39-4a26-86e7-6d2923942224.png)

![Screen Shot 2021-07-28 at 17 16 48](https://user-images.githubusercontent.com/541093/127399644-7313576d-aefd-4fb4-abe1-f9fcbd855a1d.png)

### How to test the changes in this Pull Request:

1. Build the branch
2. View any single pattern at various screen sizes
3. Try previewing it at different widths using the dropdown
4. The preview should show the whole pattern, but not have extra space around it
