### PR TITLE
Pattern Creator: Save patterns as pending or published, depending on a setting

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/includes/admin.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/admin.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Creator\Admin;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'admin_menu', __NAMESPACE__ . '\admin_menu' );
+add_action( 'admin_init', __NAMESPACE__ . '\admin_init' );
+
+const PAGE_SLUG = 'wporg-pattern-creator';
+const SECTION_NAME = 'wporg-pattern-settings';
+
+/**
+ * Registers a new settings page under Settings.
+ */
+function admin_menu() {
+	add_options_page(
+		__( 'Block Patterns', 'wporg-patterns' ),
+		__( 'Block Patterns', 'wporg-patterns' ),
+		'manage_options',
+		PAGE_SLUG,
+		__NAMESPACE__ . '\render_page'
+	);
+
+}
+
+/**
+ * Registers a new settings page under Settings.
+ */
+function admin_init() {
+	add_settings_section(
+		SECTION_NAME,
+		esc_html__( 'Editor Settings', 'wporg-patterns' ),
+		'__return_empty_string',
+		PAGE_SLUG
+	);
+
+	register_setting(
+		SECTION_NAME,
+		'wporg-pattern-default_status',
+		array(
+			'type' => 'string',
+			'sanitize_callback' => function( $value ) {
+				return in_array( $value, array( 'publish', 'pending' ) ) ? $value : 'publish';
+			},
+			'default' => 'publish',
+		)
+	);
+	add_settings_field(
+		'wporg-pattern-default_status',
+		esc_html__( 'Default status of new patterns', 'wporg-patterns' ),
+		__NAMESPACE__ . '\render_status_field',
+		PAGE_SLUG,
+		SECTION_NAME,
+		array(
+			'label_for' => 'wporg-pattern-default_status',
+		)
+	);
+}
+
+/**
+ * Render a checkbox.
+ */
+function render_status_field() {
+	$current = get_option( 'wporg-pattern-default_status' );
+	$statii = array(
+		'publish' => esc_html__( 'Published', 'wporg-patterns' ),
+		'pending' => esc_html__( 'Pending', 'wporg-patterns' ),
+	);
+
+	echo '<select name="wporg-pattern-default_status" id="wporg-pattern-default_status" aria-describedby="wporg-pattern-default_status-help">';
+	foreach ( $statii as $value => $label ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		printf( '<option value="%s" %s>%s</option>', $value, selected( $value, $current ), $label );
+	}
+	echo '</select>';
+	printf( '<p id="wporg-pattern-default_status-help">%s</p>', esc_html__( 'Use this setting to control whether new patterns need moderation before showing up (pending) or not (published).', 'wporg-patterns' ) );
+}
+
+/**
+ * Display the Block Patterns settings page.
+ */
+function render_page() {
+	require_once dirname( __DIR__ ) . '/view/settings.php';
+}

--- a/public_html/wp-content/plugins/pattern-creator/package.json
+++ b/public_html/wp-content/plugins/pattern-creator/package.json
@@ -41,6 +41,7 @@
 		"@wordpress/interface": "4.1.5",
 		"@wordpress/keyboard-shortcuts": "3.0.6",
 		"@wordpress/keycodes": "3.2.4",
+		"@wordpress/notices": "3.2.7",
 		"@wordpress/plugins": "4.0.6",
 		"@wordpress/primitives": "3.0.4",
 		"@wordpress/url": "3.3.1",

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -18,6 +18,8 @@ const AUTOSAVE_INTERVAL = 30;
 const IS_EDIT_VAR = 'edit-pattern';
 const PATTERN_ID_VAR = 'pattern-id';
 
+require_once __DIR__ . '/includes/admin.php';
+
 /**
  * Check the conditions of the page to determine if the editor should load.
  * - It should be a single pattern page.

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -91,7 +91,6 @@ function pattern_creator_init() {
 		sprintf(
 			'var wporgBlockPattern = JSON.parse( decodeURIComponent( \'%s\' ) );',
 			rawurlencode( wp_json_encode( array(
-				'defaultStatus' => 'publish',
 				'siteUrl'       => esc_url( home_url() ),
 			) ) )
 		),
@@ -126,6 +125,8 @@ function pattern_creator_init() {
 	);
 	$editor_context = new WP_Block_Editor_Context( array( 'post' => $post ) );
 	$settings       = gutenberg_get_block_editor_settings( $custom_settings, $editor_context );
+
+	$settings['defaultStatus'] = get_option( 'wporg-pattern-default_status', 'publish' );
 
 	gutenberg_initialize_editor(
 		'block-pattern-creator',

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -91,7 +91,8 @@ function pattern_creator_init() {
 		sprintf(
 			'var wporgBlockPattern = JSON.parse( decodeURIComponent( \'%s\' ) );',
 			rawurlencode( wp_json_encode( array(
-				'siteUrl'    => esc_url( home_url() ),
+				'defaultStatus' => 'publish',
+				'siteUrl'       => esc_url( home_url() ),
 			) ) )
 		),
 		'before'

--- a/public_html/wp-content/plugins/pattern-creator/src/components/save-button/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/save-button/index.js
@@ -30,17 +30,17 @@ export function SaveButton() {
 		isSaveable,
 		isPublished,
 		isPublishedOrPending,
-		notices,
 		publishStatus,
 	} = useSelect( ( select ) => {
 		const { __experimentalGetDirtyEntityRecords } = select( coreStore );
 		const { isAutosavingPost, isSavingPost, getCurrentPost, getCurrentPostId } = select( editorStore );
-		const { isPatternSaveable } = select( patternStore );
+		const { isPatternSaveable, getSettings } = select( patternStore );
 
 		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
 		const _isAutoSaving = isAutosavingPost();
 		const _post = getCurrentPost();
 		const hasPublishAction = get( _post, [ '_links', 'wp:action-publish' ], false );
+		const settings = getSettings();
 		return {
 			currentStatus: _post.status,
 			isDirty: dirtyEntityRecords.length > 0,
@@ -49,7 +49,7 @@ export function SaveButton() {
 			isSaveable: isPatternSaveable( getCurrentPostId() ),
 			isPublished: 'publish' === _post.status,
 			isPublishedOrPending: [ 'pending', 'publish' ].includes( _post.status ),
-			publishStatus: hasPublishAction ? wporgBlockPattern.defaultStatus : 'pending',
+			publishStatus: hasPublishAction ? settings.defaultStatus : 'pending',
 		};
 	} );
 	const { editPost, savePost } = useDispatch( editorStore );

--- a/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/index.js
@@ -18,7 +18,7 @@ const ForwardButton = ( { children, disabled, onClick } ) => (
 
 const getStatusMessage = ( status ) => {
 	switch ( status ) {
-		case 'published':
+		case 'publish':
 			return __(
 				'Your pattern is published. Your new design is now available to everyone.',
 				'wporg-patterns'

--- a/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/style.scss
@@ -38,23 +38,6 @@ $modal-height: 375px;
 	.components-modal__content::before {
 		margin-bottom: 0;
 	}
-
-	&.is-published {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		height: 350px;
-
-		background-image: url(./components/submission-modal/images/triangle.svg), url(./components/submission-modal/images/circle.svg), url(./components/submission-modal/images/square.svg);
-		background-repeat: no-repeat, no-repeat, no-repeat;
-		background-position: left -30% bottom -60%, left 45% bottom -110%, right -30% bottom -110%;
-		background-size: 250px;
-
-		> div {
-			margin-bottom: $grid-unit-20;
-			height: initial;
-		}
-	}
 }
 
 .submission-modal__page {
@@ -69,24 +52,6 @@ $modal-height: 375px;
 		padding: 0;
 		border: 0;
 	}
-
-	.is-published & {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		padding: $grid-unit-20;
-		color: $white;
-		width: 60%;
-
-		.submission-modal__content {
-			width: 100%;
-			padding: 0;
-			flex-direction: row;
-			flex-wrap: wrap;
-			background: transparent;
-		}
-	}
 }
 
 .submission-modal__sidebar {
@@ -99,13 +64,15 @@ $modal-height: 375px;
 
 .submission-modal__title {
 	margin: 0;
-	color: #fff;
 	font-size: 1.5rem;
 	line-height: normal;
 }
 
 .submission-modal__title-sidebar {
 	margin: $grid-unit-10 0 0 0;
+	color: $white;
+	font-size: 1.5rem;
+	line-height: normal;
 	text-align: right;
 }
 
@@ -115,10 +82,6 @@ $modal-height: 375px;
 	justify-content: space-between;
 	background: $white;
 	padding: $grid-unit-20 $grid-unit-40 $grid-unit-40;
-}
-
-.submission-modal__copy {
-	font-size: 0.875rem;
 }
 
 .submission-modal__link {

--- a/public_html/wp-content/plugins/pattern-creator/view/settings.php
+++ b/public_html/wp-content/plugins/pattern-creator/view/settings.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Pattern Creator settings.
+ */
+
+namespace WordPressdotorg\Pattern_Creator\View\Settings;
+use const WordPressdotorg\Pattern_Creator\Admin\{SECTION_NAME,PAGE_SLUG};
+
+?>
+
+<div class="wrap">
+	<h1><?php esc_html_e( 'Block Pattern Settings', 'wporg-patterns' ); ?></h1>
+	<form method="POST" action="options.php">
+	<?php
+		do_settings_sections( PAGE_SLUG );
+		settings_fields( SECTION_NAME );
+		submit_button();
+	?>
+	</form>
+</div>


### PR DESCRIPTION
When saving new patterns, they default to a "publish" status, so they are immediately viewable on the pattern directory (assuming they pass automated validation). This PR adds a setting UI to switch that default to "pending", which will let admins temporarily pause pattern submissions for moderation if necessary. This also fixes the issue where pattern validation errors are hidden behind the submission modal, now the error is visible in the modal itself.

Fixes #370, fixes #367.

### Screenshots

Admin UI to control the setting

![Screen Shot 2021-11-09 at 16 46 30](https://user-images.githubusercontent.com/541093/141010303-0f6530cd-cccb-497f-b557-938e3dd846f5.png)

Successful pattern submission to publish
<img width="640" alt="success-publish" src="https://user-images.githubusercontent.com/541093/141010323-0bcb1522-bd49-4d6d-a69a-bcb45a1921ca.png">

Successful pattern submission to pending
<img width="645" alt="success-pending" src="https://user-images.githubusercontent.com/541093/141010392-fbc1c45e-a55d-4c18-82c1-d144ca48f140.png">

Validation failure in pattern
<img width="984" alt="invalid-pattern" src="https://user-images.githubusercontent.com/541093/141010434-f12a50a1-74b0-42e2-8d5b-e3bb8b17bee9.png">

### How to test the changes in this Pull Request:

1. Go into the admin UI and set a default status
2. Create a pattern on `/new-pattern`, submit it
3. It should submit to the status you selected
4. Create a pattern with invalid content, submit it
5. It should fail to save, showing you the error in the modal
