### PR TITLE
Pattern Creation: Prevent uploads to the media library

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/package.json
+++ b/public_html/wp-content/plugins/pattern-creator/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/editor": "12.0.6",
 		"@wordpress/element": "4.0.4",
 		"@wordpress/format-library": "3.0.9",
+		"@wordpress/hooks": "3.2.2",
 		"@wordpress/i18n": "4.2.4",
 		"@wordpress/icons": "6.1.1",
 		"@wordpress/interface": "4.1.5",

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -197,3 +197,17 @@ function show_admin_bar( $show_admin_bar ) {
 }
 // Priority needs to be over 1000 to override `logged-out-admin-bar`.
 add_filter( 'show_admin_bar', __NAMESPACE__ . '\show_admin_bar', 1001 );
+
+/**
+ * Filter out `upload_files` from all non-admin users.
+ *
+ * @param bool[] $allcaps Array of key/value pairs where keys represent a capability name
+ *                        and boolean values represent whether the user has that capability.
+ */
+function disallow_uploads( $allcaps ) {
+	if ( ! isset( $allcaps['manage_options'] ) ) {
+		$allcaps['upload_files'] = false;
+	}
+	return $allcaps;
+}
+add_filter( 'user_has_cap', __NAMESPACE__ . '\disallow_uploads' );

--- a/public_html/wp-content/plugins/pattern-creator/src/api-middleware/filter-endpoints.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/api-middleware/filter-endpoints.js
@@ -5,7 +5,7 @@ export default function ( options, next ) {
 	options.path = options.path.replace( 'per_page=-1', 'per_page=50' );
 
 	// Load images with the view context, seems to work
-	if ( 0 === options.path.indexOf( '/wp/v2/media/' ) ) {
+	if ( 0 === options.path.indexOf( '/wp/v2/media' ) ) {
 		options.path = options.path.replace( 'context=edit', 'context=view' );
 	}
 

--- a/public_html/wp-content/plugins/pattern-creator/src/api-middleware/filter-endpoints.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/api-middleware/filter-endpoints.js
@@ -2,11 +2,13 @@
 // Short-circuit POST requests, bound queries, allow media, etc.
 export default function ( options, next ) {
 	// Add limits to all GET queries which attempt unbound queries
-	options.path = options.path.replace( 'per_page=-1', 'per_page=50' );
+	if ( options.path ) {
+		options.path = options.path.replace( 'per_page=-1', 'per_page=50' );
 
-	// Load images with the view context, seems to work
-	if ( 0 === options.path.indexOf( '/wp/v2/media' ) ) {
-		options.path = options.path.replace( 'context=edit', 'context=view' );
+		// Load images with the view context, seems to work
+		if ( 0 === options.path.indexOf( '/wp/v2/media' ) ) {
+			options.path = options.path.replace( 'context=edit', 'context=view' );
+		}
 	}
 
 	return next( options );

--- a/public_html/wp-content/plugins/pattern-creator/src/components/media-placeholder/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/media-placeholder/index.js
@@ -12,7 +12,7 @@ import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 
 export default function MediaPlaceholder( {
 	addToGallery,
-	allowedTypes,
+	allowedTypes = [],
 	className,
 	children,
 	disableMediaButtons,
@@ -42,8 +42,26 @@ export default function MediaPlaceholder( {
 		);
 	};
 
+	const [ firstAllowedType ] = allowedTypes;
+	const isOneType = 1 === allowedTypes.length;
+	const isAudio = isOneType && 'audio' === firstAllowedType;
+	const isImage = isOneType && 'image' === firstAllowedType;
+	const isVideo = isOneType && 'video' === firstAllowedType;
+
 	const defaultRenderPlaceholder = ( content ) => {
-		const title = labels.title || __( 'Media', 'wporg-patterns' );
+		let title = labels.title;
+		if ( title === undefined ) {
+			if ( isAudio ) {
+				title = __( 'Audio', 'wporg-patterns' );
+			} else if ( isImage ) {
+				title = __( 'Image', 'wporg-patterns' );
+			} else if ( isVideo ) {
+				title = __( 'Video', 'wporg-patterns' );
+			} else {
+				title = __( 'Media', 'wporg-patterns' );
+			}
+		}
+
 		const instructions = __(
 			"Patterns are required to use our collection of license-free media. You won't be able to upload or link to any other media in your patterns.",
 			'wporg-patterns'
@@ -81,12 +99,12 @@ export default function MediaPlaceholder( {
 			value={ Array.isArray( value ) ? value.map( ( { id } ) => id ) : value.id }
 			render={ ( { open } ) => (
 				<Button
-					variant="tertiary"
+					variant="primary"
 					onClick={ () => {
 						open();
 					} }
 				>
-					{ __( 'Pattern Media Library', 'wporg-patterns' ) }
+					{ __( 'Media Library', 'wporg-patterns' ) }
 				</Button>
 			) }
 		/>

--- a/public_html/wp-content/plugins/pattern-creator/src/components/media-placeholder/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/media-placeholder/index.js
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, Placeholder } from '@wordpress/components';
+import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+
+export default function MediaPlaceholder( {
+	addToGallery,
+	allowedTypes,
+	className,
+	children,
+	disableMediaButtons,
+	icon,
+	isAppender,
+	labels = {},
+	mediaPreview,
+	multiple = false,
+	notices,
+	onDoubleClick,
+	onSelect,
+	placeholder,
+	style,
+	value = {},
+} ) {
+	if ( disableMediaButtons ) {
+		return null;
+	}
+
+	const onlyAllowsImages = () => {
+		if ( ! allowedTypes || allowedTypes.length === 0 ) {
+			return false;
+		}
+
+		return allowedTypes.every(
+			( allowedType ) => allowedType === 'image' || allowedType.startsWith( 'image/' )
+		);
+	};
+
+	const defaultRenderPlaceholder = ( content ) => {
+		const title = labels.title || __( 'Media', 'wporg-patterns' );
+		const instructions = __(
+			"Patterns are required to use our collection of license-free media. You won't be able to upload or link to any other media in your patterns.",
+			'wporg-patterns'
+		);
+
+		const placeholderClassName = classnames( 'block-editor-media-placeholder', className, {
+			'is-appender': isAppender,
+		} );
+
+		return (
+			<Placeholder
+				icon={ icon }
+				label={ title }
+				instructions={ instructions }
+				className={ placeholderClassName }
+				notices={ notices }
+				onDoubleClick={ onDoubleClick }
+				preview={ mediaPreview }
+				style={ style }
+			>
+				{ content }
+				{ children }
+			</Placeholder>
+		);
+	};
+	const renderPlaceholder = placeholder ?? defaultRenderPlaceholder;
+
+	const mediaLibraryButton = (
+		<MediaUpload
+			addToGallery={ addToGallery }
+			gallery={ multiple && onlyAllowsImages() }
+			multiple={ multiple }
+			onSelect={ onSelect }
+			allowedTypes={ allowedTypes }
+			value={ Array.isArray( value ) ? value.map( ( { id } ) => id ) : value.id }
+			render={ ( { open } ) => (
+				<Button
+					variant="tertiary"
+					onClick={ () => {
+						open();
+					} }
+				>
+					{ __( 'Pattern Media Library', 'wporg-patterns' ) }
+				</Button>
+			) }
+		/>
+	);
+
+	const content = renderPlaceholder( mediaLibraryButton );
+	return <MediaUploadCheck fallback={ content }>{ content }</MediaUploadCheck>;
+}

--- a/public_html/wp-content/plugins/pattern-creator/src/hooks/media.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/hooks/media.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import MediaPlaceholder from '../components/media-placeholder';
+
+addFilter( 'editor.MediaPlaceholder', 'wporg/patterns/components/media-upload', () => MediaPlaceholder, 100 );

--- a/public_html/wp-content/plugins/pattern-creator/src/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/index.js
@@ -11,6 +11,7 @@ import { render, unmountComponentAtNode } from '@wordpress/element';
  * Internal dependencies
  */
 import './store';
+import './hooks/media';
 import Editor from './components/editor';
 import { filterEndpoints } from './api-middleware';
 import './style.scss';

--- a/public_html/wp-content/plugins/pattern-creator/src/store/selectors.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/selectors.js
@@ -15,7 +15,6 @@ import {
 	getDefaultBlockName,
 	getFreeformContentHandlerName,
 } from '@wordpress/blocks';
-// import { uploadMedia } from '@wordpress/media-utils';
 
 /**
  * Internal dependencies
@@ -56,17 +55,6 @@ export function getPreviewDeviceType( state ) {
 }
 
 /**
- * Returns whether the current user can create media or not.
- *
- * @param {Object} state Global application state.
- *
- * @return {Object} Whether the current user can create media or not.
- */
-export const getCanUserCreateMedia = createRegistrySelector( ( select ) => () =>
-	select( coreStore ).canUser( 'create', 'media' )
-);
-
-/**
  * Returns the settings, taking into account active features and permissions.
  *
  * @param {Object}   state             Global application state.
@@ -84,16 +72,9 @@ export const getSettings = createSelector(
 			__experimentalSetIsInserterOpened: setIsInserterOpen,
 		};
 
-		const canUserCreateMedia = getCanUserCreateMedia( state );
-		if ( ! canUserCreateMedia ) {
-			return settings;
-		}
-
-		settings.mediaUpload = () => {};
 		return settings;
 	},
 	( state ) => [
-		getCanUserCreateMedia( state ),
 		state.settings,
 		isFeatureActive( state, 'focusMode' ),
 		isFeatureActive( state, 'fixedToolbar' ),

--- a/public_html/wp-content/plugins/pattern-creator/src/store/test/selectors.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/test/selectors.js
@@ -82,7 +82,6 @@ describe( 'selectors', () => {
 				focusMode: true,
 				hasFixedToolbar: true,
 				__experimentalSetIsInserterOpened: setInserterOpened,
-				mediaUpload: expect.any( Function ),
 			} );
 		} );
 	} );

--- a/public_html/wp-content/plugins/pattern-creator/src/store/test/selectors.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/test/selectors.js
@@ -1,24 +1,10 @@
 /**
- * WordPress dependencies
- */
-import { store as coreDataStore } from '@wordpress/core-data';
-
-/**
  * Internal dependencies
  */
-import {
-	getCanUserCreateMedia,
-	getSettings,
-	isFeatureActive,
-	isInserterOpened,
-	isListViewOpened,
-} from '../selectors';
+import { getSettings, isFeatureActive, isInserterOpened, isListViewOpened } from '../selectors';
 
 describe( 'selectors', () => {
 	const canUser = jest.fn( () => true );
-	getCanUserCreateMedia.registry = {
-		select: jest.fn( () => ( { canUser } ) ),
-	};
 
 	describe( 'isFeatureActive', () => {
 		it( 'is tolerant to an undefined features preference', () => {
@@ -62,14 +48,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( isFeatureActive( state, 'chicken' ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'getCanUserCreateMedia', () => {
-		it( "selects `canUser( 'create', 'media' )` from the core store", () => {
-			expect( getCanUserCreateMedia() ).toBe( true );
-			expect( getCanUserCreateMedia.registry.select ).toHaveBeenCalledWith( coreDataStore );
-			expect( canUser ).toHaveBeenCalledWith( 'create', 'media' );
 		} );
 	} );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3695,7 +3695,7 @@
     "@wordpress/url" "^3.3.1"
     lodash "^4.17.21"
 
-"@wordpress/hooks@^3.2.2":
+"@wordpress/hooks@3.2.2", "@wordpress/hooks@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-3.2.2.tgz#15062a10ca729569d02db8d45fc349b85ad1757e"
   integrity sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==


### PR DESCRIPTION
Fixes #37 — ~There are over 100 images uploaded to the Pattern Directory, these have been verified CC0 and can be used in patterns. This PR removes the ability for users to upload to the site, but leaves the ability to open the media library to insert already-uploaded images.~

This PR is laying the groundwork for #375. It disables uploads for non-admins, and sets up a button to open the media modal. In #375, this will be used to open our Openverse modal.

⚠️  This only applies to non-admins, admin & superadmin users can still upload media so that we can manage the media library, in case it's necessary.

❓ Specifically requesting reviews because I'm touching capabilities, if there's a better way to achieve this let me know.

### Screenshots

When media blocks are inserted, they now just have "Pattern Media Library" as an option, for example the Gallery block:

<img width="911" alt="custom-gallery" src="https://user-images.githubusercontent.com/541093/139312800-383f318f-7a13-422d-8411-3134079312a4.png">

Media & Text:

<img width="869" alt="Screen Shot 2021-10-28 at 2 20 41 PM" src="https://user-images.githubusercontent.com/541093/139313074-417097bd-4250-4ce9-afc7-5639d3d8bdd1.png">

In the Media & Text block, only "Open Media Library" is available to replace the image.

<img width="661" alt="custom-replace-flow" src="https://user-images.githubusercontent.com/541093/139312802-6e0b1512-f6b8-4f05-b95a-bb85f2d9fa56.png">

The Media Library itself still has the "Upload files" tab, but if you try to upload you get a permissions error:

<img width="297" alt="Screen Shot 2021-10-28 at 2 21 51 PM" src="https://user-images.githubusercontent.com/541093/139313314-c9d12112-e4fb-4b1c-92c2-4d6e5300a2ca.png">

### How to test the changes in this Pull Request:

1. Try as various user levels (still need to be a user on the site to create patterns)
2. Create a new pattern or edit an existing one
3. Add any media block: Image, Gallery, Video, etc
4. You should **not** be able to insert via URL
5. You should **not** be able to upload your own file
6. You **should** be able to insert existing media files into the pattern
7. Play around with the pattern & blocks more - saving, editing, etc should all still work