### PR TITLE
Creator: Fix padding in editor

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/style.scss
@@ -25,3 +25,11 @@
 .pattern-visual-editor > [name="editor-canvas"] {
 	margin-top: 0 !important;
 }
+
+
+// Restore Gutenberg Styles that are overwritten by twenty twenty one
+html :where(.wp-block) {
+	margin-bottom: 28px;
+	margin-top: 28px;
+	max-width: 840px;
+}

--- a/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/style.scss
@@ -24,5 +24,4 @@
 
 .pattern-visual-editor > [name="editor-canvas"] {
 	margin-top: 0 !important;
-	padding: 8px;
 }

--- a/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/style.scss
@@ -24,4 +24,5 @@
 
 .pattern-visual-editor > [name="editor-canvas"] {
 	margin-top: 0 !important;
+	padding: 8px;
 }


### PR DESCRIPTION
Introducing Twenty Twenty styles into the editor in #417 created some small regressions.

- The padding around the content in the editor is gone
- The first "block" jumps upwards after first interaction.

This is the result of the Twenty Twenty theme overriding margin and padding on some of Gutenberg's [classic.scss](https://github.com/WordPress/gutenberg/blob/b6c79fed01b0a18802f9603176746c92cde1b02d/packages/edit-post/src/classic.scss#L23
) styles.

These styles are meant to be a fallback for themes that currently don't use `theme.json` layouts. See comment in css file for more information.

## Current Solution
Copy the Gutenberg styles to our stylesheet.  

## Alternate Approaches
#### Re-arrange CSS imports, move Gutenberg after Twenty Twenty one
This would most likely introduce other layout issues.

#### Control Via theme.json
Try this after #420 is merged


## Remaining Issues
- The Block list appender ([+]) still jumps up higher than expected because it's absolutely positioned. In the default editor it isn't noticeable because the title styles are different.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->

### Screenshots
| Before | After |
| --- | --- |
| <img src="https://d.pr/i/dkFzcb.png" width="400px"> |   <img src="https://d.pr/gptLRo.png" width="400px"> | 
| <img src="https://d.pr/i/2KMA0p.png" width="400px"> |  <img src="https://d.pr/S4Urve.png" width="400px">  | 




<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Go to `new-pattern`
2. Expect to see around the content
3. Resize the window, expect the padding persists.

<!-- If you can, add the appropriate [Component] label(s). -->
