### PR TITLE
Patterns: Show a notice to indicate the pattern status.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -30,6 +30,7 @@
 @import "pattern-grid";
 @import "pattern-menu";
 @import "pattern-navigation-layout";
+@import "pattern-notice";
 @import "pattern-order-select";
 @import "pattern-pagination";
 @import "pattern-preview";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-notice.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-notice.scss
@@ -1,0 +1,65 @@
+/* Set up some defaults for all notices. */
+.pattern__container .components-notice {
+	margin-left: 0;
+	margin-right: 0;
+	margin-bottom: $gutter-default;
+	height: auto;
+	flex-basis: 100%;
+
+	&.is-info {
+		background-color: color(gray-5);
+	}
+
+	&.is-warning {
+		background-color: color(yellow-5);
+	}
+
+	&.is-error {
+		background-color: color(red-5);
+	}
+
+	> * {
+		display: flex;
+		flex-direction: column; // stack on mobile
+		justify-content: space-between;
+		align-items: flex-start;
+		margin: 0;
+
+		strong {
+			margin-right: 0.5ch;
+		}
+
+		button {
+			margin-top: 0.75rem;
+			background: color(gray-0);
+			border: 1px solid color(gray-10);
+			box-sizing: border-box;
+			box-shadow: inset 0 -1px 0 color(gray-10);
+			border-radius: 2px;
+			color: color(gray-80);
+
+			&:hover {
+				border-color: color(gray-50) !important;
+				box-shadow: inset 0 -1px 0 color(gray-50) !important;
+				color: color(gray-90) !important;
+			}
+
+			&:focus {
+				border-color: color(gray-0) !important;
+				box-shadow:
+					inset 0 0 0 1px #fff,
+					0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color) !important;
+			}
+		}
+
+		@media only screen and (min-width: $breakpoint-small) {
+			align-items: center;
+			flex-direction: row;
+
+			button {
+				margin-top: 0;
+			}
+		}
+	}
+}
+

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-notice.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-notice.scss
@@ -69,3 +69,11 @@
 	padding-right: $gutter-default;
 	min-height: $gutter-default * 2;
 }
+
+.pattern__status-notice-modal.pattern__status-notice-modal {
+	max-width: $gutter-default * 14;
+
+	p {
+		line-height: 1.6;
+	}
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-notice.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-notice.scss
@@ -63,3 +63,9 @@
 	}
 }
 
+.pattern__status-notice {
+	margin-top: 0;
+	padding-left: $gutter-default;
+	padding-right: $gutter-default;
+	min-height: $gutter-default * 2;
+}

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -78,34 +78,6 @@ body.single-wporg-pattern {
 		}
 	}
 
-	.pattern-actions__notice {
-		margin: 1.5rem 0 0;
-		height: auto;
-		flex-basis: 100%;
-
-		// @wordpress/components/notice wraps content
-		> * {
-			display: flex;
-			flex-direction: column; // stack on mobile
-			justify-content: space-between;
-			align-items: flex-start;
-			margin: 0;
-
-			button {
-				margin-top: 0.75rem;
-			}
-
-			@media only screen and (min-width: $breakpoint-small) {
-				align-items: center;
-				flex-direction: row;
-
-				button {
-					margin-top: 0;
-				}
-			}
-		}
-	}
-
 	.pattern-actions__guide {
 		max-width: $breakpoint-mobile / 1.25;
 

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -24,18 +24,6 @@ $raw_block_content = get_the_content();
 			?>
 
 			<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-				<header class="entry-header">
-					<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-					<div class="pattern__categories">
-						<?php
-						$categories_list = get_the_term_list( get_the_ID(), 'wporg-pattern-category' );
-						if ( $categories_list ) {
-							echo $categories_list; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						}
-						?>
-					</div>
-				</header><!-- .entry-header -->
-
 				<div
 					hidden
 					class="pattern__container"

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-success-message.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview-actions/copy-success-message.js
@@ -18,8 +18,8 @@ const CopySuccessMessage = ( { onClick } ) => (
 		] }
 	>
 		<div>
-			<b>{ __( 'Pattern copied!', 'wporg-patterns' ) }</b>
-			{ __( ' Now you can paste it into any WordPress post or page.', 'wporg-patterns' ) }
+			<strong>{ __( 'Pattern copied!', 'wporg-patterns' ) }</strong>
+			{ __( 'Now you can paste it into any WordPress post or page.', 'wporg-patterns' ) }
 		</div>
 	</Notice>
 );

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
@@ -14,6 +14,7 @@ import PatternPreview from '../pattern-preview';
 import PatternPreviewActions from '../pattern-preview-actions';
 import PatternThumbnail from '../pattern-thumbnail';
 import ReportPatternButton from '../report-pattern-button';
+import StatusNotice from './status-notice';
 import { store as patternStore } from '../../store';
 
 const Pattern = ( { postId, userHasReported } ) => {
@@ -41,6 +42,7 @@ const Pattern = ( { postId, userHasReported } ) => {
 	return (
 		<>
 			<header className="entry-header">
+				<StatusNotice pattern={ pattern } />
 				<h1 className="entry-title">{ decodeEntities( pattern.title.rendered ) }</h1>
 				<div className="pattern__categories">
 					{ categories.map( ( { id, name, link } ) => (

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -18,13 +19,37 @@ import { store as patternStore } from '../../store';
 const Pattern = ( { postId, userHasReported } ) => {
 	// postId as passed from the HTML dataset is a string.
 	postId = Number( postId ) || 0;
-	const pattern = useSelect( ( select ) => select( patternStore ).getPattern( postId ), [ postId ] );
+	const { pattern, categories } = useSelect(
+		( select ) => {
+			const _pattern = select( patternStore ).getPattern( postId );
+			const allCategories = select( patternStore ).getCategories() || [];
+			const _categories = _pattern?.[ 'pattern-categories' ]
+				.map( ( cid ) => allCategories.find( ( { id } ) => id === cid ) )
+				.filter( Boolean );
+
+			return {
+				pattern: _pattern,
+				categories: _categories || [],
+			};
+		},
+		[ postId ]
+	);
 	if ( ! pattern ) {
 		return null;
 	}
 
 	return (
 		<>
+			<header className="entry-header">
+				<h1 className="entry-title">{ decodeEntities( pattern.title.rendered ) }</h1>
+				<div className="pattern__categories">
+					{ categories.map( ( { id, name, link } ) => (
+						<a href={ link } key={ id }>
+							{ decodeEntities( name ) }
+						</a>
+					) ) }
+				</div>
+			</header>
 			<PatternPreviewActions postId={ postId } />
 			<div className="pattern-preview__container">
 				<PatternPreview blockContent={ pattern.content.rendered } />

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
@@ -41,7 +41,11 @@ export default function ( { pattern } ) {
 						</p>
 					</Notice>
 					{ showModal && (
-						<Modal title={ __( 'Review Pending', 'wporg-patterns' ) } onRequestClose={ closeModal }>
+						<Modal
+							title={ __( 'Review Pending', 'wporg-patterns' ) }
+							onRequestClose={ closeModal }
+							className="pattern__status-notice-modal"
+						>
 							<p>
 								{ __(
 									'All patterns submitted to WordPress.org are subject to both automated and manual approval. It might take a few days for your pattern to be approved.',
@@ -83,7 +87,11 @@ export default function ( { pattern } ) {
 						</p>
 					</Notice>
 					{ showModal && (
-						<Modal title={ __( 'Drafts', 'wporg-patterns' ) } onRequestClose={ closeModal }>
+						<Modal
+							title={ __( 'Drafts', 'wporg-patterns' ) }
+							onRequestClose={ closeModal }
+							className="pattern__status-notice-modal"
+						>
 							<p>
 								{ __(
 									'Patterns can be saved as a draft which can be submitted for approval at any time. This allows you to save your design and come back to it later to submit.',
@@ -119,7 +127,11 @@ export default function ( { pattern } ) {
 						</p>
 					</Notice>
 					{ showModal && (
-						<Modal title={ __( 'Declined', 'wporg-patterns' ) } onRequestClose={ closeModal }>
+						<Modal
+							title={ __( 'Declined', 'wporg-patterns' ) }
+							onRequestClose={ closeModal }
+							className="pattern__status-notice-modal"
+						>
 							<p>
 								{ __(
 									'WordPress.org has chosen to decline listing your pattern for the following reason:',

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
@@ -1,0 +1,152 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Modal, Notice } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+export default function ( { pattern } ) {
+	const [ showModal, setShowModal ] = useState( false );
+	const openModal = () => setShowModal( true );
+	const closeModal = () => setShowModal( false );
+
+	const isMyPattern = window.wporgPatternsData.userId === pattern.author;
+
+	if ( ! isMyPattern ) {
+		return null;
+	}
+
+	switch ( pattern.status ) {
+		case 'pending':
+			return (
+				<>
+					<Notice
+						className="pattern__status-notice"
+						status="warning"
+						isDismissible={ false }
+						actions={ [
+							{
+								label: __( 'Learn More', 'wporg-patterns' ),
+								onClick: openModal,
+								variant: 'secondary',
+							},
+						] }
+					>
+						<p>
+							<strong>{ __( 'Review pending.', 'wporg-patterns' ) }</strong>
+							{ __(
+								'This pattern is only visible to you. Once approved it will be published to everyone.',
+								'wporg-patterns'
+							) }
+						</p>
+					</Notice>
+					{ showModal && (
+						<Modal title={ __( 'Review Pending', 'wporg-patterns' ) } onRequestClose={ closeModal }>
+							<p>
+								{ __(
+									'All patterns submitted to WordPress.org are subject to both automated and manual approval. It might take a few days for your pattern to be approved.',
+									'wporg-patterns'
+								) }
+							</p>
+							<p>
+								{ __(
+									'Reviewers look for content that may be problematic (copyright or trademark issues) and wether your pattern works as intended.',
+									'wporg-patterns'
+								) }
+							</p>
+						</Modal>
+					) }
+				</>
+			);
+
+		case 'draft':
+			return (
+				<>
+					<Notice
+						className="pattern__status-notice"
+						status="info"
+						isDismissible={ false }
+						actions={ [
+							{
+								label: __( 'Learn More', 'wporg-patterns' ),
+								onClick: openModal,
+								variant: 'secondary',
+							},
+						] }
+					>
+						<p>
+							<strong>{ __( 'Saved as draft.', 'wporg-patterns' ) }</strong>
+							{ __(
+								'This pattern is only visible to you. When you’re ready, submit it to be published to everyone.',
+								'wporg-patterns'
+							) }
+						</p>
+					</Notice>
+					{ showModal && (
+						<Modal title={ __( 'Drafts', 'wporg-patterns' ) } onRequestClose={ closeModal }>
+							<p>
+								{ __(
+									'Patterns can be saved as a draft which can be submitted for approval at any time. This allows you to save your design and come back to it later to submit.',
+									'wporg-patterns'
+								) }
+							</p>
+						</Modal>
+					) }
+				</>
+			);
+
+		case 'declined':
+			return (
+				<>
+					<Notice
+						className="pattern__status-notice"
+						status="error"
+						isDismissible={ false }
+						actions={ [
+							{
+								label: __( 'Learn More', 'wporg-patterns' ),
+								onClick: openModal,
+								variant: 'secondary',
+							},
+						] }
+					>
+						<p>
+							<strong>{ __( 'Pattern declined.', 'wporg-patterns' ) }</strong>
+							{ __(
+								'WordPress.org has chosen not to include this pattern in the directory.',
+								'wporg-patterns'
+							) }
+						</p>
+					</Notice>
+					{ showModal && (
+						<Modal title={ __( 'Declined', 'wporg-patterns' ) } onRequestClose={ closeModal }>
+							<p>
+								{ __(
+									'WordPress.org has chosen to decline listing your pattern for the following reason:',
+									'wporg-patterns'
+								) }
+							</p>
+							<p>
+								{ __(
+									'You can update your pattern to resubmitt it for approval at any time.',
+									'wporg-patterns'
+								) }
+							</p>
+						</Modal>
+					) }
+				</>
+			);
+
+		case 'publish':
+			return (
+				<Notice className="pattern__status-notice" status="success" isDismissible={ false }>
+					<p>
+						<strong>{ __( 'Pattern published!', 'wporg-patterns' ) }</strong>
+						{ __( 'Your new design is now available to everyone.', 'wporg-patterns' ) }
+					</p>
+				</Notice>
+			);
+	}
+
+	return null;
+}

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
@@ -54,7 +54,7 @@ export default function ( { pattern } ) {
 							</p>
 							<p>
 								{ __(
-									'Reviewers look for content that may be problematic (copyright or trademark issues) and wether your pattern works as intended.',
+									'Reviewers look for content that may be problematic (copyright or trademark issues) and whether your pattern works as intended.',
 									'wporg-patterns'
 								) }
 							</p>


### PR DESCRIPTION
Fixes #36. When viewing your own patterns, they should have a notice to indicate the current status - published, pending, draft, or declined. Currently, declined is a work-in-progress, but the rest of the states work.

### Screenshots

![draft-notice](https://user-images.githubusercontent.com/541093/137529221-ae72c515-00ea-42e2-9d4a-946406b33f4c.png)

<img width="472" alt="draft-modal" src="https://user-images.githubusercontent.com/541093/137529220-fc7325f4-bcad-4520-8359-e5136a0c1b9a.png">

![pending-notice](https://user-images.githubusercontent.com/541093/137529223-c4fc1c66-9e59-42b4-a5c4-42a10a191ca0.png)

<img width="414" alt="pending-modal" src="https://user-images.githubusercontent.com/541093/137529222-9b4cc023-c3b3-42e0-9459-483a9a52a81e.png">

![published-notice](https://user-images.githubusercontent.com/541093/137529225-a03b2c0d-8b6c-4b11-80a3-aaba2f392d15.png)

### How to test the changes in this Pull Request:

1. View an existing pattern that you've authored.
2. It should have a notice indicating the status, matching the post status of the pattern.
3. Click learn more on Pending & Draft patterns to read the details.
4. View a pattern by another user, there should not be a notice.

