### PR TITLE
Remove the translate animation.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -78,8 +78,7 @@
 		bottom: 0;
 		padding: 0.375rem;
 		opacity: 0;
-		transform: translateY(6px);
-		transition: transform 0.075s ease-in-out, opacity 0.075s ease-in-out;
+		transition: opacity 0.075s ease-in-out;
 
 		> *:not(:first-child) {
 			margin-left: 0.375rem;
@@ -90,7 +89,6 @@
 	&:focus-within {
 		.pattern-grid__actions {
 			opacity: 1;
-			transform: translateY(0);
 		}
 	}
 }


### PR DESCRIPTION
This PR removes the `transform` animation on the Pattern Thumbnail Options to fix an issue that exists in chrome documented in #415.

## What's the problem?

Pulled from #415 

> This appears to be the result of [this chrome bug.](https://bugs.chromium.org/p/chromium/issues/detail?id=20574).
> 
> Essentially what is happening is that the ancestor, in this case: pattern-grid__actions is pulled out of the flow (because of GPU compositing) with transform: translateY(6px);. As a result, the [Dropdown component](https://github.com/WordPress/gutenberg/blob/3da717b8d0ac7d7821fc6d0475695ccf3ae2829f/packages/components/src/popover/style.scss#L5) which uses position: fixed, affixes to the wrong layer. It has the correct top position of the document but its relativity is incorrect.

## Changes
 - Remove the animation and leave the transition on `opacity` only.

## Alternate Approaches
### Animate using non GPU accelerated properties
I tried using the less performant `bottom` property to animate but it was janky and not worth it.

### Extend Gutenberg Component Styles
I couldn't really think of anything that would work seeing that half of the CSS that causes the issue is in the Gutenberg component. I found some resources that said you can add `-webkit-transform: translateZ(0)` to the `position: fixed` element to fix it but I don't think we want to be extending Gutenberg Popover styles from our codebase.


## Screenshots
_It's a bit tough to tell the difference via the gifs but essentially the second one doesn't fade downwards_
| Before | After |
| --- | --- |
| <img src="https://d.pr/i/o6zWEF.gif"> |  <img src="https://d.pr/i/1dhcIg.gif"> |

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #415 

### How to test the changes in this Pull Request:

1. Create multiple patterns
2. In chrome, navigate to `my-patterns`
3. Hover on a thumbnail
4. Click the dropdown button
5. Expect to see the menu directly under the button

<!-- If you can, add the appropriate [Component] label(s). -->
