### PR TITLE
Fix typo on empty Favorites screen.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/empty-header.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/empty-header.js
@@ -13,7 +13,7 @@ function EmptyHeader( { isLoggedIn } ) {
 			<h2>{ __( 'Collect and view your favorite patterns.', 'wporg-patterns' ) }</h2>
 			<p>
 				{ __(
-					'Tap the heart on any pattern to make it as a favorite. All your favorite patterns will appear here.',
+					'Tap the heart on any pattern to mark it as a favorite. All your favorite patterns will appear here.',
 					'wporg-patterns'
 				) }
 			</p>


### PR DESCRIPTION
<img width="648" alt="image" src="https://user-images.githubusercontent.com/191598/135482103-1cd85255-6814-4dac-9be0-d195fcc35e40.png">

The empty favorites screen has copy that mentions the ability to "make it as a favorite." This is a typo; It should say "mark it as a favorite." This originated from my Figma file, so kudos for the dedication to pixel perfection. ;)