### PR TITLE
Creator: Use Twenty Twenty-One styles in editor

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
@@ -48,6 +48,12 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const ref = useMouseMoveTypingReset();
 	const contentRef = useRef();
 	const mergedRefs = useMergeRefs( [ contentRef, useTypingObserver() ] );
+	if ( -1 === settings.__unstableResolvedAssets.styles.indexOf( 'theme-styles' ) ) {
+		settings.__unstableResolvedAssets.styles +=
+			'\n<link rel="stylesheet" id="theme-styles" href="https://wp-themes.com/wp-content/themes/twentytwentyone/style.css" media="all" />';
+		settings.__unstableResolvedAssets.styles +=
+			'\n<style>body.editor-styles-wrapper { background-color: white; }</style>';
+	}
 
 	return (
 		<BlockEditorProvider

--- a/public_html/wp-content/plugins/pattern-creator/src/components/editor/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/editor/style.scss
@@ -33,6 +33,7 @@ html {
 		display: block;
 		width: 100%;
 		height: 100%;
+		padding-top: 32px;
 		background-color: $white;
 	}
 }


### PR DESCRIPTION
Fixes #388. This adds the same theme styles to the editor as are used in the preview. This is most obvious in button styles, but the font was also different.

### Screenshots

Before:
![](https://user-images.githubusercontent.com/541093/156064206-4497f2d3-9a54-43e5-9705-db9250d9c2ca.png)

After:
![](https://user-images.githubusercontent.com/541093/156064204-e98ba10a-8353-4157-8046-fd9c2c1d5b88.png)

Frontend (see #416 for the alignment issue):
![front-end](https://user-images.githubusercontent.com/541093/156064321-cccd1a2f-c947-4f8d-908f-4e07a90352a7.png)

### How to test the changes in this Pull Request:

1. Create a new pattern, use headings, buttons, etc
2. View the finished pattern on the frontend
3. The fonts and styles should be the same as in the editor
