### PR TITLE
Bin: Add a script to run spam checks over the patterns

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/bin/check-spam.php
+++ b/public_html/wp-content/plugins/pattern-directory/bin/check-spam.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory;
+
+use function WordPressdotorg\Pattern_Directory\Pattern_Validation\check_for_spam;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, SPAM_STATUS };
+
+// This script should only be called in a CLI environment.
+if ( 'cli' != php_sapi_name() ) {
+	die();
+}
+
+$opts = getopt( '', array( 'post:', 'url:', 'abspath:', 'post_status:', 'per_page:', 'all', 'apply', 'verbose' ) );
+
+if ( empty( $opts['url'] ) ) {
+	$opts['url'] = 'https://wordpress.org/patterns/';
+}
+
+if ( empty( $opts['abspath'] ) && false !== strpos( __DIR__, 'wp-content' ) ) {
+	$opts['abspath'] = substr( __DIR__, 0, strpos( __DIR__, 'wp-content' ) );
+}
+
+$opts['post_status'] = isset( $opts['post_status'] ) ? explode( ',', $opts['post_status'] ) : array( 'publish', 'pending' );
+$opts['apply']       = isset( $opts['apply'] );
+$opts['verbose']     = isset( $opts['verbose'] );
+$opts['all']         = isset( $opts['all'] );
+
+// Bootstrap WordPress
+$_SERVER['HTTP_HOST']   = parse_url( $opts['url'], PHP_URL_HOST );
+$_SERVER['REQUEST_URI'] = parse_url( $opts['url'], PHP_URL_PATH );
+
+require rtrim( $opts['abspath'], '/' ) . '/wp-load.php';
+
+if ( ! $opts['all'] && ! isset( $opts['post'] ) ) {
+	fwrite( STDERR, "Error! Either specify a post ID with --post=<ID> or explicitly run over --all.\n" );
+	die();
+}
+
+if ( ! $opts['apply'] ) {
+	echo "Dry run, will not update any patterns.\n";
+}
+
+$args = array(
+	'post_type' => POST_TYPE,
+	'post_status' => $opts['post_status'],
+	'posts_per_page' => $opts['per_page'] ?: -1,
+	'post_parent' => 0,
+	'orderby' => 'date',
+	'order' => 'DESC',
+);
+if ( isset( $opts['post'] ) ) {
+	$args = array(
+		'post_type' => POST_TYPE,
+		'p' => absint( $opts['post'] ),
+	);
+}
+
+$query = new \WP_Query( $args );
+
+$count_checked = 0;
+$count_spam = 0;
+while ( $query->have_posts() ) {
+	$count_checked++;
+	$query->the_post();
+	$pattern = get_post();
+
+	list( $is_spam, $spam_reason ) = check_for_spam(
+		array(
+			'ID'          => $pattern->ID,
+			'post_name'   => $pattern->post_name,
+			'post_author' => $pattern->post_author,
+			'title'       => $pattern->post_title,
+			'content'     => $pattern->post_content,
+			'description' => $pattern->wpop_description ?: '',
+			'keywords'    => $pattern->wpop_keywords ?: '',
+		)
+	);
+
+	if ( $is_spam ) {
+		$count_spam++;
+
+		if ( $opts['verbose'] ) {
+			echo "{$pattern->ID}: Spam found: $spam_reason\n"; // phpcs:ignore
+		}
+
+		if ( $opts['apply'] ) {
+			wp_update_post(
+				array(
+					'ID' => $pattern->ID,
+					'post_status' => SPAM_STATUS,
+				)
+			);
+			echo "{$pattern->ID}: Post status updated.\n"; // phpcs:ignore
+
+			// Add a note explaining why this post is in pending, if it's due to spam.
+			if ( function_exists( '\WordPressdotorg\InternalNotes\create_note' ) ) {
+				\WordPressdotorg\InternalNotes\create_note(
+					$pattern->ID,
+					array(
+						'post_author'  => get_user_by( 'login', 'wordpressdotorg' )->ID ?? 0,
+						'post_excerpt' => $spam_reason,
+					)
+				);
+			}
+		}
+	} else {
+		if ( $opts['verbose'] ) {
+			echo "{$pattern->ID}: Not spam.\n"; // phpcs:ignore
+		}
+	}
+}
+
+echo "$count_checked patterns checked, $count_spam found to be spam.\n"; // phpcs:ignore

--- a/public_html/wp-content/plugins/pattern-directory/bin/check-spam.php
+++ b/public_html/wp-content/plugins/pattern-directory/bin/check-spam.php
@@ -20,7 +20,7 @@ if ( empty( $opts['abspath'] ) && false !== strpos( __DIR__, 'wp-content' ) ) {
 	$opts['abspath'] = substr( __DIR__, 0, strpos( __DIR__, 'wp-content' ) );
 }
 
-$opts['post_status'] = isset( $opts['post_status'] ) ? explode( ',', $opts['post_status'] ) : array( 'publish', 'pending' );
+$opts['post_status'] = isset( $opts['post_status'] ) ? explode( ',', $opts['post_status'] ) : array( 'pending' );
 $opts['apply']       = isset( $opts['apply'] );
 $opts['verbose']     = isset( $opts['verbose'] );
 $opts['all']         = isset( $opts['all'] );


### PR DESCRIPTION
For a little while, patterns that were submitted as pending were not getting the spam checks applied. I wanted to quickly check the handful of patterns that were submitted, but there's no easy way to manually run the spam check. This adds a bin script (so it requires a sandbox) to run the checks over all patterns, with a few query params.

For example, to run over all draft patterns:

```
$ php ./bin/check-spam.php --all --post_status=draft
Dry run, will not update any patterns.
19 patterns checked, 3 found to be spam.
```

That command won't make any changes, it just reports totals. Adding `--verbose` gives more details:

```
$ php ./bin/check-spam.php --all --post_status=draft --verbose
Dry run, will not update any patterns.
1: Not spam.
2: Not spam.
3: Spam found: Only contains Paragraph blocks.
...
19 patterns checked, 3 found to be spam.
```

Still no changes. To update the status & flag as possible spam, run with `--apply`:

```
$ php ./bin/check-spam.php --all --post_status=draft --verbose
Dry run, will not update any patterns.
1: Not spam.
2: Not spam.
3: Spam found: Only contains Paragraph blocks.
3: Post status updated.
...
19 patterns checked, 3 found to be spam.
```

Other possible arguments are `--post=<ID>` (instead of `--all`, will override it), or `--per_page=<count>`.

### How to test the changes in this Pull Request:

1. Run the script
2. It should correctly detect spam based on the validation
3. If you apply the changes, it should update the status of any spammy pattern
4. Try submitting a spam pattern via the editor (use the keyword `PatternDirectorySpamTest`) 
5. It should still flag that as spam
