### PR TITLE
Creator: Fix layout & alignment options

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -222,7 +222,12 @@ function rest_api_init() {
 add_action( 'rest_api_init', __NAMESPACE__ . '\rest_api_init' );
 
 /**
- * Add Twenty Twenty-One styles, set the editor background to white, and add the correct layout settings.
+ * Filter editor settings to add extra styles to the Pattern Creator editor.
+ *
+ * This adds `link` & `style` tags to be loaded into the editor's iframe.
+ * - Load Twenty Twenty-One styles for a theme preview
+ * - Set the editor background to white for a cleaner preview
+ * - Add layout styles for the pattern container so that alignments work
  *
  * @param array $settings Default editor settings.
  * @return array Updated settings.

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -155,6 +155,8 @@ function pattern_creator_init() {
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-site' );
 	wp_enqueue_style( 'wp-format-library' );
+	// Load layout and margin styles.
+	wp_enqueue_style( 'wp-editor-classic-layout-styles' );
 	wp_enqueue_media();
 }
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\pattern_creator_init', 20 );

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -220,3 +220,27 @@ function rest_api_init() {
 	$controller->register_routes();
 }
 add_action( 'rest_api_init', __NAMESPACE__ . '\rest_api_init' );
+
+/**
+ * Add Twenty Twenty-One styles, set the editor background to white, and add the correct layout settings.
+ *
+ * @param array $settings Default editor settings.
+ * @return array Updated settings.
+ */
+function add_theme_styles_to_editor( $settings ) {
+	if ( ! isset( $settings['__unstableResolvedAssets']['styles'] ) ) {
+		return $settings;
+	}
+
+	$block_gap = wp_get_global_styles( array( 'spacing', 'blockGap' ) );
+	$layout = wp_get_global_settings( array( 'layout' ) );
+	$style = gutenberg_get_layout_style( '.pattern-block-editor__block-list.is-root-container', $layout, true, $block_gap );
+
+	$settings['__unstableResolvedAssets']['styles'] .=
+		'\n<link rel="stylesheet" id="theme-styles" href="https://wp-themes.com/wp-content/themes/twentytwentyone/style.css" media="all" />'; //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+	$settings['__unstableResolvedAssets']['styles'] .=
+		'\n<style>body.editor-styles-wrapper { background-color: white; }' . $style . '</style>';
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\add_theme_styles_to_editor', 20 );

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -237,6 +237,8 @@ function add_theme_styles_to_editor( $settings ) {
 		return $settings;
 	}
 
+	// Build up the alignment styles to match the layout set in theme.json.
+	// See https://github.com/WordPress/gutenberg/blob/9d4b83cbbafcd6c6cbd20c86b572f458fc65ff16/lib/block-supports/layout.php#L38
 	$block_gap = wp_get_global_styles( array( 'spacing', 'blockGap' ) );
 	$layout = wp_get_global_settings( array( 'layout' ) );
 	$style = gutenberg_get_layout_style( '.pattern-block-editor__block-list.is-root-container', $layout, true, $block_gap );

--- a/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
@@ -44,12 +44,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const ref = useMouseMoveTypingReset();
 	const contentRef = useRef();
 	const mergedRefs = useMergeRefs( [ contentRef, useTypingObserver() ] );
-	if ( -1 === settings.__unstableResolvedAssets.styles.indexOf( 'theme-styles' ) ) {
-		settings.__unstableResolvedAssets.styles +=
-			'\n<link rel="stylesheet" id="theme-styles" href="https://wp-themes.com/wp-content/themes/twentytwentyone/style.css" media="all" />';
-		settings.__unstableResolvedAssets.styles +=
-			'\n<style>body.editor-styles-wrapper { background-color: white; }</style>';
-	}
 
 	return (
 		<BlockEditorProvider

--- a/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
@@ -14,6 +14,7 @@ import {
 	__unstableIframe as Iframe,
 	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
 	__experimentalUseResizeCanvas as useResizeCanvas,
+	useSetting,
 	__unstableUseTypingObserver as useTypingObserver,
 } from '@wordpress/block-editor';
 /* eslint-enable @wordpress/no-unsafe-wp-apis */
@@ -37,6 +38,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 		},
 		[ setIsInserterOpen ]
 	);
+	const layout = useSetting( 'layout' );
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor( 'postType', POST_TYPE );
 	const resizedCanvasStyles = useResizeCanvas( deviceType, true );
 	const ref = useMouseMoveTypingReset();
@@ -73,7 +75,10 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					contentRef={ mergedRefs }
 					name="editor-canvas"
 				>
-					<BlockList className="pattern-block-editor__block-list wp-site-blocks" />
+					<BlockList
+						className="pattern-block-editor__block-list wp-site-blocks"
+						__experimentalLayout={ layout }
+					/>
 				</Iframe>
 			</BlockTools>
 		</BlockEditorProvider>

--- a/public_html/wp-content/plugins/pattern-creator/src/components/editor/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/editor/style.scss
@@ -33,7 +33,6 @@ html {
 		display: block;
 		width: 100%;
 		height: 100%;
-		padding-top: 32px;
 		background-color: $white;
 	}
 }

--- a/public_html/wp-content/plugins/pattern-creator/src/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/index.js
@@ -33,16 +33,17 @@ export function reinitializeEditor( target, { postId, ...settings } ) {
 	unmountComponentAtNode( target );
 	const reboot = reinitializeEditor.bind( null, target, settings );
 
+	// Update the store synchronously before rendering so that we won't trigger
+	// unnecessary re-renders with useEffect.
 	dispatch( patternStore ).updateSettings( settings );
-	render( <Editor initialSettings={ settings } onError={ reboot } postId={ postId } />, target );
+	render( <Editor onError={ reboot } postId={ postId } />, target );
 }
 
 /**
  * Initializes the pattern editor screen.
  *
- * @param {string} id              ID of the root element to render the screen in.
- * @param {Object} settings        Editor settings.
- * @param {number} settings.postId ID of the current post.
+ * @param {string} id       ID of the root element to render the screen in.
+ * @param {Object} settings Editor settings.
  */
 export function initialize( id, settings ) {
 	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -136,6 +136,11 @@ function generate_block_editor_styles_html() {
 	wp_styles()->do_items( $handles );
 	wp_styles()->done = $done;
 
+	$block_gap = wp_get_global_styles( array( 'spacing', 'blockGap' ) );
+	$layout = wp_get_global_settings( array( 'layout' ) );
+	$style = gutenberg_get_layout_style( 'body > div', $layout, true, $block_gap );
+	echo '<style>' . $style . '</style>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
 	wp_add_inline_script(
 		'wporg-pattern-script',
 		sprintf(

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -136,6 +136,8 @@ function generate_block_editor_styles_html() {
 	wp_styles()->do_items( $handles );
 	wp_styles()->done = $done;
 
+	// Build up the alignment styles to match the layout set in theme.json.
+	// See https://github.com/WordPress/gutenberg/blob/9d4b83cbbafcd6c6cbd20c86b572f458fc65ff16/lib/block-supports/layout.php#L38
 	$block_gap = wp_get_global_styles( array( 'spacing', 'blockGap' ) );
 	$layout = wp_get_global_settings( array( 'layout' ) );
 	$style = gutenberg_get_layout_style( 'body > div', $layout, true, $block_gap );

--- a/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
@@ -114,17 +114,6 @@ function Iframe(
         max-height: 100%;
         pointer-events: none;
     }
-    body > div > :where(:not(.alignleft):not(.alignright)) {
-        max-width: 800px;
-        margin-left: auto !important;
-        margin-right: auto !important;
-    }
-    body > div > .alignwide { max-width: 1000px;}
-    body > div .alignfull { max-width: none; }
-    body > div .alignleft { float: left; margin-right: 2em; margin-left: 0; }
-    body > div .alignright { float: right; margin-left: 2em; margin-right: 0; }
-    body > div > * { margin-top: 0; margin-bottom: 0; }
-    body > div > * + * { margin-top: 24px;  margin-bottom: 0; }
     </style>`;
 
 	const setRef = useCallback( ( node ) => {

--- a/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
@@ -114,6 +114,17 @@ function Iframe(
         max-height: 100%;
         pointer-events: none;
     }
+    body > div > :where(:not(.alignleft):not(.alignright)) {
+        max-width: 800px;
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
+    body > div > .alignwide { max-width: 1000px;}
+    body > div .alignfull { max-width: none; }
+    body > div .alignleft { float: left; margin-right: 2em; margin-left: 0; }
+    body > div .alignright { float: right; margin-left: 2em; margin-right: 0; }
+    body > div > * { margin-top: 0; margin-bottom: 0; }
+    body > div > * + * { margin-top: 24px;  margin-bottom: 0; }
     </style>`;
 
 	const setRef = useCallback( ( node ) => {

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
@@ -11,7 +11,7 @@ import Iframe from '../iframe';
 import getCardFrameHeight from '../../utils/get-card-frame-height';
 import useInView from '../../hooks/in-view';
 
-const VIEWPORT_WIDTH = 800;
+const VIEWPORT_WIDTH = 1200;
 
 function PatternThumbnail( { className, html } ) {
 	const wrapperRef = useRef();

--- a/public_html/wp-content/themes/pattern-directory/theme.json
+++ b/public_html/wp-content/themes/pattern-directory/theme.json
@@ -4,6 +4,10 @@
         "appearanceTools": true,
         "color": {
             "link": true
+        },
+        "layout": {
+            "contentSize": "800px",
+            "wideSize": "1000px"
         }
     }
 }


### PR DESCRIPTION
This is an assortment of trial and error right now, trying to get the alignment options back onto top-level blocks _and_ working so that default alignment is not edge to edge/full width.

Adding `__experimentalLayout` to `BlockList` & `layout` to `theme.json` enables wide/full alignment & uses the 800px/1000px values:
<img width="390" alt="Screen Shot 2022-03-09 at 6 45 17 PM" src="https://user-images.githubusercontent.com/541093/157558375-a6b7060e-47ca-449d-b710-5160f17c66ac.png">

Align wide behaves as expected:
<img width="1135" alt="Screen Shot 2022-03-09 at 6 42 51 PM" src="https://user-images.githubusercontent.com/541093/157558409-b15911e3-5a55-4a57-a0fa-d0c52e2cc2f8.png">

"None" alignment still displays as full width in the editor _and_ the frontend.
<img width="1140" alt="Screen Shot 2022-03-09 at 6 47 01 PM" src="https://user-images.githubusercontent.com/541093/157558567-f9a7fd2c-f9f2-4de4-a52f-5e96964deefb.png">

The toolbar often overlaps the first block, I'm not sure why, I was hoping figuring out the alignment would also fix whatever style conflict is happening here. Might be related to #422 
<img width="393" alt="Screen Shot 2022-03-09 at 6 49 25 PM" src="https://user-images.githubusercontent.com/541093/157558885-61564d08-cf65-46e0-9114-bd2e74f418e5.png">

@StevenDufresne This is the layout stuff I mentioned in DM - I don't really have anything coherent right now, because it's still not really doing what I want, but if you have any comments I'd appreciate it.
