### PR TITLE
Center loader in Openverse control.

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/openverse/grid.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/openverse/grid.js
@@ -120,7 +120,7 @@ export default function OpenverseGrid( { searchTerm, onClose, onSelect, multiple
 
 	if ( isLoading ) {
 		return (
-			<div className="pattern-openverse__loader">
+			<div className="pattern-openverse__spinner">
 				<Spinner />
 			</div>
 		);

--- a/public_html/wp-content/plugins/pattern-creator/src/components/openverse/grid.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/openverse/grid.js
@@ -120,7 +120,7 @@ export default function OpenverseGrid( { searchTerm, onClose, onSelect, multiple
 
 	if ( isLoading ) {
 		return (
-			<div>
+			<div className="pattern-openverse__loader">
 				<Spinner />
 			</div>
 		);

--- a/public_html/wp-content/plugins/pattern-creator/src/components/openverse/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/openverse/style.scss
@@ -44,6 +44,11 @@
 	}
 }
 
+.pattern-openverse__loader {
+	text-align: center;
+	margin-top: $grid-unit-40;
+}
+
 .pattern-openverse__error {
 	margin-top: $grid-unit-40;
 }

--- a/public_html/wp-content/plugins/pattern-creator/src/components/openverse/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/openverse/style.scss
@@ -45,8 +45,8 @@
 }
 
 .pattern-openverse__loader {
-	text-align: center;
 	margin-top: $grid-unit-40;
+	text-align: center;
 }
 
 .pattern-openverse__error {

--- a/public_html/wp-content/plugins/pattern-creator/src/components/openverse/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/openverse/style.scss
@@ -44,7 +44,7 @@
 	}
 }
 
-.pattern-openverse__loader {
+.pattern-openverse__spinner {
 	margin-top: $grid-unit-40;
 	text-align: center;
 }


### PR DESCRIPTION
This PR centers the openverse `<Spinner>` keeping it in rough alignment with the title in the response.

**Note** The `<Spinner>` controls seems to have changed and it is not rendering properly. I will address that in a follow up PR. [Issue](https://github.com/WordPress/pattern-directory/issues/402).

### Screenshots
| Before | After |
| --- | --- |
|   ![](https://d.pr/i/kwdWG3.png) | ![](https://d.pr/i/B6pelg.png) |

### How to test the changes in this Pull Request:

1. Add Image block
2. Click "Media Library"
3. Select a category
4. Expect to see the loader

