### PR TITLE
Pattern Preview: Update styles to match editor.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -5,6 +5,8 @@ namespace WordPressdotorg\Pattern_Directory\Theme;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG_POST_TYPE;
 
+require_once __DIR__ . '/includes/inline-styles.php';
+
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets', 20 );
 add_action( 'wp_head', __NAMESPACE__ . '\generate_block_editor_styles_html' );
@@ -115,7 +117,8 @@ function enqueue_assets() {
  * See https://github.com/WordPress/gutenberg/blob/6ad2a433769a4514fc52083e97aa47a0bc9edf07/lib/client-assets.php#L710
  */
 function generate_block_editor_styles_html() {
-	$handles = array( 'wp-block-library' );
+	wp_enqueue_global_styles();
+	$handles = array( 'wp-block-library', 'global-styles' );
 
 	$block_registry = \WP_Block_Type_Registry::get_instance();
 

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -149,6 +149,9 @@ function generate_block_editor_styles_html() {
 		),
 		'before'
 	);
+
+	wp_dequeue_style( 'global-styles' );
+	wp_deregister_style( 'global-styles' );
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/includes/inline-styles.php
+++ b/public_html/wp-content/themes/pattern-directory/includes/inline-styles.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Inject the <style> tags into the content itself so that it's available in the API.
+ *
+ * By default these styles are injected by a hook (ex, wp_footer) that is not triggered
+ * in an API request, so the content we retrieve from the API is missing it.
+ *
+ * We need to add styles for both the layout & element styles (link color), and unhook
+ * the existing core & Gutenberg hooks.
+ *
+ * See https://github.com/WordPress/gutenberg/issues/38167 & https://github.com/WordPress/gutenberg/issues/35376.
+ */
+
+namespace WordPressdotorg\Pattern_Directory\Theme\Inline_Styles;
+use WP_Block_Type_Registry;
+
+/**
+ * Renders the layout config to the block wrapper.
+ *
+ * See `wp_render_layout_support_flag`, `gutenberg_render_layout_support_flag`.
+ *
+ * @param  string $block_content Rendered block content.
+ * @param  array  $block         Block object.
+ * @return string                Filtered block content.
+ */
+function render_layout_support_styles( $block_content, $block ) {
+	$block_type     = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$support_layout = gutenberg_block_has_support( $block_type, array( '__experimentalLayout' ), false );
+
+	if ( ! $support_layout ) {
+		return $block_content;
+	}
+
+	$block_gap             = wp_get_global_settings( array( 'spacing', 'blockGap' ) );
+	$default_layout        = wp_get_global_settings( array( 'layout' ) );
+	$has_block_gap_support = isset( $block_gap ) ? null !== $block_gap : false;
+	$default_block_layout  = _wp_array_get( $block_type->supports, array( '__experimentalLayout', 'default' ), array() );
+	$used_layout           = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $default_block_layout;
+	if ( isset( $used_layout['inherit'] ) && $used_layout['inherit'] ) {
+		if ( ! $default_layout ) {
+			return $block_content;
+		}
+		$used_layout = $default_layout;
+	}
+
+	$id        = uniqid();
+	$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
+	// Skip if gap value contains unsupported characters.
+	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
+	// because we only want to match against the value, not the CSS attribute.
+	$gap_value = preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
+	$style     = gutenberg_get_layout_style( ".wp-container-$id", $used_layout, $has_block_gap_support, $gap_value );
+	// This assumes the hook only applies to blocks with a single wrapper.
+	// I think this is a reasonable limitation for that particular hook.
+	$content = preg_replace(
+		'/' . preg_quote( 'class="', '/' ) . '/',
+		'class="wp-container-' . $id . ' ',
+		$block_content,
+		1
+	);
+
+	return $content . '<style>' . $style . '</style>';
+}
+remove_filter( 'render_block', 'wp_render_layout_support_flag' );
+remove_filter( 'render_block', 'gutenberg_render_layout_support_flag', 10, 2 );
+add_filter( 'render_block', __NAMESPACE__ . '\render_layout_support_styles', 10, 2 );
+
+/**
+ * Render the elements stylesheet.
+ *
+ * See `wp_render_elements_support`, `gutenberg_render_elements_support`.
+ *
+ * @param  string $block_content Rendered block content.
+ * @param  array  $block         Block object.
+ * @return string                Filtered block content.
+ */
+function render_elements_support_styles( $block_content, $block ) {
+
+	if ( ! $block_content ) {
+		return $block_content;
+	}
+
+	$link_color = null;
+	if ( ! empty( $block['attrs'] ) ) {
+		$link_color = _wp_array_get( $block['attrs'], array( 'style', 'elements', 'link', 'color', 'text' ), null );
+	}
+
+	/*
+	* For now we only care about link color.
+	* This code in the future when we have a public API
+	* should take advantage of WP_Theme_JSON_Gutenberg::compute_style_properties
+	* and work for any element and style.
+	*/
+	if ( null === $link_color ) {
+		return $block_content;
+	}
+
+	$class_name = 'wp-elements-' . uniqid();
+
+	if ( strpos( $link_color, 'var:preset|color|' ) !== false ) {
+		// Get the name from the string and add proper styles.
+		$index_to_splice = strrpos( $link_color, '|' ) + 1;
+		$link_color_name = substr( $link_color, $index_to_splice );
+		$link_color      = "var(--wp--preset--color--$link_color_name)";
+	}
+	$link_color_declaration = esc_html( safecss_filter_attr( "color: $link_color" ) );
+
+	$style = "<style>.$class_name a{" . $link_color_declaration . ";}</style>\n";
+
+	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
+	// Retrieve the opening tag of the first HTML element.
+	$html_element_matches = array();
+	preg_match( '/<[^>]+>/', $block_content, $html_element_matches, PREG_OFFSET_CAPTURE );
+	$first_element = $html_element_matches[0][0];
+	// If the first HTML element has a class attribute just add the new class
+	// as we do on layout and duotone.
+	if ( strpos( $first_element, 'class="' ) !== false ) {
+		$content = preg_replace(
+			'/' . preg_quote( 'class="', '/' ) . '/',
+			'class="' . $class_name . ' ',
+			$block_content,
+			1
+		);
+	} else {
+		// If the first HTML element has no class attribute we should inject the attribute before the attribute at the end.
+		$first_element_offset = $html_element_matches[0][1];
+		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
+	}
+
+	return $content . $style;
+}
+remove_filter( 'render_block', 'wp_render_elements_support', 10, 2 );
+remove_filter( 'render_block', 'gutenberg_render_elements_support', 10, 2 );
+add_filter( 'render_block', __NAMESPACE__ . '\render_elements_support_styles', 10, 2 );

--- a/public_html/wp-content/themes/pattern-directory/includes/inline-styles.php
+++ b/public_html/wp-content/themes/pattern-directory/includes/inline-styles.php
@@ -18,6 +18,7 @@ use WP_Block_Type_Registry;
  * Renders the layout config to the block wrapper.
  *
  * See `wp_render_layout_support_flag`, `gutenberg_render_layout_support_flag`.
+ * Copied from https://github.com/WordPress/gutenberg/blob/0ea49d674a376636db5c0722ae41083394df9e60/lib/block-supports/layout.php#L132.
  *
  * @param  string $block_content Rendered block content.
  * @param  array  $block         Block object.
@@ -69,6 +70,7 @@ add_filter( 'render_block', __NAMESPACE__ . '\render_layout_support_styles', 10,
  * Render the elements stylesheet.
  *
  * See `wp_render_elements_support`, `gutenberg_render_elements_support`.
+ * Copied from https://github.com/WordPress/gutenberg/blob/0ea49d674a376636db5c0722ae41083394df9e60/lib/block-supports/elements.php#L15.
  *
  * @param  string $block_content Rendered block content.
  * @param  array  $block         Block object.


### PR DESCRIPTION
Fixes #416 — The pattern content rendered in the preview frame is pulled from the API, and is only the post content. On regular page loads, there are extra styles output in the footer for alignment, spacing, and link color (if applicable). These were not being added to the preview, causing differences between editor & frontend. Additionally, the default preset classes were not loaded, so background colors, etc, were not applied.

1. To fix the extra `style` tag issues, I've copied over the gutenberg code to render these styles, and am injecting them directly into the content. This should only be a temporary fix, until the Style Engine work is done, since one of the bugs mentioned is this issue with API responses.
2. The preset classes were not loaded (due to [unregistering `global-styles` in wporg-mu-plugins](https://github.com/WordPress/wporg-mu-plugins/blob/7674f5dbf3c0d326008ad1d4884946e2b7ee4a60/mu-plugins/blocks/global-header-footer/blocks.php#L258)), so those are loaded in when generating the styles to inject into the preview iframe. They're immediately unregistered to avoid overwriting the properties for the header & footer (see https://github.com/WordPress/wporg-mu-plugins/pull/166).

### Screenshots

| Editor | Before | After |
|--------|--------|-------|
| ![](https://user-images.githubusercontent.com/541093/156424991-25e9e5c3-d0a6-47b9-bae3-ba11f401c056.png) | ![](https://user-images.githubusercontent.com/541093/156424999-7640daf4-07e5-4817-ba8f-632af75cfe7d.png) | ![](https://user-images.githubusercontent.com/541093/156424997-817c1244-3a9e-4e06-81f6-89dee466748c.png) |

### How to test the changes in this Pull Request:

1. Create a new pattern
2. Add a group block and give it a background color or gradient
3. Add more content inside, a Row or Buttons would work
4. Change the default alignment of items, for example, to center
5. Once you have a customized pattern, save it
6. Preview it on the frontend
7. It should match the editor view
