### PR TITLE
Creator: Move initial editor settings into initialize function

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/editor/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/editor/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { AsyncModeProvider, useDispatch, useSelect } from '@wordpress/data';
 import { BlockBreadcrumb } from '@wordpress/block-editor';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import {
 	ComplementaryArea,
 	FullscreenMode,
@@ -41,27 +41,20 @@ const interfaceLabels = {
 	actions: __( 'Editor publish', 'wporg-patterns' ),
 };
 
-function Editor( { initialSettings, onError, postId } ) {
+function Editor( { onError, postId } ) {
 	const { isInserterOpen, isListViewOpen, post, sidebarIsOpened, settings } = useSelect( ( select ) => {
-		const { isInserterOpened, isListViewOpened, getSettings, isFeatureActive, getPreviewDeviceType } = select(
-			patternStore
-		);
+		const { isInserterOpened, isListViewOpened, getSettings } = select( patternStore );
 		const { getEntityRecord } = select( coreStore );
-
-		const _settings = getSettings();
-		_settings.focusMode = isFeatureActive( 'focusMode' );
-		_settings.hasFixedToolbar = isFeatureActive( 'fixedToolbar' ) || getPreviewDeviceType() !== 'Desktop';
-		_settings.hasReducedUI = isFeatureActive( 'reducedUI' );
 
 		return {
 			isInserterOpen: isInserterOpened(),
 			isListViewOpen: isListViewOpened(),
 			post: getEntityRecord( 'postType', POST_TYPE, postId ),
 			sidebarIsOpened: !! select( interfaceStore ).getActiveComplementaryArea( patternStore.name ),
-			settings: _settings,
+			settings: getSettings(),
 		};
 	}, [] );
-	const { setIsInserterOpened, updateSettings } = useDispatch( patternStore );
+	const { setIsInserterOpened } = useDispatch( patternStore );
 	const [ isEntitiesSavedStatesOpen, setIsEntitiesSavedStatesOpen ] = useState( false );
 	const closeEntitiesSavedStates = useCallback( () => {
 		setIsEntitiesSavedStatesOpen( false );
@@ -69,22 +62,6 @@ function Editor( { initialSettings, onError, postId } ) {
 	const openEntitiesSavedStates = useCallback( () => {
 		setIsEntitiesSavedStatesOpen( true );
 	}, [] );
-
-	useEffect( () => {
-		updateSettings( initialSettings );
-	}, [] );
-
-	const editorSettings = useMemo( () => {
-		const result = {
-			...settings,
-			fullscreenMode: true,
-			supportsLayout: false,
-			__experimentalLocalAutosaveInterval: 30,
-			__experimentalSetIsInserterOpened: setIsInserterOpened,
-		};
-
-		return result;
-	}, [ settings, setIsInserterOpened ] );
 
 	// Don't render the Editor until the settings are set and loaded
 	if ( ! settings?.siteUrl || ! post ) {
@@ -108,7 +85,7 @@ function Editor( { initialSettings, onError, postId } ) {
 	return (
 		<ShortcutProvider>
 			<SlotFillProvider>
-				<EditorProvider settings={ editorSettings } post={ post }>
+				<EditorProvider settings={ settings } post={ post }>
 					<ErrorBoundary onError={ onError }>
 						<FullscreenMode isActive />
 						<UrlController postId={ postId } />

--- a/public_html/wp-content/plugins/pattern-creator/src/store/selectors.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/selectors.js
@@ -66,9 +66,13 @@ export const getSettings = createSelector(
 	( state, setIsInserterOpen ) => {
 		const settings = {
 			...state.settings,
+			fullscreenMode: true,
 			outlineMode: true,
 			focusMode: isFeatureActive( state, 'focusMode' ),
-			hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
+			hasFixedToolbar:
+				isFeatureActive( state, 'fixedToolbar' ) || getPreviewDeviceType( state ) !== 'Desktop',
+			hasReducedUI: isFeatureActive( state, 'reducedUI' ),
+			__experimentalLocalAutosaveInterval: 30,
 			__experimentalSetIsInserterOpened: setIsInserterOpen,
 		};
 
@@ -78,6 +82,8 @@ export const getSettings = createSelector(
 		state.settings,
 		isFeatureActive( state, 'focusMode' ),
 		isFeatureActive( state, 'fixedToolbar' ),
+		isFeatureActive( state, 'reducedUI' ),
+		getPreviewDeviceType( state ),
 	]
 );
 

--- a/public_html/wp-content/plugins/pattern-creator/src/store/test/selectors.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/store/test/selectors.js
@@ -4,8 +4,6 @@
 import { getSettings, isFeatureActive, isInserterOpened, isListViewOpened, isPatternSaveable } from '../selectors';
 
 describe( 'selectors', () => {
-	const canUser = jest.fn( () => true );
-
 	describe( 'isFeatureActive', () => {
 		it( 'is tolerant to an undefined features preference', () => {
 			// See: https://github.com/WordPress/gutenberg/issues/14580
@@ -52,36 +50,41 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getSettings', () => {
-		it( "returns the settings when the user can't create media", () => {
-			canUser.mockReturnValueOnce( false );
-			canUser.mockReturnValueOnce( false );
+		it( 'returns the default settings', () => {
 			const state = { settings: {}, preferences: {} };
 			const setInserterOpened = () => {};
 			expect( getSettings( state, setInserterOpened ) ).toEqual( {
 				outlineMode: true,
 				focusMode: false,
-				hasFixedToolbar: false,
+				fullscreenMode: true,
+				hasFixedToolbar: true,
+				hasReducedUI: false,
 				__experimentalSetIsInserterOpened: setInserterOpened,
+				__experimentalLocalAutosaveInterval: 30,
 			} );
 		} );
 
-		it( 'returns the extended settings when the user can create media', () => {
+		it( 'returns the merged settings', () => {
 			const state = {
 				settings: { key: 'value' },
 				preferences: {
 					features: {
 						focusMode: true,
 						fixedToolbar: true,
+						reducedUI: true,
 					},
 				},
 			};
 			const setInserterOpened = () => {};
 			expect( getSettings( state, setInserterOpened ) ).toEqual( {
-				outlineMode: true,
 				key: 'value',
+				outlineMode: true,
 				focusMode: true,
+				fullscreenMode: true,
 				hasFixedToolbar: true,
+				hasReducedUI: true,
 				__experimentalSetIsInserterOpened: setInserterOpened,
+				__experimentalLocalAutosaveInterval: 30,
 			} );
 		} );
 	} );


### PR DESCRIPTION
This straightens out the editor settings somewhat by synchronously setting them (`updateSettings`) in `reinitializeEditor`. It also cleans up where the preference checks happen - previously there were some in `<Editor />` and some in the `getSettings` selector; now building the whole settings object happens in the selector.

### How to test the changes in this Pull Request:

There should be no visual or functional changes. The code should be more readable. Make sure the editor still works :)
