### PR TITLE
Theme: Show unlisted reason on your patterns

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -233,9 +233,7 @@ function register_post_type_data() {
 			'type'              => 'string',
 			'description'       => 'The ID of a flag reason, used to indicate why a pattern was unlisted.',
 			'single'            => true,
-			'sanitize_callback' => function( $value, $key, $type ) {
-				return preg_replace( '/[^0-9]/', '', $value );
-			},
+			'sanitize_callback' => 'sanitize_text_field',
 			'auth_callback'     => __NAMESPACE__ . '\can_edit_this_pattern',
 			'show_in_rest'      => array(
 				'schema' => array(

--- a/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/utils.js
+++ b/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/utils.js
@@ -22,7 +22,7 @@ export const getUnlistedReasons = ( { onSuccess = noop, onFailure = noop } ) => 
 							return 0;
 					}
 				} )
-				.map( ( i ) => ( { label: i.name, value: i.id.toString() } ) );
+				.map( ( i ) => ( { label: i.name, value: i.slug } ) );
 			onSuccess( reasonList );
 		} )
 		.catch( onFailure );

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
@@ -5,6 +5,26 @@ import { __ } from '@wordpress/i18n';
 import { Modal, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
+function getUnlistedReason( pattern ) {
+	const reasonSlug = pattern.meta.wpop_unlisted_reason || '';
+	switch ( reasonSlug ) {
+		case '1-inappropriate':
+			return __(
+				'This pattern contains content deemed inappropriate for a general audience.',
+				'wporg-patterns'
+			);
+		case '2-copyright':
+			return __(
+				'This pattern contains copyrighted material or uses a trademark without permission.',
+				'wporg-patterns'
+			);
+		case '3-broken':
+			return __( 'This pattern is broken or does not display correctly.', 'wporg-patterns' );
+		default:
+			return __( 'Additional review has been requested for this pattern.', 'wporg-patterns' );
+	}
+}
+
 export default function ( { pattern } ) {
 	const [ showModal, setShowModal ] = useState( false );
 	const openModal = () => setShowModal( true );
@@ -128,9 +148,12 @@ export default function ( { pattern } ) {
 						>
 							<p>
 								{ __(
-									'WordPress.org has chosen to decline listing your pattern for the following reason:',
+									'WordPress.org has removed your pattern from the directory for the following reason:',
 									'wporg-patterns'
 								) }
+							</p>
+							<p>
+								<em>{ getUnlistedReason( pattern ) }</em>
 							</p>
 							<p>
 								{ __(


### PR DESCRIPTION
Fixes #371 — Explain why the pattern has been unlisted in the "Learn more" modal.

### Screenshots

<img width="397" alt="Screen Shot 2021-11-19 at 1 47 07 PM" src="https://user-images.githubusercontent.com/541093/142675433-7cd07368-c9fd-40dd-ae2f-e29b5b22e650.png">
<img width="393" alt="Screen Shot 2021-11-19 at 1 47 16 PM" src="https://user-images.githubusercontent.com/541093/142675435-d1343acc-f759-491d-91c2-75e0064cb1da.png">

### How to test the changes in this Pull Request:

1. Open at pattern in the wp-admin editor and unlist it, select one of the radio reasons.
2. Make sure you're logged in as the author of that pattern, then view it on the frontend.
3. It should have a red banner, click the Learn more button
4. The modal should pop up and explain the reason you chose.
