### PR TITLE
Theme: Update the page title when navigating through pages

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/document-title-monitor/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/document-title-monitor/index.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as patternStore } from '../../store';
+import { getPageFromPath, removeQueryString } from '../../utils';
+import { useRoute } from '../../hooks';
+
+const DocumentTitleMonitor = () => {
+	const { path } = useRoute();
+
+	const title = useSelect( ( select ) => {
+		const _query = select( patternStore ).getQueryFromUrl( path );
+		const category = select( patternStore ).getCategoryById( _query[ 'pattern-categories' ] )?.name;
+		const authorName = wporgPatternsData.currentAuthorName || _query?.author_name;
+		const page = getPageFromPath( path );
+
+		const currentPath = removeQueryString( path );
+		const currentSection = currentPath.replace( '/patterns', '' ).split( '/' )[ 1 ] || '';
+		const parts = [];
+
+		if ( 'categories' === currentSection && category ) {
+			parts.push(
+				/* translators: Taxonomy term name */
+				sprintf( __( 'Block Patterns: %s', 'wporg-patterns' ), category )
+			);
+		} else if ( 'author' === currentSection && authorName ) {
+			parts.push(
+				/* translators: Author name */
+				sprintf( __( 'Block Patterns by %s', 'wporg-patterns' ), authorName )
+			);
+		} else {
+			parts.push( __( 'Block Pattern Directory', 'wporg-patterns' ) );
+		}
+
+		if ( page > 1 ) {
+			parts.push(
+				/* translators: Page number */
+				sprintf( __( 'Page %d', 'wporg-patterns' ), page )
+			);
+		}
+
+		parts.push( __( 'WordPress.org', 'wporg-patterns' ) );
+		return parts.join( ' | ' );
+	} );
+
+	useEffect( () => {
+		if ( title ) {
+			document.title = title;
+		}
+	}, [ title ] );
+
+	return null;
+};
+
+export default DocumentTitleMonitor;

--- a/public_html/wp-content/themes/pattern-directory/src/components/document-title-monitor/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/document-title-monitor/index.js
@@ -21,16 +21,18 @@ const DocumentTitleMonitor = () => {
 		const authorName = wporgPatternsData.currentAuthorName || _query?.author_name;
 		const page = getPageFromPath( path );
 
-		const currentPath = removeQueryString( path );
-		const currentSection = currentPath.replace( '/patterns', '' ).split( '/' )[ 1 ] || '';
+		// Remove irrelvant content from the path: query string, site subdirectory.
+		const contentPath = removeQueryString( path ).replace( /^\/patterns/, '' );
+		// Get the first item after the `/`: categories, author, etc.
+		const section = contentPath.split( '/' )[ 1 ] || '';
 		const parts = [];
 
-		if ( 'categories' === currentSection && category ) {
+		if ( 'categories' === section && category ) {
 			parts.push(
 				/* translators: Taxonomy term name */
 				sprintf( __( 'Block Patterns: %s', 'wporg-patterns' ), category )
 			);
-		} else if ( 'author' === currentSection && authorName ) {
+		} else if ( 'author' === section && authorName ) {
 			parts.push(
 				/* translators: Author name */
 				sprintf( __( 'Block Patterns by %s', 'wporg-patterns' ), authorName )

--- a/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import DocumentTitleMonitor from '../document-title-monitor';
 import EmptyHeader from './empty-header';
 import PatternGrid from '../pattern-grid';
 import PatternGridMenu from '../pattern-grid-menu';
@@ -31,6 +32,7 @@ const Patterns = () => {
 
 	return (
 		<RouteProvider>
+			<DocumentTitleMonitor />
 			<QueryMonitor />
 			<BreadcrumbMonitor />
 			<PatternGridMenu />


### PR DESCRIPTION
Fixes #310 - Keep the title updated when navigating through categories, matching the behavior of the PHP title function. See #318/#319.

- Home: `Block Pattern Directory | WordPress.org`
- Categories: `Block Patterns: Columns | WordPress.org`
- Author, paginated: `Block Patterns by WordPress.org | Page 3 | WordPress.org`

### How to test the changes in this Pull Request:

1. Navigate through pages, the title should update and be correct
2. Reload the page, the title should match the title generated by PHP
