### PR TITLE
Remove custom layout declarations.

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
@@ -26,12 +26,6 @@ import { useMergeRefs } from '@wordpress/compose';
 import { POST_TYPE, store as patternStore } from '../../store';
 import { SidebarInspectorFill } from '../sidebar';
 
-const LAYOUT = {
-	type: 'default',
-	// At the root level of the site editor, no alignments should be allowed.
-	alignments: [],
-};
-
 export default function BlockEditor( { setIsInserterOpen } ) {
 	const { settings, deviceType } = useSelect(
 		( select ) => {
@@ -73,10 +67,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					contentRef={ mergedRefs }
 					name="editor-canvas"
 				>
-					<BlockList
-						className="pattern-block-editor__block-list wp-site-blocks"
-						__experimentalLayout={ LAYOUT }
-					/>
+					<BlockList className="pattern-block-editor__block-list wp-site-blocks" />
 				</Iframe>
 			</BlockTools>
 		</BlockEditorProvider>

--- a/public_html/wp-content/plugins/pattern-creator/src/components/editor/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/editor/index.js
@@ -78,6 +78,7 @@ function Editor( { initialSettings, onError, postId } ) {
 		const result = {
 			...settings,
 			fullscreenMode: true,
+			supportsLayout: false,
 			__experimentalLocalAutosaveInterval: 30,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 		};


### PR DESCRIPTION
Fixes #389 

This PR removes the custom Layout object that modifies internal Gutenberg functionality to allow custom block alignments.
 
Gutenberg supports full width alignments when `add_theme_support('align-wide')` is added to a theme. We have that included in our `functions.php` which is why the full-width alignments show up when adding blocks on a new post/page. However, `new-pattern` uses our own import of the `Editor/BlockEditor` and therefore behaves differently. The problem here was solved in two steps:
- Remove the custom layout passed into the Block editor
- Set `supportsLayout` to `false` for the block editor. 

### Considerations
- If we allow users to set widths that are not supported in their themes, is that a problem? No, the alignment tool will not show anything selected when a user toggles the control and once the user updates the pattern on their site, it will replace the pattern's default.
- Is turning off `supportsLayout` going to cause problems in the future since it's a forward-leaning feature? 
  - I don't think so, but not sure. But since it's only affecting how patterns are created, we can remove it in the future if it causes problems. 


### Screenshots
**Enabled on Image Block**
<img src="https://d.pr/i/fn67kh.png" width="500px"/>

**Enabled on Group Block**
<img src="https://d.pr/i/wb71EK.png" width="500px"/>

### How to test the changes in this Pull Request:

1. Visit `new-pattern`
2. Add an image block
3. Verify you have all the alignments shown in screenshot.
4. Save pattern with a "full" alignment
5. Copy your pattern and expect to see that alignment attached.

**Reading/Code References**
- Where Gutenberg determines alignment support: [Link](https://github.com/WordPress/gutenberg/blob/32ecd97e988174b6401289c44200135c224ca104/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js#L16)
- The default layout configurations: [Link](https://github.com/WordPress/gutenberg/blob/bf405a3f1280cade6b9f480c973261b987d5fd53/packages/block-editor/src/layouts/flow.js)

<!-- If you can, add the appropriate [Component] label(s). -->
