### PR TITLE
Submission Window: Add more padding around content.

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/style.scss
@@ -81,7 +81,7 @@ $modal-height: 375px;
 	flex-direction: column;
 	justify-content: space-between;
 	background: $white;
-	padding: $grid-unit-20 $grid-unit-40 $grid-unit-40;
+	padding: $grid-unit-40;
 }
 
 .submission-modal__link {
@@ -100,7 +100,6 @@ $modal-height: 375px;
 	display: grid;
 	grid-template-columns: 50% 50%;
 	grid-gap: $grid-unit-05;
-	padding-top: $grid-unit-10;
 	margin: 0;
 
 	li {


### PR DESCRIPTION
This PR makes the content padding consistent within the submission modal to fix overlap with the close button.

Fixes #410

## Screenshots
**Highlighting Boundaries**
<img src="https://d.pr/i/Xo0l3L.png" width="500px" />
**Default View**
<img src="https://d.pr/i/ziGpuc.png" width="500px" />

## Changes
This PR also makes an incidental change to remove the padding from the category list (Line 103) that was causing overflow. We currently only support 10 categories. When we support more in the list, we'll need to create a proper overflow contain as seen in the designs

### How to test the changes in this Pull Request:

1. Create Pattern
2. Click Submit Pattern
3. Verify close button.
