### PR TITLE
Add logging for patterns and flags

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -10,6 +10,7 @@ namespace WordPressdotorg\Pattern_Directory;
 
 require_once __DIR__ . '/includes/class-rest-flags-controller.php';
 require_once __DIR__ . '/includes/class-rest-favorite-controller.php';
+require_once __DIR__ . '/includes/logging.php';
 require_once __DIR__ . '/includes/pattern-post-type.php';
 require_once __DIR__ . '/includes/pattern-flag-post-type.php';
 require_once __DIR__ . '/includes/pattern-validation.php';

--- a/public_html/wp-content/plugins/pattern-directory/includes/logging.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/logging.php
@@ -18,7 +18,7 @@ add_action( 'transition_post_status', __NAMESPACE__ . '\flag_status_change', 10,
  */
 function logging_enabled() {
 	$support       = post_type_supports( PATTERN_POST_TYPE, 'wporg-internal-notes' )
-	                 && post_type_supports( PATTERN_POST_TYPE, 'wporg-log-notes' );
+					&& post_type_supports( PATTERN_POST_TYPE, 'wporg-log-notes' );
 	$callable_func = is_callable( '\\WordPressdotorg\\InternalNotes\\create_note' );
 
 	return $support && $callable_func;
@@ -65,27 +65,27 @@ function flag_status_change( $new_status, $old_status, $post ) {
 	} elseif ( 'new' === $old_status && PENDING_STATUS === $new_status ) {
 		$msg = sprintf(
 			// translators: User name;
-			__( 'New flag submitted by %s', 'wporg' ),
+			__( 'New flag submitted by %s', 'wporg-patterns' ),
 			esc_html( $user_handle ),
 		);
 	} elseif ( PENDING_STATUS === $new_status ) {
 		$msg = sprintf(
 			// translators: 1. User name; 2. Post status;
-			__( 'Flag submitted by %1$s set to %2$s', 'wporg' ),
+			__( 'Flag submitted by %1$s set to %2$s', 'wporg-patterns' ),
 			esc_html( $user_handle ),
 			esc_html( $new->label )
 		);
 	} elseif ( RESOLVED_STATUS === $new_status ) {
 		$msg = sprintf(
 			// translators: 1. User name; 2. Post status;
-			__( 'Flag submitted by %1$s marked as %2$s', 'wporg' ),
+			__( 'Flag submitted by %1$s marked as %2$s', 'wporg-patterns' ),
 			esc_html( $user_handle ),
 			esc_html( $new->label )
 		);
 	} elseif ( 'trash' === $new_status ) {
 		$msg = sprintf(
 			// translators: User name;
-			__( 'Flag submitted by %s moved to trash.', 'wporg' ),
+			__( 'Flag submitted by %s moved to trash.', 'wporg-patterns' ),
 			esc_html( $user_handle )
 		);
 	}

--- a/public_html/wp-content/plugins/pattern-directory/includes/logging.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/logging.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Logging;
+
+use WordPressdotorg\InternalNotes;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN_POST_TYPE;
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\{ PENDING_STATUS, RESOLVED_STATUS, POST_TYPE as FLAG_POST_TYPE };
+
+/**
+ * Actions and filters.
+ */
+add_action( 'transition_post_status', __NAMESPACE__ . '\flag_status_change', 10, 3 );
+
+/**
+ * Check if logging is enabled for patterns.
+ *
+ * @return bool
+ */
+function logging_enabled() {
+	$support       = post_type_supports( PATTERN_POST_TYPE, 'wporg-internal-notes' )
+	                 && post_type_supports( PATTERN_POST_TYPE, 'wporg-log-notes' );
+	$callable_func = is_callable( '\\WordPressdotorg\\InternalNotes\\create_note' );
+
+	return $support && $callable_func;
+}
+
+/**
+ * Add a log entry to a pattern when a flag's status changes.
+ *
+ * @param string   $new_status
+ * @param string   $old_status
+ * @param \WP_Post $post
+ *
+ * @return void
+ */
+function flag_status_change( $new_status, $old_status, $post ) {
+	if ( ! logging_enabled() ) {
+		return;
+	}
+
+	if ( FLAG_POST_TYPE !== get_post_type( $post ) ) {
+		return;
+	}
+
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+
+	$pattern_id = $post->post_parent;
+
+	if ( ! $pattern_id ) {
+		return;
+	}
+
+	$new = get_post_status_object( $new_status );
+	$user = get_user_by( 'id', $post->post_author );
+	$user_handle = sprintf(
+		'@%s',
+		$user->user_login
+	);
+
+	$msg = '';
+	if ( $new_status === $old_status ) {
+		return;
+	} elseif ( 'new' === $old_status && PENDING_STATUS === $new_status ) {
+		$msg = sprintf(
+			// translators: User name;
+			__( 'New flag submitted by %s', 'wporg' ),
+			esc_html( $user_handle ),
+		);
+	} elseif ( PENDING_STATUS === $new_status ) {
+		$msg = sprintf(
+			// translators: 1. User name; 2. Post status;
+			__( 'Flag submitted by %1$s set to %2$s', 'wporg' ),
+			esc_html( $user_handle ),
+			esc_html( $new->label )
+		);
+	} elseif ( RESOLVED_STATUS === $new_status ) {
+		$msg = sprintf(
+			// translators: 1. User name; 2. Post status;
+			__( 'Flag submitted by %1$s marked as %2$s', 'wporg' ),
+			esc_html( $user_handle ),
+			esc_html( $new->label )
+		);
+	} elseif ( 'trash' === $new_status ) {
+		$msg = sprintf(
+			// translators: User name;
+			__( 'Flag submitted by %s moved to trash.', 'wporg' ),
+			esc_html( $user_handle )
+		);
+	}
+
+	if ( $msg ) {
+		$data = array(
+			'post_excerpt' => $msg,
+			'post_type'    => InternalNotes\LOG_POST_TYPE,
+		);
+
+		InternalNotes\create_note( $pattern_id, $data );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -52,7 +52,7 @@ function register_post_type_data() {
 			'show_in_admin_bar'     => false,
 			'show_in_rest'          => true,
 			'rest_controller_class' => '\\WordPressdotorg\\Pattern_Directory\\REST_Flags_Controller',
-			'supports'              => array( 'author', 'excerpt', 'wporg-internal-notes' ),
+			'supports'              => array( 'author', 'excerpt' ),
 			'can_export'            => false,
 			'delete_with_user'      => false,
 		)

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -57,7 +57,7 @@ function register_post_type_data() {
 			'public'          => true,
 			'show_in_rest'    => true,
 			'rewrite'         => array( 'slug' => 'pattern' ),
-			'supports'        => array( 'title', 'editor', 'author', 'custom-fields', 'revisions', 'wporg-internal-notes' ),
+			'supports'        => array( 'title', 'editor', 'author', 'custom-fields', 'revisions', 'wporg-internal-notes', 'wporg-log-notes' ),
 			'capability_type' => array( 'pattern', 'patterns' ),
 			'map_meta_cap'    => true,
 		)


### PR DESCRIPTION
This enables the [new logging feature](https://github.com/WordPress/wporg-internal-notes/pull/9) in the Internal Notes plugin for the Pattern post type, and adds some custom logging for when a pattern gets flagged and when flags are managed by moderators.

This wraps up #57, albeit in a slightly different way than originally imagined. There are probably still some workflow improvements that could be made around reviewing flags, but this is an MVP, and we can iterate once we have a better idea of how pattern moderation is going to play out.

Fixes #57

### Screenshot

<img src="https://user-images.githubusercontent.com/916023/157977673-178a7bb2-904e-4312-a634-30c3de898297.jpg" width="30%" />

### How to test the changes in this Pull Request:

1. Create a new pattern. Then edit the pattern.
2. View the pattern on the front end. Click the "Report this pattern" button and submit a flag.
3. In WP Admin, go to Block Pattern > All Flags. Mark the flag as resolved.
4. Now view the Edit screen in WP Admin for the pattern. Open the Notes sidebar. All of your previous activity should be recorded in log entries.
