### PR TITLE
Patterns by Author: Show the author's display name instead of username.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -85,6 +85,7 @@ function enqueue_assets() {
 				"var wporgPatternsData = JSON.parse( decodeURIComponent( '%s' ) )",
 				rawurlencode( wp_json_encode( array(
 					'userId' => get_current_user_id(),
+					'currentAuthorName' => esc_html( get_the_author_meta( 'display_name' ) ),
 				) ) ),
 			),
 			'before'

--- a/public_html/wp-content/themes/pattern-directory/src/components/breadcrumb-monitor/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/breadcrumb-monitor/index.js
@@ -26,13 +26,11 @@ const setBreadcrumbText = ( label ) => {
 const BreadcrumbMonitor = () => {
 	const { path } = useRoute();
 
-	const { authorName, categoryName, query } = useSelect( ( select ) => {
+	const { authorName, categoryName } = useSelect( ( select ) => {
 		const _query = select( patternStore ).getQueryFromUrl( path );
 		const category = select( patternStore ).getCategoryById( _query[ 'pattern-categories' ] );
 		return {
-			query: _query,
-			// @todo Get the author's display name.
-			authorName: _query?.author_name,
+			authorName: wporgPatternsData.currentAuthorName || _query?.author_name,
 			categoryName: category?.name,
 		};
 	}, [] );
@@ -40,7 +38,7 @@ const BreadcrumbMonitor = () => {
 	useEffect( () => {
 		if ( authorName ) {
 			// translators: %s is the author name.
-			setBreadcrumbText( sprintf( __( 'Author: %s', 'wporg-patterns' ), query.author_name ) );
+			setBreadcrumbText( sprintf( __( 'Author: %s', 'wporg-patterns' ), authorName ) );
 		} else if ( categoryName ) {
 			// translators: %s is the category name.
 			setBreadcrumbText( sprintf( __( 'Category: %s', 'wporg-patterns' ), categoryName ) );

--- a/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
@@ -64,7 +64,7 @@ function ContextBar( props ) {
 			const _query = { ...getQueryFromUrl( path ), ...props.query };
 
 			return {
-				author: _query?.author_name,
+				author: wporgPatternsData.currentAuthorName || _query?.author_name,
 				category: getCategoryById( _query[ 'pattern-categories' ] ),
 				count: getPatternTotalsByQuery( _query ),
 				isLoadingPatterns: isLoadingPatternsByQuery( _query ),


### PR DESCRIPTION
Fixes #311. Currently, the author archive breadcrumb and context bar use the author's username (ex, `wordpressdotorg`), but it would be better to show the display name. This PR injects the current author name into the `wporgPatternsData` global, setting it when on the author page. This avoids needing to create a separate endpoint for user information, since moving to an author archive will always load a new page from the server.

If/when we move to more SPA-style control, we can revisit this.

### Screenshots

| Before | After |
|--------|------|
| <img width="596" alt="Screen Shot 2021-07-29 at 4 07 55 PM" src="https://user-images.githubusercontent.com/541093/127558901-75b46e66-1f0f-4891-88e7-46cbae20ac70.png"> | <img width="737" alt="Screen Shot 2021-07-29 at 3 47 49 PM" src="https://user-images.githubusercontent.com/541093/127558917-79e6a689-9d42-4c61-82fa-39dd44b9c8d2.png"> |


### How to test the changes in this Pull Request:

1. Set up some patterns with different authors
2. Set the author display names to something custom, optionally with non-english characters
3. View an author archive
4. The blue bar should read "Author: Display Name"
5. The grey bar should read "X patterns by Display Name", or "X [category] patterns by Display Name"
