### PR TITLE
Patterns: Update permissions to allow pattern creation and editing by all logged-in users.

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -649,6 +649,8 @@ function set_pattern_caps( $user_caps ) {
 	);
 	$cap_map = (array) get_post_type_capabilities( (object) $cap_args );
 
+	// Users should have the same permissions for patterns as posts, for example,
+	// if they have `edit_posts`, they should be granted `edit_patterns`, and so on.
 	foreach ( $user_caps as $cap => $bool ) {
 		if ( $bool && isset( $cap_map[ $cap ] ) ) {
 			$user_caps[ $cap_map[ $cap ] ] = true;
@@ -657,9 +659,13 @@ function set_pattern_caps( $user_caps ) {
 
 	// Set caps to allow for front end pattern creation.
 	if ( is_user_logged_in() && ! is_admin() ) {
-		$user_caps['publish_patterns']        = true;
-		$user_caps['edit_patterns']           = true;
-		$user_caps['edit_published_patterns'] = true;
+		$user_caps['read']                       = true;
+		$user_caps['publish_patterns']           = true;
+		$user_caps['edit_patterns']              = true;
+		$user_caps['edit_published_patterns']    = true;
+		$user_caps['delete_patterns']            = true;
+		$user_caps['delete_published_patterns']  = true;
+		// Note that `edit_others_patterns` & `delete_others_patterns` are separate capabilities.
 	}
 
 	return $user_caps;

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/capabilities-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/capabilities-test.php
@@ -42,6 +42,14 @@ class Capabilities_Test extends WP_UnitTestCase {
 
 	protected $subscriber_caps = array();
 
+	protected $granted_caps = array(
+		'edit_patterns'             => true,
+		'edit_published_patterns'   => true,
+		'publish_patterns'          => true,
+		'delete_patterns'           => true,
+		'delete_published_patterns' => true,
+	);
+
 	/**
 	 * Set up shared fixtures.
 	 */
@@ -225,14 +233,7 @@ class Capabilities_Test extends WP_UnitTestCase {
 		wp_set_current_user( self::$user_contributor );
 
 		$caps = $this->merge_caps( $this->contributor_caps, $this->admin_editor_caps );
-		$front_end_caps = array_merge(
-			$caps,
-			array(
-				'edit_patterns'           => true,
-				'edit_published_patterns' => true,
-				'publish_patterns'        => true,
-			)
-		);
+		$front_end_caps = array_merge( $caps, $this->granted_caps );
 
 		// Test front end caps.
 		foreach ( $front_end_caps as $cap => $expected_result ) {
@@ -261,14 +262,7 @@ class Capabilities_Test extends WP_UnitTestCase {
 		wp_set_current_user( self::$user_subscriber );
 
 		$caps = $this->merge_caps( $this->subscriber_caps, $this->admin_editor_caps );
-		$front_end_caps = array_merge(
-			$caps,
-			array(
-				'edit_patterns'           => true,
-				'edit_published_patterns' => true,
-				'publish_patterns'        => true,
-			)
-		);
+		$front_end_caps = array_merge( $caps, $this->granted_caps );
 
 		// Test front end caps.
 		foreach ( $front_end_caps as $cap => $expected_result ) {


### PR DESCRIPTION
Fixes #377 — Anyone with a wp.org account can now create, edit, view, and delete their own patterns.

The permissions that were already granted in #249 don't actually cover everything required by the editor.

1. The CPT endpoint checks against `current_user_can( 'read_post', $post->ID )` ([source](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L1606)), which fails for wporg users who aren't members of the site, because they don't have `read` permission.
2. Delete permissions are necessary to delete patterns.

I don't see anything unexpected from adding the `read` perm on the frontend, but I'm requesting review just to make sure there isn't something I'm missing.

### How to test the changes in this Pull Request:

1. Log into a user account that isn't a member of w.org/patterns
2. View [wordpress.org/patterns](https://wordpress.org/patterns/), you should have an admin bar with the + New button
3. The only item in that dropdown should be Block Pattern, click it
4. The editor should open without console errors
5. Add a pattern, save it however you want (draft or submit, it will go to pending, not publish)
6. It should save successfully
7. Go to [wordpress.org/patterns/my-patterns](https://wordpress.org/patterns/my-patterns/), you should see the pattern you just created
8. Open it in the editor (either using the 🔽  menu or the Edit link in the admin bar)
9. It should load

You can try editing things you don't have access to, it should prevent you. There are a few issues with permissions + the Query Loop block, but I think the solution there will be mocking, see #23.
