### PR TITLE
Fix handling of 'locale' query variable to avoid PHP notices/warnings.

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -537,7 +537,7 @@ function filter_patterns_rest_query( $args, $request ) {
 	// Prioritise results in the requested locale.
 	// Does not limit to only the requested locale, so as to provide results when no translations
 	// exist for the locale, or we do not recognise the locale.
-	if ( $locale ) {
+	if ( $locale && is_string( $locale ) ) {
 		$args['meta_query']['orderby_locale'] = array(
 			'key'     => 'wpop_locale',
 			'compare' => 'IN',

--- a/public_html/wp-content/plugins/pattern-directory/includes/search.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/search.php
@@ -64,7 +64,12 @@ function should_handle_query( $handle_query, $query ) {
  */
 function modify_es_query_args( $es_query_args, $wp_query ) {
 	$user_query = $wp_query->get( 's' );
-	$locales    = array_unique( $wp_query->get( 'meta_query' )['orderby_locale']['value'] );
+	$meta_query = $wp_query->get( 'meta_query' );
+	$locales    = [ 'en_US' ];
+
+	if ( ! empty( $meta_query['orderby_locale']['value'] ) ) {
+		$locales = array_unique( $meta_query['orderby_locale']['value'] );
+	}
 
 	jetpack_require_lib( 'jetpack-wpes-query-builder/jetpack-wpes-query-parser' );
 


### PR DESCRIPTION
Currently passing an array of locales is accepted and throws notices, but likewise, if a locale is not set, the ES args are set to an invalid state causing a 400 response from ES.
