### PR TITLE
Pattern Creator: Add `theme.json` to theme to enable appearance tools.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -28,13 +28,8 @@ add_action( 'template_redirect', __NAMESPACE__ . '\rewrite_urls' );
  * as indicating support for post thumbnails.
  */
 function setup() {
-	add_theme_support( 'post-thumbnails' );
-
 	// Add gutenberg styling supports.
 	add_theme_support( 'align-wide' );
-	add_theme_support( 'custom-spacing' );
-	add_theme_support( 'custom-line-height' );
-	add_theme_support( 'experimental-link-color' );
 
 	// The parent wporg theme is designed for use on wordpress.org/* and assumes locale-domains are available.
 	// Remove hreflang support.

--- a/public_html/wp-content/themes/pattern-directory/theme.json
+++ b/public_html/wp-content/themes/pattern-directory/theme.json
@@ -1,0 +1,9 @@
+{
+    "version": 2,
+    "settings": {
+        "appearanceTools": true,
+        "color": {
+            "link": true
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `theme.json` file to enable [appearanceTools](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#opt-in-into-ui-controls), which enables all the possible UI controls for typography, colors, spacing, etc. It also enables the custom link color, since `add_theme_support( 'experimental-link-color' );` doesn't seem to work.

Just adding a `theme.json` doesn't trigger `wp_is_block_theme`, so we don't need to worry about any conflicts or issues with the global header.

⚠️  There's a bug where the theme style overrides the link color when the container has a background, I'm not sure if this is a theme issue or not since I can't customize the link color on TT1 [#55028-core](https://core.trac.wordpress.org/ticket/55028).

### Screenshots

New settings available in sidebar:

<img width="276" alt="Screen Shot 2022-03-02 at 3 08 13 PM" src="https://user-images.githubusercontent.com/541093/156441326-68da6580-5436-4f06-a951-66df0278f993.png">

### How to test the changes in this Pull Request:

1. Create a new pattern
2. See all the UI options available to you
3. Use them, they should appear on the frontend correctly

Note that this PR builds on #419 so that the styles are injected as expected.

