### PR TITLE
Fix Spinner does not stop when favorites is an empty list

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
@@ -112,7 +112,7 @@ function ContextBar( props ) {
 
 	const spinnerClassName = classnames( {
 		'context-bar__spinner': true,
-		'context-bar__spinner--is-hidden': ! isLoadingPatterns,
+		'context-bar__spinner--is-hidden': ! isLoadingPatterns || props.isEmpty,
 	} );
 
 	return (

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
@@ -55,7 +55,12 @@ const MyFavorites = () => {
 			<QueryMonitor />
 			<div ref={ ref }>
 				{ isLoggedIn && (
-					<PatternGridMenu basePath="/favorites/" query={ query } onNavigation={ onNavigation } />
+					<PatternGridMenu
+						basePath="/favorites/"
+						query={ query }
+						onNavigation={ onNavigation }
+						isEmpty={ isEmpty }
+					/>
 				) }
 			</div>
 			{ ! isLoggedIn || isEmpty ? (


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
If a user didn't add any pattern to its favorite list, when switching to other categories, the loading spinner would keep spinning even if the loading is over.

### Root cause
**Details**
This is the logic that decides whether to stop showing the spinner.
https://github.com/WordPress/pattern-directory/blob/21e69c4986286c8a0db749999b649b58947456b7/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js#L115
Its logic comes from this function:
https://github.com/WordPress/pattern-directory/blob/21e69c4986286c8a0db749999b649b58947456b7/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js#L69
https://github.com/WordPress/pattern-directory/blob/21e69c4986286c8a0db749999b649b58947456b7/public_html/wp-content/themes/pattern-directory/src/store/selectors.js#L20-L24
`isLoading` would always be `true` when the favorites list is empty (i.e., You won't see any patterns under Favorites `All`)
Once there's a pattern in the favorites list, `isLoading` would become `false` (explained later), and the problem is solved then.

The reason `isLoading` is always `true` in this case is that the `queryString` could not be found in `state.patterns.queries`.
Why so? That's because we didn't call `getPatternsByQuery( modifiedQuery )`
https://github.com/WordPress/pattern-directory/blob/21e69c4986286c8a0db749999b649b58947456b7/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js#L37
when the fav list is empty, which causes that the `queryString` isn't stored via dispatching the`loadPatterns`.
And this is also why `isLoading` would become `false` once there's a pattern in the favorites list - the `getPatternsByQuery( modifiedQuery )` is called.
https://github.com/WordPress/pattern-directory/blob/21e69c4986286c8a0db749999b649b58947456b7/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js#L53-L58

So here comes the first solution

**Sol 1** 
Call `getPatternsByQuery( modifiedQuery )` no matter if the `favorites.length===0` or not
```js
const temp = getPatternsByQuery( modifiedQuery );
const posts = favorites.length ? temp : [];
```
However, though it solved the `isLoading` is always `true` problem, it would bring another issue.
Since we don't have any items in the favorites list for the moment, the `include` in `modifiedQuery` would be`[]`, and when this `modifiedQuery` is sent as payload through the `getPatternsByQuery( modifiedQuery )`, the `include=[]` would be filtered out in advance in `addQueryArgs` before sending to the endpoint `'/wp/v2/wporg-pattern'`.
https://github.com/WordPress/pattern-directory/blob/21e69c4986286c8a0db749999b649b58947456b7/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js#L35
https://github.com/WordPress/pattern-directory/blob/21e69c4986286c8a0db749999b649b58947456b7/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js#L48-L49
Usually, for a normal case, it would include something like `include[0]=732` in the payload when sending to that endpoint and gets the response with the pattern data of patternId 732.
And since in the case mentioned above, `include=[]` is filtered out from payload, the endpoint response would still return with `our suggested favorite patterns` for a certain category and the patterns would be stored in `state.patterns.queries`.
<img width="3242" alt="image" src="https://user-images.githubusercontent.com/18050944/157715783-15ef7b90-b790-449e-bb1d-99e0ba4241a7.png">
<img width="3208" alt="image" src="https://user-images.githubusercontent.com/18050944/157715982-3f58c965-23aa-4605-8032-57ed6221a89a.png">
<img width="3238" alt="image" src="https://user-images.githubusercontent.com/18050944/157717895-4ae5baa1-cca0-40e1-a68c-4c016efac4bd.png">
Since there are favorite patterns returned by endpoint and stored into state, it would make the number of patterns in a category wrong.
https://github.com/WordPress/pattern-directory/blob/21e69c4986286c8a0db749999b649b58947456b7/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js#L74
https://github.com/WordPress/pattern-directory/blob/21e69c4986286c8a0db749999b649b58947456b7/public_html/wp-content/themes/pattern-directory/src/store/selectors.js#L60-L63
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/18050944/157718333-0c3ced2a-d4f8-4116-bd03-33b866fba9ad.png">

This issue could be solved by making it still send `include` in payload with value like `[-1]` to make it return `[]`, which is definitely a bad idea and confusing solution that needs some comments. 

Or we can modify the logic of the endpoint and the `addQueryArgs` instead to make it send something legit when `include=[]` from client to the endpoint and have some corresponding process to it. And this is where I found it difficult for the moment to locate where and how the query string params `pattern-categories` and `include` are processed. Might need more studies and some clarifying for my doubts on my side if we choose this solution at the end of the day.

**Sol 2** 
Add a condition check for `query.include` in `isLoadingPatternByQuery`.
![image](https://user-images.githubusercontent.com/18050944/157721415-8777e0e0-cd1a-4bd8-ade0-2237686cbf45.png)
It's not that ideal as it's kind of specifically for a certain case and might need some comments.
But it probably is safe for the moment to my knowledge as the `include=[favorite patternIds]` is only used and included by `MyFavorites`.

**Sol 3** 
[Pass isEmpty as isFavoritesEmpty to ContextBar](https://github.com/WordPress/pattern-directory/commit/960a80353e2b978647645057d30c52d32204bb1e)
It's also not that ideal as far as I'm concerned as it's a bit not clean and consistent.
But the code could speak itself.

<hr>
<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #362 

<!-- Don't forget to update the title with something descriptive. -->

### Screencasts
Before:
https://d.pr/v/pTI4lI
After:
https://d.pr/v/pdkMqt

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Go to Favorites -> All
2. Empty the favorites list
3. Switch to other categories
4. Spinner should not be seen

<!-- If you can, add the appropriate [Component] label(s). -->
