### PR TITLE
Patterns: Focus on the context bar after navigation

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_context-bar.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_context-bar.scss
@@ -35,6 +35,13 @@
 			}
 		}
 	}
+
+	&:focus {
+		outline: none;
+		box-shadow:
+			inset 0 0 0 1px #fff,
+			0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	}
 }
 
 .context-bar__copy {

--- a/public_html/wp-content/themes/pattern-directory/package.json
+++ b/public_html/wp-content/themes/pattern-directory/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/core-data": "4.0.1",
 		"@wordpress/data": "6.0.1",
 		"@wordpress/data-controls": "2.2.2",
+		"@wordpress/dom": "3.2.2",
 		"@wordpress/element": "4.0.0",
 		"@wordpress/html-entities": "3.2.1",
 		"@wordpress/i18n": "4.2.1",

--- a/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
@@ -7,9 +7,10 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -109,38 +110,36 @@ function ContextBar( props ) {
 		}
 	}, [ query, isLoadingPatterns ] );
 
-	const classes = classnames( {
+	const spinnerClassName = classnames( {
 		'context-bar__spinner': true,
 		'context-bar__spinner--is-hidden': ! isLoadingPatterns,
 	} );
 
 	return (
-		<header className="context-bar" aria-live="polite" aria-atomic="true" tabIndex="0">
-			{ ! message ? null : (
-				<>
-					<h2 className="context-bar__copy">
-						<span className={ classes }>
-							<Spinner />
-						</span>
-						<span>{ message }</span>
-						{ pageLabel && <span className="screen-reader-text">{ pageLabel }</span> }
-					</h2>
-					{ context.links && context.links.length > 0 && (
-						<div className="context-bar__links">
-							<h3 className="context-bar__title">{ context.title }</h3>
+		<div className={ message ? null : 'screen-reader-text' }>
+			<header className="context-bar" aria-live="polite" aria-atomic="true" tabIndex="0">
+				<h2 className="context-bar__copy">
+					<span className={ spinnerClassName }>
+						<Spinner />
+					</span>
+					<span>{ message || __( 'All patterns.', 'wporg-patterns' ) }</span>
+					{ pageLabel && <span className="screen-reader-text">{ pageLabel }</span> }
+				</h2>
+				{ context.links && context.links.length > 0 && (
+					<div className="context-bar__links">
+						<h3 className="context-bar__title">{ context.title }</h3>
 
-							<ul>
-								{ context.links.map( ( i ) => (
-									<li key={ i.href }>
-										<a href={ i.href }>{ i.label }</a>
-									</li>
-								) ) }
-							</ul>
-						</div>
-					) }
-				</>
-			) }
-		</header>
+						<ul>
+							{ context.links.map( ( i ) => (
+								<li key={ i.href }>
+									<a href={ i.href }>{ i.label }</a>
+								</li>
+							) ) }
+						</ul>
+					</div>
+				) }
+			</header>
+		</div>
 	);
 }
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/context-bar/messaging.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/context-bar/messaging.js
@@ -136,3 +136,18 @@ export const getSearchMessage = ( count, searchTerm ) => {
 		}
 	);
 };
+
+/**
+ * Returns a message regarding current search status.
+ *
+ * @param {number} page       Current page number.
+ * @param {number} totalPages Total number of pages.
+ * @return {string}
+ */
+export const getPageLabel = ( page = 1, totalPages = 1 ) => {
+	if ( 1 === totalPages ) {
+		return '';
+	}
+	/* translators: %1$d: current page. %2$d: total number of pages.  */
+	return sprintf( __( 'Page %1$d of %2$d.', 'wporg-patterns' ), page, totalPages );
+};

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
@@ -14,6 +14,7 @@ import PatternGridMenu from '../pattern-grid-menu';
 import PatternThumbnail from '../pattern-thumbnail';
 import QueryMonitor from '../query-monitor';
 import { RouteProvider } from '../../hooks';
+import useFocusOnNavigation from '../../hooks/use-focus-on-navigation';
 
 const MyFavorites = () => {
 	const { isEmpty, query } = useSelect( ( select ) => {
@@ -40,6 +41,7 @@ const MyFavorites = () => {
 			isEmpty: ! isLoading && ! posts.length,
 		};
 	} );
+	const [ ref, onNavigation ] = useFocusOnNavigation();
 
 	const mostFavoritedQuery = { orderby: 'favorite_count', per_page: 6 };
 	if ( query[ 'pattern-categories' ] ) {
@@ -51,7 +53,11 @@ const MyFavorites = () => {
 	return (
 		<RouteProvider>
 			<QueryMonitor />
-			{ isLoggedIn && <PatternGridMenu basePath="/favorites/" query={ query } /> }
+			<div ref={ ref } className="patterns-header">
+				{ isLoggedIn && (
+					<PatternGridMenu basePath="/favorites/" query={ query } onNavigation={ onNavigation } />
+				) }
+			</div>
 			{ ! isLoggedIn || isEmpty ? (
 				<>
 					<EmptyHeader isLoggedIn={ isLoggedIn } />
@@ -68,7 +74,7 @@ const MyFavorites = () => {
 					</PatternGrid>
 				</>
 			) : (
-				<PatternGrid query={ query }>
+				<PatternGrid query={ query } onNavigation={ onNavigation }>
 					{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
 				</PatternGrid>
 			) }

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
@@ -53,7 +53,7 @@ const MyFavorites = () => {
 	return (
 		<RouteProvider>
 			<QueryMonitor />
-			<div ref={ ref } className="patterns-header">
+			<div ref={ ref }>
 				{ isLoggedIn && (
 					<PatternGridMenu basePath="/favorites/" query={ query } onNavigation={ onNavigation } />
 				) }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
@@ -51,7 +51,9 @@ const PatternGridMenu = ( { basePath = '', onNavigation, ...props } ) => {
 						onClick={ ( event ) => {
 							event.preventDefault();
 							updatePath( event.target.pathname );
-							onNavigation();
+							if ( 'function' === typeof onNavigation ) {
+								onNavigation();
+							}
 						} }
 						isLoading={ isLoading }
 					/>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
@@ -14,7 +14,7 @@ import NavigationLayout from '../navigation-layout';
 import { store as patternStore } from '../../store';
 import { useRoute } from '../../hooks';
 
-const PatternGridMenu = ( { basePath = '', ...props } ) => {
+const PatternGridMenu = ( { basePath = '', onNavigation, ...props } ) => {
 	const { path, update: updatePath } = useRoute();
 	const { categorySlug, isLoading, options } = useSelect( ( select ) => {
 		const { getCategoryById, getCategories, getQueryFromUrl, getUrlFromQuery, isLoadingCategories } = select(
@@ -51,6 +51,7 @@ const PatternGridMenu = ( { basePath = '', ...props } ) => {
 						onClick={ ( event ) => {
 							event.preventDefault();
 							updatePath( event.target.pathname );
+							onNavigation();
 						} }
 						isLoading={ isLoading }
 					/>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/index.js
@@ -10,7 +10,7 @@ import GridSkeleton from './grid-skeleton';
 import Pagination from './pagination';
 import { store as patternStore } from '../../store';
 
-function PatternGrid( { header, children, query, showPagination = true } ) {
+function PatternGrid( { header, children, onNavigation, query, showPagination = true } ) {
 	const { isLoading, posts, totalPages } = useSelect( ( select ) => {
 		const { getPatternTotalPagesByQuery, getPatternsByQuery, isLoadingPatternsByQuery } = select(
 			patternStore
@@ -29,7 +29,9 @@ function PatternGrid( { header, children, query, showPagination = true } ) {
 			<div className="pattern-grid">
 				{ isLoading ? <GridSkeleton length={ query?.per_page } /> : posts.map( children ) }
 			</div>
-			{ showPagination && <Pagination totalPages={ totalPages } currentPage={ query?.page } /> }
+			{ showPagination && (
+				<Pagination totalPages={ totalPages } currentPage={ query?.page } onNavigation={ onNavigation } />
+			) }
 		</>
 	);
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid/pagination.js
@@ -10,7 +10,7 @@ import { getQueryString } from '@wordpress/url';
 import getPaginationList from '../../utils/get-pagination-list';
 import { useRoute } from '../../hooks';
 
-export default function Pagination( { currentPage = 1, totalPages } ) {
+export default function Pagination( { currentPage = 1, onNavigation, totalPages } ) {
 	const { path, update: updatePath } = useRoute();
 	if ( ! totalPages || totalPages <= 1 ) {
 		return null;
@@ -29,6 +29,9 @@ export default function Pagination( { currentPage = 1, totalPages } ) {
 	const onClick = ( event, page ) => {
 		event.preventDefault();
 		updatePath( getPageUrl( page ) );
+		if ( 'function' === typeof onNavigation ) {
+			onNavigation();
+		}
 	};
 
 	return (

--- a/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
@@ -38,7 +38,7 @@ const Patterns = () => {
 			<DocumentTitleMonitor />
 			<QueryMonitor />
 			<BreadcrumbMonitor />
-			<div ref={ ref } className="patterns-header">
+			<div ref={ ref }>
 				{ isSearch ? <ContextBar query={ query } /> : <PatternGridMenu onNavigation={ onNavigation } /> }
 			</div>
 			{ isEmpty ? (

--- a/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
@@ -1,13 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { focus } from '@wordpress/dom';
-import { useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import BreadcrumbMonitor from '../breadcrumb-monitor';
 import ContextBar from '../context-bar';
 import DocumentTitleMonitor from '../document-title-monitor';
 import EmptyHeader from './empty-header';
@@ -15,10 +14,9 @@ import PatternGrid from '../pattern-grid';
 import PatternGridMenu from '../pattern-grid-menu';
 import PatternThumbnail from '../pattern-thumbnail';
 import QueryMonitor from '../query-monitor';
-import BreadcrumbMonitor from '../breadcrumb-monitor';
-
 import { RouteProvider } from '../../hooks';
 import { store as patternStore } from '../../store';
+import useFocusOnNavigation from '../../hooks/use-focus-on-navigation';
 
 const Patterns = () => {
 	const { isEmpty, isSearch, query } = useSelect( ( select ) => {
@@ -33,19 +31,7 @@ const Patterns = () => {
 			query: _query,
 		};
 	} );
-	const ref = useRef();
-	const onNavigation = () => {
-		if ( ! ref?.current ) {
-			return;
-		}
-
-		const tabStops = focus.tabbable.find( ref.current );
-		const target = tabStops[ tabStops.length - 1 ] || false;
-
-		if ( target ) {
-			target.focus();
-		}
-	};
+	const [ ref, onNavigation ] = useFocusOnNavigation();
 
 	return (
 		<RouteProvider>

--- a/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { focus } from '@wordpress/dom';
+import { useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -31,13 +33,28 @@ const Patterns = () => {
 			query: _query,
 		};
 	} );
+	const ref = useRef();
+	const onNavigation = () => {
+		if ( ! ref?.current ) {
+			return;
+		}
+
+		const tabStops = focus.tabbable.find( ref.current );
+		const target = tabStops[ tabStops.length - 1 ] || false;
+
+		if ( target ) {
+			target.focus();
+		}
+	};
 
 	return (
 		<RouteProvider>
 			<DocumentTitleMonitor />
 			<QueryMonitor />
 			<BreadcrumbMonitor />
-			{ isSearch ? <ContextBar query={ query } /> : <PatternGridMenu /> }
+			<div ref={ ref } className="patterns-header">
+				{ isSearch ? <ContextBar query={ query } /> : <PatternGridMenu onNavigation={ onNavigation } /> }
+			</div>
 			{ isEmpty ? (
 				<>
 					<EmptyHeader />
@@ -46,7 +63,7 @@ const Patterns = () => {
 					</PatternGrid>
 				</>
 			) : (
-				<PatternGrid query={ query }>
+				<PatternGrid query={ query } onNavigation={ onNavigation }>
 					{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
 				</PatternGrid>
 			) }

--- a/public_html/wp-content/themes/pattern-directory/src/hooks/use-focus-on-navigation.js
+++ b/public_html/wp-content/themes/pattern-directory/src/hooks/use-focus-on-navigation.js
@@ -7,7 +7,7 @@ import { focus } from '@wordpress/dom';
 /**
  * Hook used to focus the first tabbable element with a callback.
  *
- * @return {Array} Ref callback.
+ * @return {Array} Ref and callback.
  */
 export default function useFocusOnNavigation() {
 	const containerRef = useRef();

--- a/public_html/wp-content/themes/pattern-directory/src/hooks/use-focus-on-navigation.js
+++ b/public_html/wp-content/themes/pattern-directory/src/hooks/use-focus-on-navigation.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useRef } from '@wordpress/element';
+import { focus } from '@wordpress/dom';
+
+/**
+ * Hook used to focus the first tabbable element with a callback.
+ *
+ * @return {Array} Ref callback.
+ */
+export default function useFocusOnNavigation() {
+	const containerRef = useRef();
+
+	const callback = useCallback( () => {
+		if ( ! containerRef?.current ) {
+			return;
+		}
+
+		const tabStops = focus.tabbable.find( containerRef.current );
+		const target = tabStops[ tabStops.length - 1 ] || false;
+
+		if ( target ) {
+			target.focus();
+		}
+
+		target.focus();
+	}, [] );
+
+	return [ containerRef, callback ];
+}


### PR DESCRIPTION
This triggers the browser to scroll back to the top of the page, moves the keyboard focus, and announces to screen reader users that the page content has changed. The ContextBar content is now always on screen, but sometimes (ex, on the homepage), it is visually hidden. There is also now a "Page X of Y." label in the ContextBar, but this is only read by screen readers.

Fixes #297.

To test (expected behavior):

With a keyboard, a screen reader, or a mouse…

- Go to the Home page.
- Click any category, the category should load and the focus is moved to the context bar. If you're using a screen reader, you will hear "Loading" and then "X [category] patterns. Page 1 of 5." (only if the category is paginated).
- Tabbing from here will move focus onto the first pattern in the grid.
- Tab through all the patterns until you reach the pagination, click a page number.
- The next page will start loading. Again, if using a screen reader, you will hear "Loading" and then "X [category] patterns. Page 2 of 5."
- Focus and browser scroll has been moved back to the top of the grid, so you should have the ContextBar on-screen.
- Tabbing from here will move focus onto the first pattern in the grid.

Try with the My Favorites section, move between categories, etc.