### PR TITLE
Openverse: Add endpoint to proxy search requests with authentication

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -123,7 +123,7 @@ class Openverse_Client {
 		if ( 200 !== $response_code ) {
 			return new WP_Error(
 				'invalid-ov-token-request',
-				sprintf( __( 'The token generation request failed with a %s error.', 'wporg-patterns' ), $response_code )
+				sprintf( 'The token generation request failed with a %s error.', $response_code )
 			);
 		}
 

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -137,9 +137,10 @@ class Openverse_Client {
 			return new WP_Error( 'invalid-ov-token-response', __( 'The token generation response is malformed.', 'wporg-patterns' ) );
 		}
 
-		// Invalidate the token 5 minutes early, just in case.
-		$token['expires_at'] = time() + $token['expires_in'] - 5 * MINUTE_IN_SECONDS;
+		// Invalidate the token a minute early, ensures that any requests around the "expiry" succeed as long as the request is made within a minute of the token validation being run.
+		$token['expires_at'] = time() + $token['expires_in'] - MINUTE_IN_SECONDS;
 		update_option( self::TOKEN_OPTION_KEY, $token );
+		delete_option( self::TOKEN_OPTION_KEY . '_refresh' );
 
 		return $token['access_token'];
 	}

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -76,7 +76,7 @@ class Openverse_Client {
 		if ( time() >= $token['expires_at'] ) {
 			return false;
 		}
-		return true;
+		return time() - $token['expires_at'];
 	}
 
 	/**

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Class Openverse_Client
+ *
+ * @package WordPressdotorg\Pattern_Creator
+ */
+class Openverse_Client {
+	/**
+	 * @var string The option key where the cache is saved in the database.
+	 */
+	const CACHE_KEY = 'openverse_search';
+
+	/**
+	 * @var string The option key where the cache is saved in the database.
+	 */
+	const TOKEN_OPTION_KEY = 'ov-oauth-token';
+
+	/**
+	 * @var array<string, string> The set of parameters for this request.
+	 */
+	protected $params = array();
+
+	/**
+	 * @var string The base URL for requests.
+	 */
+	protected $url = 'https://api.openverse.engineering';
+
+	/**
+	 * Openverse_Client constructor.
+	 */
+	public function __construct( array $params = [] ) {
+		$defaults = array(
+			'per_page' => 30,
+			'page' => 1,
+		);
+
+		$this->params = wp_parse_args( $params, $defaults );
+	}
+
+	/**
+	 * Get the parameters for this request.
+	 *
+	 * @return array
+	 */
+	public function get_params() {
+		return $this->params;
+	}
+
+	/**
+	 * Get the parameters for this request.
+	 *
+	 * @param string $key     Which parameter to return.
+	 * @param mixed  $default The default value, if not found in the set params.
+	 * @return array
+	 */
+	public function get_param( $key, $default = null ) {
+		if ( isset( $this->params[ $key ] ) ) {
+			return $this->params[ $key ];
+		}
+		return $default;
+	}
+
+	/**
+	 * Check if token exists and has not expired.
+	 *
+	 * @param array $token Token object.
+	 * @return bool
+	 */
+	public function is_valid_token( $token ) {
+		if ( ! isset( $token['access_token'] ) || ! $token['access_token'] ) {
+			return false;
+		}
+		if ( ! isset( $token['expires_at'] ) ) {
+			return false;
+		}
+		if ( time() >= $token['expires_at'] ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Get (or generate) a valid oauth token.
+	 *
+	 * @return string|WP_Error A valid token or WP_Error if there was an error.
+	 */
+	public function get_oauth_token() {
+		$token = get_option( self::TOKEN_OPTION_KEY, array() );
+		if ( $this->is_valid_token( $token ) ) {
+			return $token['access_token'];
+		}
+
+		$response = wp_remote_post( $this->url . '/v1/auth_tokens/token/', array(
+			'body' => array(
+				'client_id' => PATTERN_OV_OAUTH_ID,
+				'client_secret' => PATTERN_OV_OAUTH_SECRET,
+				'grant_type' => 'client_credentials',
+			),
+		) );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $response_code ) {
+			return new WP_Error(
+				'invalid-ov-token-request',
+				sprintf( __( 'The token generation request failed with a %s error.', 'wporg-patterns' ), $response_code )
+			);
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$token = json_decode( $body, true ); // Second param returns decoded value as assoc array.
+		if ( null === $token ) {
+			return new WP_Error( 'invalid-ov-token-response', __( 'The token generation response is malformed.', 'wporg-patterns' ) );
+		}
+
+		// Invalidate the token 5 minutes early, just in case.
+		$token['expires_at'] = time() + $token['expires_in'] - 5 * MINUTE_IN_SECONDS;
+		update_option( self::TOKEN_OPTION_KEY, $token );
+
+		return $token['access_token'];
+	}
+
+	/**
+	 * Get the results from the Openverse API.
+	 *
+	 * @return WP_Error|array
+	 */
+	public function fetch_results() {
+		$auth_token = $this->get_oauth_token();
+		if ( is_wp_error( $auth_token ) ) {
+			return $auth_token;
+		}
+
+		$url = add_query_arg(
+			array(
+				'format' => 'json',
+				'license' => 'cc0',
+				'q' => $this->get_param( 'search' ),
+				'page' => $this->get_param( 'page' ),
+				'page_size' => $this->get_param( 'per_page' ),
+			),
+			$this->url . '/v1/images',
+		);
+		$response = wp_remote_get(
+			$url,
+			array(
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $auth_token,
+				),
+			)
+		);
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $response_code ) {
+			return new WP_Error(
+				'invalid-openverse-request',
+				sprintf( __( 'The Openverse API request failed with a %s error.', 'wporg-patterns' ), $response_code )
+			);
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$data = json_decode( $body );
+		if ( null === $data ) {
+			return new WP_Error( 'invalid-openverse-response', __( 'The Openverse API response is malformed.', 'wporg-patterns' ) );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Return the list of search results, possibly from a local cache.
+	 *
+	 * @return WP_Error|array
+	 */
+	public function search() {
+		if ( ! $this->get_param( 'search' ) ) {
+			return new WP_Error( 'invalid-empty-search', __( 'Search term cannot be empty.', 'wporg-patterns' ) );
+		}
+
+		$cache_key = self::CACHE_KEY . md5( wp_json_encode( $this->get_params() ) );
+		$ttl = HOUR_IN_SECONDS;
+
+		$results = get_transient( $cache_key );
+		if ( false === $results ) {
+			$results = $this->fetch_results();
+			if ( is_wp_error( $results ) ) {
+				return $results;
+			}
+			set_transient( $cache_key, $results, $ttl );
+		}
+
+		return $results;
+	}
+}

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -64,7 +64,7 @@ class Openverse_Client {
 	 * Check if token exists and has not expired.
 	 *
 	 * @param array $token Token object.
-	 * @return bool
+	 * @return bool|int False upon failure, seconds remaining for token on success.
 	 */
 	public function is_valid_token( $token ) {
 		if ( ! isset( $token['access_token'] ) || ! $token['access_token'] ) {

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -8,7 +8,7 @@ class Openverse_Client {
 	/**
 	 * @var string The option key where the cache is saved in the database.
 	 */
-	const CACHE_KEY = 'openverse_search';
+	const CACHE_KEY = 'ov-request';
 
 	/**
 	 * @var string The option key where the cache is saved in the database.

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -193,7 +193,7 @@ class Openverse_Client {
 
 		$data = json_decode( $body );
 		if ( null === $data ) {
-			return new WP_Error( 'invalid-openverse-response', __( 'The Openverse API response is malformed.', 'wporg-patterns' ) );
+			return new WP_Error( 'invalid-openverse-response', 'The Openverse API response is malformed.' );
 		}
 
 		return $data;

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -169,6 +169,7 @@ class Openverse_Client {
 		$response = wp_remote_get(
 			$url,
 			array(
+				'timeout' => 15,
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $auth_token,
 				),

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -134,7 +134,7 @@ class Openverse_Client {
 
 		$token = json_decode( $body, true ); // Second param returns decoded value as assoc array.
 		if ( null === $token ) {
-			return new WP_Error( 'invalid-ov-token-response', __( 'The token generation response is malformed.', 'wporg-patterns' ) );
+			return new WP_Error( 'invalid-ov-token-response', 'The token generation response is malformed.' );
 		}
 
 		// Invalidate the token a minute early, ensures that any requests around the "expiry" succeed as long as the request is made within a minute of the token validation being run.

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -90,7 +90,7 @@ class Openverse_Client {
 		if ( $token_life >= 5 * MINUTE_IN_SECONDS ) {
 			return $token['access_token'];
 		}
-		
+
 		$being_refreshed = get_option( self::TOKEN_OPTION_KEY . '_refresh' );
 		if ( $being_refreshed > time() - MINUTE_IN_SECONDS ) {
 			// Return stale token if possible.
@@ -183,7 +183,7 @@ class Openverse_Client {
 		if ( 200 !== $response_code ) {
 			return new WP_Error(
 				'invalid-openverse-request',
-				sprintf(  'The Openverse API request failed with a %s error.', $response_code )
+				sprintf( 'The Openverse API request failed with a %s error.', $response_code )
 			);
 		}
 
@@ -221,13 +221,13 @@ class Openverse_Client {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					return $results;
 				}
-			
+
 				// Log the error
-				trigger_error( $results->get_error_code(), E_USER_WARNING );
+				trigger_error( $results->get_error_code(), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 				// Set a short timeout to avoid hammering the API during outages.
 				set_transient( $cache_key, [], 0.5 * MINUTE_IN_SECONDS );
-		
+
 				return new WP_Error(
 					'search-request-failed',
 					__( 'The search API provider is currently experiencing an error. Try again in a few seconds', 'wporg-patterns' ) // Publicly facing human-readable error.

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-client.php
@@ -182,7 +182,7 @@ class Openverse_Client {
 		if ( 200 !== $response_code ) {
 			return new WP_Error(
 				'invalid-openverse-request',
-				sprintf( __( 'The Openverse API request failed with a %s error.', 'wporg-patterns' ), $response_code )
+				sprintf(  'The Openverse API request failed with a %s error.', $response_code )
 			);
 		}
 

--- a/public_html/wp-content/plugins/pattern-creator/includes/openverse-rest-controller.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/openverse-rest-controller.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Class Openverse_REST_Controller
+ *
+ * This serves as a proxy layer to authenticate and cache the Openverse API requests.
+ *
+ * @package WordPressdotorg\Pattern_Creator
+ */
+class Openverse_REST_Controller extends WP_REST_Controller {
+	/**
+	 * @var string The namespace of this controller's route.
+	 */
+	protected $namespace = 'wporg/v1';
+
+	/**
+	 * @var string The base of this controller's route.
+	 */
+	protected $rest_base = 'openverse';
+
+	/**
+	 * Register the search route for Openverse.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/search',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Return the list of search results, possibly from a local cache.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$ov_client = new Openverse_Client( $request->get_params() );
+		$results = $ov_client->search();
+
+		if ( is_wp_error( $results ) ) {
+			return $results;
+		}
+
+		$data = array();
+		foreach ( $results->results as $item ) {
+			$itemdata = $this->prepare_item_for_response( $item, $request );
+			$data[] = $this->prepare_response_for_collection( $itemdata );
+		}
+
+		$response = rest_ensure_response( $data );
+		$response->header( 'X-WP-Total', (int) $results->result_count );
+		$response->header( 'X-WP-TotalPages', (int) $results->page_count );
+
+		return $response;
+	}
+
+	/**
+	 * All logged-in users can make openverse requests.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|bool
+	 */
+	public function get_items_permissions_check( $request ) {
+		return current_user_can( 'read' );
+	}
+
+	/**
+	 * Prepare the item for the REST response, strip out unused fields.
+	 *
+	 * @param mixed           $item Object as returned from the Openverse API.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		return array(
+			'title' => sanitize_text_field( $item->title ),
+			'url' => esc_url( $item->url ),
+			'thumbnail' => esc_url( $item->thumbnail ),
+		);
+	}
+
+	/**
+	 * Get the query params for collections
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		return array(
+			'page'     => array(
+				'description'       => 'Current page of the collection.',
+				'type'              => 'integer',
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
+			),
+			'per_page' => array(
+				'description'       => 'Maximum number of items to be returned in result set.',
+				'type'              => 'integer',
+				'default'           => 30,
+				'sanitize_callback' => 'absint',
+			),
+			'search'   => array(
+				'description'       => 'Limit results to those matching a string.',
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+		);
+	}
+}

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -217,3 +217,14 @@ function disallow_uploads( $allcaps ) {
 	return $allcaps;
 }
 add_filter( 'user_has_cap', __NAMESPACE__ . '\disallow_uploads' );
+
+/**
+ * Set up any custom endpoints.
+ */
+function rest_api_init() {
+	require_once __DIR__ . '/includes/openverse-client.php';
+	require_once __DIR__ . '/includes/openverse-rest-controller.php';
+	$controller = new \Openverse_REST_Controller();
+	$controller->register_routes();
+}
+add_action( 'rest_api_init', __NAMESPACE__ . '\rest_api_init' );


### PR DESCRIPTION
See #375 — This PR adds an API endpoint to proxy the Openverse requests through WP, so that we can add authentication & some light caching. The OV API uses OAuth to bypass rate limiting, so we need to be able to generate and use an oauth token when making requests. Additionally, the requests are cached for an hour, to prevent excessive use of the OV API & make things a little faster for folks making repeated searches.

This will need two new secrets for the consumer ID & secret.

### How to test the changes in this Pull Request:

I use [Insomnia](https://insomnia.rest/) to test API changes, but you can also request via curl.

Get the secrets, search for "Pattern Directory Openverse Oauth2". Set these in a new file `mu-plugins/1-sandbox.php` (since 0-sandbox is tracked in git).

```php
<?php

define( 'PATTERN_OV_OAUTH_ID', '…' );
define( 'PATTERN_OV_OAUTH_SECRET', '…' );
```

1. Set up an application password for your user to use with Basic Auth
2. Create a GET request to `http://localhost:8888/wp-json/wporg/v1/openverse/search`, with the parameter `search` & any value you want to search for
3. It should succeed. The response is an array of `{ title, url, thumbnail }`, and you should see two headers `X-WP-Total`, `X-WP-TotalPages`.
4. You can check that it created an auth token by running `yarn wp-env run cli "wp option get ov-oauth-token"`
5. Run the request again and it should return faster (locally cached now)
6. Try different requests, edge cases, etc

Here's a command for curl, you'll just want to add your auth info (or change `get_items_permissions_check`):

```bash
curl --request GET \
  --url 'http://localhost:8888/wp-json/wporg/v1/openverse/search?search=Blue%20Sky' \
  --header 'Authorization: Basic [user:app password]'
```

