### PR TITLE
Translations: Enable translations for all published patterns

### DIFF
--- a/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
@@ -117,23 +117,17 @@ class Pattern {
 		$defaults = [
 			'post_type'      => POST_TYPE,
 			// Note: This must be set for cli context, in isolated test context this is defaulted to 'publish'
-			// Prevents unexpected patterns in translations. Unlisted to ensure that specifically flagged
-			// dotorg patterns are translated, even if temporarily unlisted.
-			'post_status'    => 'publish,unlisted',
+			// Prevents unexpected patterns in translations
+			'post_status'    => 'publish',
 			'posts_per_page' => -1,
 			'orderby'        => [
 				'post_date' => 'DESC',
 			],
-			// Only select en_US patterns that are marked as glotpress translatable.
+			// Only select en_US patterns.
 			'meta_query' => [
 				[
 					'key'   => 'wpop_locale',
 					'value' => 'en_US',
-				],
-				'relation' => 'AND',
-				[
-					'key'   => TRANSLATED_BY_GLOTPRESS_KEY,
-					'value' => 1,
 				],
 			],
 		];

--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -10,7 +10,6 @@ namespace WordPressdotorg\Pattern_Translations;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 
 const GLOTPRESS_PROJECT = 'patterns/core';
-const TRANSLATED_BY_GLOTPRESS_KEY = '_glotpress_translated';
 
 const TRANSLATED_TAXONOMIES = [
 	// Taxonomy => Translation Context, see pattern-directory/bin/i18n.php


### PR DESCRIPTION
Fixes #391 — this removes the `_glotpress_translated` meta restriction on importing patterns into glotpress, so that all submitted patterns will be sent for translation. It also removes the "unlisted" patterns from being sent for translation, since unlisted is meant for moderated, broken, or otherwise removed patterns (it's really unlikely that an unlisted pattern would be re-listed without changing the content).

### How to test the changes in this Pull Request:

I don't think this _can_ be tested before merge, but after merge we should start to see the strings from these patterns show up in [translate.wp.org](https://translate.wordpress.org/projects/patterns/core/).

- [Two offset images with description](https://wordpress.org/patterns/pattern/two-offset-images-with-description/)
- [Large background image with title and description](https://wordpress.org/patterns/pattern/large-background-image-with-title-and-description/)
- [Image and Calendar](https://wordpress.org/patterns/pattern/image-and-calendar/)
- [Short text surrounded by round images](https://wordpress.org/patterns/pattern/short-text-surrounded-by-round-images/)
- [Two column 404](https://wordpress.org/patterns/pattern/two-column-404/)
- [Image framed by a cover block](https://wordpress.org/patterns/pattern/image-framed-by-a-cover-block/)
- [Heading with image and text columns](https://wordpress.org/patterns/pattern/heading-with-image-and-text-columns/)
- [Slanted background with text and a button](https://wordpress.org/patterns/pattern/slanted-background-with-text-and-a-button/)
- [Two columns with images, text, and social icons](https://wordpress.org/patterns/pattern/two-columns-with-images-text-and-social-icons/)

<!-- If you can, add the appropriate [Component] label(s). -->
