### PR TITLE
Activate submit button without title.

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/store/selectors.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/selectors.js
@@ -118,8 +118,8 @@ export function isListViewOpened( state ) {
 /**
  * Returns whether the pattern is "saveable".
  *
- * A pattern can be saved if it has a title and content. The other requirements
- * are handled in the publish flow, title and content are the only things
+ * A pattern can be saved if it has content. The other requirements
+ * are handled in the publish flow, content is the only thing
  * required for saving a draft.
  *
  * See https://github.com/WordPress/gutenberg/blob/31330dbb737ce30646a4300410faed633061547a/packages/editor/src/store/selectors.js#L531
@@ -132,10 +132,7 @@ export function isListViewOpened( state ) {
 export const isPatternSaveable = createRegistrySelector( ( select ) => ( state, postId ) => {
 	const post = select( coreStore ).getEditedEntityRecord( 'postType', POST_TYPE, postId ) || EMPTY_OBJECT;
 
-	const hasTitle = !! post.title;
-	const hasContent = ! isEditedPostEmpty( post );
-
-	return hasTitle && hasContent;
+	return ! isEditedPostEmpty( post );
 } );
 
 function isEditedPostEmpty( post ) {

--- a/public_html/wp-content/plugins/pattern-creator/src/store/test/selectors.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/test/selectors.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getSettings, isFeatureActive, isInserterOpened, isListViewOpened } from '../selectors';
+import { getSettings, isFeatureActive, isInserterOpened, isListViewOpened, isPatternSaveable } from '../selectors';
 
 describe( 'selectors', () => {
 	const canUser = jest.fn( () => true );
@@ -105,6 +105,46 @@ describe( 'selectors', () => {
 			expect( isListViewOpened( state ) ).toBe( true );
 			state.listViewPanel = false;
 			expect( isListViewOpened( state ) ).toBe( false );
+		} );
+	} );
+
+	it( 'should return false if post has no blocks', () => {
+		isPatternSaveable.registry = {
+			select: jest.fn( () => ( {
+				getEditedEntityRecord: () => {
+					return {
+						blocks: [],
+					};
+				},
+			} ) ),
+		};
+
+		const state = {};
+		expect( isPatternSaveable( state ) ).toBe( false );
+	} );
+
+	describe( 'isPatternSaveable', () => {
+		it( 'should return true if post has a block', () => {
+			isPatternSaveable.registry = {
+				select: jest.fn( () => ( {
+					getEditedEntityRecord: () => {
+						return {
+							blocks: [
+								{
+									attributes: { content: 'w', dropCap: false },
+									clientId: 'wordpress',
+									innerBlocks: [],
+									isValid: true,
+									name: 'core/paragraph',
+								},
+							],
+						};
+					},
+				} ) ),
+			};
+
+			const state = {};
+			expect( isPatternSaveable( state ) ).toBe( true );
 		} );
 	} );
 } );

--- a/public_html/wp-content/plugins/pattern-creator/src/store/test/selectors.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/test/selectors.js
@@ -119,8 +119,7 @@ describe( 'selectors', () => {
 			} ) ),
 		};
 
-		const state = {};
-		expect( isPatternSaveable( state ) ).toBe( false );
+		expect( isPatternSaveable( {} ) ).toBe( false );
 	} );
 
 	describe( 'isPatternSaveable', () => {
@@ -143,8 +142,7 @@ describe( 'selectors', () => {
 				} ) ),
 			};
 
-			const state = {};
-			expect( isPatternSaveable( state ) ).toBe( true );
+			expect( isPatternSaveable( {} ) ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR removes the title restriction from `isPatternSaveable` so users can bring up the submit window and fill in the necessary information.

**Acceptance Criteria**
- Users can click the submit button after adding content to their pattern.
- The submit button should not be active if the pattern only has a title.
- Users must have a title set before moving on to the second window in the submission flow.

Fixes #409

### Screenshots
| Details |  State | |
| --- | --- | --- |
| Has a title but no content.  | Can't submit | <img src="https://d.pr/N3QMYk.png" width="600px"> |
| Has a block, no title.  | Can submit  | <img src="https://d.pr/AerkFT.png" width="600px"> |
| Has no title  | Can't proceed  | <img src="https://d.pr/NL0gdE.png" width="600px"> |
| Has title  | Can proceed  | <img src="https://d.pr/qeXLI4.png" width="600px"> |

### How to test the changes in this Pull Request:

1. Visit `/new-pattern`
2. Add a block
3. Click submit
4. Notice the "next" button is disabled
6. Add a title
7. Proceed and submit pattern

<!-- If you can, add the appropriate [Component] label(s). -->
