### PR TITLE
Add spam checking on pattern submissions

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
@@ -7,6 +7,7 @@ use function WordPressdotorg\Locales\get_locales_with_english_names;
 use function WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\get_pattern_ids_with_pending_flags;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG;
+use const  WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{UNLISTED_STATUS, SPAM_STATUS};
 
 defined( 'WPINC' ) || die();
 
@@ -381,8 +382,11 @@ function display_post_states( $post_states, $post ) {
 		$post_status = '';
 	}
 
-	if ( 'unlisted' === $post->post_status && 'unlisted' !== $post_status ) {
-		$post_states['unlisted'] = _x( 'Unlisted', 'post status', 'wporg-patterns' );
+	if (
+		$post->post_status !== $post_status &&
+		in_array( $post->post_status, [ UNLISTED_STATUS, SPAM_STATUS ] )
+	) {
+		$post_states[ $post->post_status ] = get_post_status_object( $post->post_status )->label;
 	}
 
 	return $post_states;

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
@@ -7,7 +7,7 @@ use function WordPressdotorg\Locales\get_locales_with_english_names;
 use function WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\get_pattern_ids_with_pending_flags;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG;
-use const  WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{UNLISTED_STATUS, SPAM_STATUS};
+use const  WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ UNLISTED_STATUS, SPAM_STATUS };
 
 defined( 'WPINC' ) || die();
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -6,7 +6,9 @@ use Error, WP_Block_Type_Registry;
 use function WordPressdotorg\Locales\{ get_locales, get_locales_with_english_names, get_locales_with_native_names };
 use function WordPressdotorg\Pattern_Directory\Favorite\get_favorite_count;
 
-const POST_TYPE = 'wporg-pattern';
+const POST_TYPE       = 'wporg-pattern';
+const UNLISTED_STATUS = 'unlisted';
+const SPAM_STATUS     = 'pending-review';
 
 add_action( 'init', __NAMESPACE__ . '\register_post_type_data' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_fields' );
@@ -393,17 +395,34 @@ function register_rest_fields() {
  */
 function register_post_statuses() {
 	register_post_status(
-		'unlisted',
+		UNLISTED_STATUS,
 		array(
-			'label'                  => __( 'Unlisted', 'wporg-patterns' ),
-			'label_count'            => _n_noop(
+			'label'                  => _x( 'Unlisted', 'post status', 'wporg-patterns' ),
+			'label_count'            => _nx_noop(
 				'Unlisted <span class="count">(%s)</span>',
 				'Unlisted <span class="count">(%s)</span>',
+				'post status',
 				'wporg-patterns'
 			),
 			'public'                 => false,
 			'protected'              => true,
-			'show_in_admin_all_list' => false,
+			'show_in_admin_all_list' => true,
+		)
+	);
+
+	register_post_status(
+		SPAM_STATUS,
+		array(
+			'label'                  => _x( 'Possible Spam', 'post status', 'wporg-patterns' ),
+			'label_count'            => _nx_noop(
+				'Possible Spam <span class="count">(%s)</span>',
+				'Possible Spam <span class="count">(%s)</span>',
+				'post status',
+				'wporg-patterns'
+			),
+			'public'                 => false,
+			'protected'              => true,
+			'show_in_admin_all_list' => true,
 		)
 	);
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -19,6 +19,7 @@ add_filter( 'rest_' . POST_TYPE . '_query', __NAMESPACE__ . '\filter_patterns_re
 add_filter( 'user_has_cap', __NAMESPACE__ . '\set_pattern_caps' );
 add_filter( 'posts_orderby', __NAMESPACE__ . '\filter_orderby_locale', 10, 2 );
 
+
 /**
  * Registers post types and associated taxonomies, meta data, etc.
  */

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -16,9 +16,9 @@ add_filter( 'allowed_block_types_all', __NAMESPACE__ . '\remove_disallowed_block
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\disable_block_directory', 0 );
 add_filter( 'rest_' . POST_TYPE . '_collection_params', __NAMESPACE__ . '\filter_patterns_collection_params' );
 add_filter( 'rest_' . POST_TYPE . '_query', __NAMESPACE__ . '\filter_patterns_rest_query', 10, 2 );
+add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\maybe_filter_post_status', 10, 2 );
 add_filter( 'user_has_cap', __NAMESPACE__ . '\set_pattern_caps' );
 add_filter( 'posts_orderby', __NAMESPACE__ . '\filter_orderby_locale', 10, 2 );
-
 
 /**
  * Registers post types and associated taxonomies, meta data, etc.
@@ -669,4 +669,51 @@ function set_pattern_caps( $user_caps ) {
 	}
 
 	return $user_caps;
+}
+
+/**
+ * Filter pattern edits through the rest-api to validate that the pattern is what we expect.
+ *
+ * This prevents publishing patterns that do not meet our automated checks, pushing it to a human
+ * review queue. Once the pattern is there, it cannot be published by a non-privledged user.
+ *
+ * @param stdClass        $prepared_post The Rest API payload, see `rest_pre_insert_{$this->post_type}` filter.
+ * @param WP_REST_Request $request       The Rest API request object.
+ * @return stdClass The modified $prepared_post.
+ */
+function maybe_filter_post_status( $prepared_post, $request ) {
+	// If they're not trying to publish the post, that's okay.
+	if ( 'publish' !== $prepared_post->post_status ) {
+		return $prepared_post;
+	}
+
+	$post_type = get_post_type_object( POST_TYPE );
+	$post      = get_post( $prepared_post->ID  );
+
+	// Do not allow for non-privledged users to move a pending post to another status.
+	if (
+		'pending' === $post->post_status &&
+		! current_user_can( $post_type->cap->edit_others_patterns )
+	) {
+		$prepared_post->post_status = 'pending';
+	}
+
+	// Perform checks over the post to see if we want to accept the pattern as-is, or if it needs to go through human review.
+	$validation = validate_pattern( $prepared_post, $post );
+	if ( ! $validation || is_wp_error( $validation ) ) {
+		$prepared_post->post_status = 'pending';
+	}
+
+	return $prepared_post;
+}
+
+/**
+ * Run validations against a given pattern to see if it passes our requirements.
+ *
+ * @param stdClass        $prepared_post The Rest API payload, see `rest_pre_insert_{$this->post_type}` filter.
+ * @param WP_REST_Request $request       The Rest API request object.
+ * @return bool Whether the pattern meets the requirements.
+ */
+function validate_pattern( $prepared_post, $post ) {
+	return true;
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace WordPressdotorg\Pattern_Directory\Pattern_Validation;
-use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{POST_TYPE,UNLISTED_STATUS,SPAM_STATUS};
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, UNLISTED_STATUS, SPAM_STATUS };
 
 use WordPressdotorg\Pattern_Translations\Pattern as Translations_Pattern;
 use WordPressdotorg\Pattern_Translations\PatternParser as Translations_PatternParser;

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -11,7 +11,6 @@ add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_title', 1
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_status', 11, 2 );
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_against_spam', 20, 2 );
 
-
 /**
  * Strip out basic HTML to get at the manually-entered content in block content.
  *

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -284,6 +284,23 @@ function validate_against_spam( $prepared_post, $request ) {
 	// Not yet detected as spam.
 	$is_spam = false;
 
+	// Treat Paragraph-only submissions as likely spam.
+	if ( ! $is_spam ) {
+		// Only fetches the top-level of blocks, we're only
+		$block_names_in_use = array_filter(
+			array_unique(
+				wp_list_pluck(
+					parse_blocks( $content ),
+					'blockName'
+				)
+			)
+		);
+
+		if ( array( 'core/paragraph' ) === $block_names_in_use ) {
+			$is_spam = true;
+		}
+	}
+
 	// Run it past Akismet.
 	if ( ! $is_spam && is_callable( array( 'Akismet', 'rest_auto_check_comment' ) ) ) {
 		$current_user = wp_get_current_user();

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -246,6 +246,12 @@ function validate_against_spam( $prepared_post, $request ) {
 	$description = $request['meta']['wpop_description'] ?? ( $post->wpop_description ?: '' );
 	$keywords    = $request['meta']['wpop_keywords'] ?? ( $post->wpop_keywords ?: '' );
 
+	// Extract URLs.
+	$links = array();
+	if ( preg_match_all( '![\b\W"\'](?P<link>((http|https|ftp|mailto):)?//[/.\w]+)[\b\W"\']!', $content, $m ) ) {
+		$links = array_unique( $m['link'] );
+	}
+
 	// Stringify.
 	if ( ! class_exists( '\WordPressdotorg\Pattern_Translations\Pattern' ) ) {
 		// This is just a fall-back for local environments where the Translator isn't active.
@@ -272,6 +278,8 @@ function validate_against_spam( $prepared_post, $request ) {
 
 	// Combine strings for ease of use.
 	$combined_strings = implode( "\n", $strings );
+	$combined_links   = implode( "\n", $links );
+	$combined         = $combined_strings . "\n" . $combined_links;
 
 	// Not yet detected as spam.
 	$is_spam = false;

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -246,12 +246,6 @@ function validate_against_spam( $prepared_post, $request ) {
 	$description = $request['meta']['wpop_description'] ?? ( $post->wpop_description ?: '' );
 	$keywords    = $request['meta']['wpop_keywords'] ?? ( $post->wpop_keywords ?: '' );
 
-	// Extract URLs.
-	$links = array();
-	if ( preg_match_all( '![\b\W"\'](?P<link>((http|https|ftp|mailto):)?//[/.\w]+)[\b\W"\']!', $content, $m ) ) {
-		$links = array_unique( $m['link'] );
-	}
-
 	// Stringify.
 	if ( ! class_exists( '\WordPressdotorg\Pattern_Translations\Pattern' ) ) {
 		// This is just a fall-back for local environments where the Translator isn't active.

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -11,6 +11,7 @@ add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_title', 1
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_status', 11, 2 );
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_against_spam', 20, 2 );
 
+
 /**
  * Strip out basic HTML to get at the manually-entered content in block content.
  *
@@ -241,7 +242,7 @@ function validate_against_spam( $prepared_post, $request ) {
 	// Extract strings and URLs, run against spam checks.
 	$post = get_post( $prepared_post->ID );
 
-	$title       = $prepared_post->post_title   ?? $post->post_title;
+	$title       = $prepared_post->post_title ?? $post->post_title;
 	$content     = $prepared_post->post_content ?? $post->post_content;
 	$description = $request['meta']['wpop_description'] ?? ( $post->wpop_description ?: '' );
 	$keywords    = $request['meta']['wpop_keywords'] ?? ( $post->wpop_keywords ?: '' );
@@ -260,7 +261,7 @@ function validate_against_spam( $prepared_post, $request ) {
 			$title,
 			$description,
 			wp_strip_all_tags( $content ),
-			$keywords
+			$keywords,
 		);
 	} else {
 		$pattern              = new Translations_Pattern();
@@ -315,7 +316,7 @@ function validate_against_spam( $prepared_post, $request ) {
 			'comment_author_url'   => '',
 			'comment_content'      => $combined_strings,
 			'comment_content_raw'  => $content,
-			'permalink'            => get_permalink( $post )
+			'permalink'            => get_permalink( $post ),
 		);
 
 		$akismet = \Akismet::rest_auto_check_comment( $akismet_payload );

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -278,8 +278,6 @@ function validate_against_spam( $prepared_post, $request ) {
 
 	// Combine strings for ease of use.
 	$combined_strings = implode( "\n", $strings );
-	$combined_links   = implode( "\n", $links );
-	$combined         = $combined_strings . "\n" . $combined_links;
 
 	// Not yet detected as spam.
 	$is_spam     = false;

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -3,7 +3,7 @@
  * Test Block Pattern validation.
  */
 
-use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, SPAM_STATUS };
 
 /**
  * Test pattern validation.
@@ -273,7 +273,7 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 		$this->assertFalse( $response->is_error() );
 		$data = $response->get_data();
 
-		$this->assertSame( 'pending', $data['status'] );
+		$this->assertSame( SPAM_STATUS, $data['status'] );
 	}
 
 	/**
@@ -290,7 +290,7 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 		$this->assertFalse( $response->is_error() );
 		$data = $response->get_data();
 
-		$this->assertSame( 'pending', $data['status'] );
+		$this->assertSame( SPAM_STATUS, $data['status'] );
 	}
 }
 

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -267,7 +267,7 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 		$response = $this->save_block_pattern( array(
 			'title'   => 'Spam Check',
 			'content' => "<!-- wp:heading -->\n<h2 id=\"spam-check\">Spam Check.</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Paragraph: PatternDirectorySpamTest</p>\n<!-- /wp:paragraph -->",
-			'status'  => 'publish'
+			'status'  => 'publish',
 		) );
 
 		$this->assertFalse( $response->is_error() );
@@ -284,7 +284,7 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 		$response = $this->save_block_pattern( array(
 			'title'   => 'Spam Check',
 			'content' => "<!-- wp:paragraph -->\n<p>Paragraph one.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Paragraph two.</p>\n<!-- /wp:paragraph -->",
-			'status'  => 'publish'
+			'status'  => 'publish',
 		) );
 
 		$this->assertFalse( $response->is_error() );

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -39,11 +39,17 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	 * Helper function to handle REST requests to save the pattern.
 	 */
 	protected function save_block_content( $content ) {
-		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		return $this->save_block_pattern( compact( 'content' ) );
+	}
+
+	/**
+	 * Helper function to handle a REST request to save a full pattern.
+	 */
+	protected function save_block_pattern( $attributes ) {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern' . ( self::$pattern_id ? '/' . self::$pattern_id : '' ) );
 		$request->set_header( 'content-type', 'application/json' );
-		$request->set_body( json_encode( array(
-			'content' => $content,
-		) ) );
+		$request->set_body( json_encode( $attributes ) );
+
 		return rest_do_request( $request );
 	}
 
@@ -251,6 +257,40 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 		$this->assertTrue( $response->is_error() );
 		$data = $response->get_data();
 		$this->assertSame( 'rest_pattern_invalid_blocks', $data['code'] );
+	}
+
+	/**
+	 * Test a block that's detected as spam should be pending.
+	 */
+	public function test_spam_should_be_pending() {
+		wp_set_current_user( self::$user );
+		$response = $this->save_block_pattern( array(
+			'title'   => 'Spam Check',
+			'content' => "<!-- wp:heading -->\n<h2 id=\"spam-check\">Spam Check.</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Paragraph: PatternDirectorySpamTest</p>\n<!-- /wp:paragraph -->",
+			'status'  => 'publish'
+		) );
+
+		$this->assertFalse( $response->is_error() );
+		$data = $response->get_data();
+
+		$this->assertSame( 'pending', $data['status'] );
+	}
+
+	/**
+	 * Test that paragraph-only posts should be detected as spam.
+	 */
+	public function test_only_paragraphs_are_spam() {
+		wp_set_current_user( self::$user );
+		$response = $this->save_block_pattern( array(
+			'title'   => 'Spam Check',
+			'content' => "<!-- wp:paragraph -->\n<p>Paragraph one.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Paragraph two.</p>\n<!-- /wp:paragraph -->",
+			'status'  => 'publish'
+		) );
+
+		$this->assertFalse( $response->is_error() );
+		$data = $response->get_data();
+
+		$this->assertSame( 'pending', $data['status'] );
 	}
 }
 

--- a/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
@@ -10,6 +10,7 @@ class Pattern {
 	public $description = '';
 	public $html = '';
 	public $source_url = '';
+	public $keywords = '';
 
 	public $locale = 'en_US';
 	public $parent = false;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR adds some anti-spam checks to pattern submissions:
 - Akismet
 - Basic paragraph-only detection (ie. if a submission is only paragraphs, it's likely to require manual review / be an automated bot)
 - A keyword to use for testing the spam process.

In order to simplify the text being checked, I leveraged the Pattern Translator codebase to extract all strings from the submitted content, rather than simply passing the HTML to Akismet, to avoid any issues related to HTML.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #22

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

1. Apply PR
2. Create a Spam pattern. (Either by including `PatternDirectorySpamTest` within the content, or the pattern only containing `core/paragraph` blocks)
3. Verify that the post is pending review.

You can also try running `yarn test:php` however I've been unable to run phpunit locally due to `wp-env` problems, so I'm not able to check the unit test additions actually work.

<!-- If you can, add the appropriate [Component] label(s). -->
