### PR TITLE
Add post type support for Internal Notes on patterns and flags

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -52,7 +52,7 @@ function register_post_type_data() {
 			'show_in_admin_bar'     => false,
 			'show_in_rest'          => true,
 			'rest_controller_class' => '\\WordPressdotorg\\Pattern_Directory\\REST_Flags_Controller',
-			'supports'              => array( 'author', 'excerpt' ),
+			'supports'              => array( 'author', 'excerpt', 'wporg-internal-notes' ),
 			'can_export'            => false,
 			'delete_with_user'      => false,
 		)

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -57,7 +57,7 @@ function register_post_type_data() {
 			'public'          => true,
 			'show_in_rest'    => true,
 			'rewrite'         => array( 'slug' => 'pattern' ),
-			'supports'        => array( 'title', 'editor', 'author', 'custom-fields', 'revisions' ),
+			'supports'        => array( 'title', 'editor', 'author', 'custom-fields', 'revisions', 'wporg-internal-notes' ),
 			'capability_type' => array( 'pattern', 'patterns' ),
 			'map_meta_cap'    => true,
 		)


### PR DESCRIPTION
Enables the Internal Notes sidebar in the block editor for pattern and pattern flag post types, when the Internal Notes plugin is also activated.

Refs #105 