### PR TITLE
Patterns: Edit pattern link should go to English pattern on main site

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -9,7 +9,6 @@ use function WordPressdotorg\Pattern_Directory\Favorite\get_favorite_count;
 const POST_TYPE = 'wporg-pattern';
 
 add_action( 'init', __NAMESPACE__ . '\register_post_type_data' );
-add_filter( 'rest_' . POST_TYPE . '_item_schema', __NAMESPACE__ . '\update_schema' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_fields' );
 add_action( 'init', __NAMESPACE__ . '\register_post_statuses' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_assets' );
@@ -246,23 +245,6 @@ function register_post_type_data() {
 }
 
 /**
- * Add the "parent" to the pattern endpoint.
- *
- * This takes advantage of page behavior in `WP_REST_Posts_Controller`, which will output the parent ID if the
- * schema contains the parent property. It also checks that the ID referenced is a valid post.
- *
- * @param array $schema Item schema data.
- */
-function update_schema( $schema ) {
-	$schema['properties']['parent'] = array(
-		'description' => __( 'The ID for the original English pattern.', 'wporg-patterns' ),
-		'type'        => 'integer',
-		'context'     => array( 'view', 'edit' ),
-	);
-	return $schema;
-}
-
-/**
  * Adds extra fields to REST API responses.
  */
 function register_rest_fields() {
@@ -384,6 +366,21 @@ function register_rest_fields() {
 						'type'  => 'string',
 					),
 				),
+			),
+		)
+	);
+
+	// Add the parent pattern (English original) to the endpoint.
+	// We only need to set the schema. `WP_REST_Posts_Controller` will output the parent ID if the
+	// schema contains the parent property. It also checks that the ID referenced is a valid post.
+	register_rest_field(
+		POST_TYPE,
+		'parent',
+		array(
+			'schema' => array(
+				'description' => __( 'The ID for the original English pattern.', 'wporg-patterns' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
 			),
 		)
 	);

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -9,6 +9,7 @@ use function WordPressdotorg\Pattern_Directory\Favorite\get_favorite_count;
 const POST_TYPE = 'wporg-pattern';
 
 add_action( 'init', __NAMESPACE__ . '\register_post_type_data' );
+add_filter( 'rest_' . POST_TYPE . '_item_schema', __NAMESPACE__ . '\update_schema' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_fields' );
 add_action( 'init', __NAMESPACE__ . '\register_post_statuses' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_assets' );
@@ -242,6 +243,23 @@ function register_post_type_data() {
 			),
 		)
 	);
+}
+
+/**
+ * Add the "parent" to the pattern endpoint.
+ *
+ * This takes advantage of page behavior in `WP_REST_Posts_Controller`, which will output the parent ID if the
+ * schema contains the parent property. It also checks that the ID referenced is a valid post.
+ *
+ * @param array $schema Item schema data.
+ */
+function update_schema( $schema ) {
+	$schema['properties']['parent'] = array(
+		'description' => __( 'The ID for the original English pattern.', 'wporg-patterns' ),
+		'type'        => 'integer',
+		'context'     => array( 'view', 'edit' ),
+	);
+	return $schema;
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/src/components/manage-options/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/manage-options/index.js
@@ -13,12 +13,13 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as patternStore } from '../../store';
 
 const ManageOptions = ( { patternId, isSmall } ) => {
-	const { isDraft } = useSelect(
+	const { isDraft, parent } = useSelect(
 		( select ) => {
 			const _pattern = select( patternStore ).getPattern( patternId );
 
 			return {
 				isDraft: _pattern?.status === 'draft',
+				parent: _pattern?.parent || 0,
 			};
 		},
 		[ patternId ]
@@ -48,7 +49,7 @@ const ManageOptions = ( { patternId, isSmall } ) => {
 		}
 	};
 
-	const editLink = `${ wporgPatternsUrl.site }/pattern/${ patternId }/edit/`;
+	const editLink = `${ wporgPatternsUrl.site }/pattern/${ parent ? parent : patternId }/edit/`;
 
 	const toggleContent = isSmall ? (
 		<Icon icon={ chevronDown } />
@@ -76,7 +77,11 @@ const ManageOptions = ( { patternId, isSmall } ) => {
 		>
 			{ () => (
 				<>
-					<MenuItem href={ editLink }>{ __( 'Open in editor', 'wporg-patterns' ) }</MenuItem>
+					<MenuItem href={ editLink }>
+						{ parent
+							? __( 'Open original in editor', 'wporg-patterns' )
+							: __( 'Open in editor', 'wporg-patterns' ) }
+					</MenuItem>
 					{ ! isDraft && (
 						<MenuItem onClick={ onRevertToDraft }>
 							{ __( 'Revert to draft', 'wporg-patterns' ) }


### PR DESCRIPTION
It should not be possible to edit translated patterns in the Pattern Creator (they'll still need to be editable in wp-admin for internal notes). This PR changes out the "Open in editor" item for "Open original in editor" when viewing a translated pattern you own. If you click it, it will open the English version of the pattern.

See #386

### Screenshots

<img width="994" alt="Screen Shot 2022-01-21 at 4 48 10 PM" src="https://user-images.githubusercontent.com/541093/150604641-87dc3b9d-7a51-44e3-ad66-ec76c7ba8f71.png">

### How to test the changes in this Pull Request:

1. View a translated pattern that you own
2. Click Options
3. The dropdown should now say "Open original in editor"
4. Clicking should open the pattern creator, with the same pattern in English
5. View an English pattern you own
6. Click Options
7. The dropdown should now say "Open in editor"
8. Clicking should open the pattern creator, with this pattern
