### PR TITLE
Pattern moderation: Store unlisted reason as tax term instead of postmeta

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
@@ -528,18 +528,17 @@ function handle_bulk_actions( $sendback, $doaction, $post_ids ) {
 			break;
 		case 'unlist':
 			$post_data['_status'] = UNLISTED_STATUS;
+
+			$reason_term = get_term_by( 'slug', '4-spam', FLAG_REASON );
+			if ( $reason_term ) {
+				$post_data['tax_input'] = array(
+					FLAG_REASON => $reason_term->term_id,
+				);
+			}
 			break;
 	}
 
 	$result = bulk_edit_posts( $post_data );
-	if ( 'unlist' === $doaction ) {
-		$reason_term = get_term_by( 'slug', '4-spam', FLAG_REASON );
-		if ( $reason_term ) {
-			foreach ( $result['updated'] as $post_id ) {
-				update_post_meta( $post_id, 'wpop_unlisted_reason', $reason_term->term_id );
-			}
-		}
-	}
 
 	if ( is_array( $result ) ) {
 		$result['updated'] = count( $result['updated'] );

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
@@ -532,7 +532,7 @@ function handle_bulk_actions( $sendback, $doaction, $post_ids ) {
 			$reason_term = get_term_by( 'slug', '4-spam', FLAG_REASON );
 			if ( $reason_term ) {
 				$post_data['tax_input'] = array(
-					FLAG_REASON => $reason_term->term_id,
+					FLAG_REASON => array( $reason_term->term_id ),
 				);
 			}
 			break;

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -82,7 +82,7 @@ function register_post_type_data() {
 
 	register_taxonomy(
 		TAX_TYPE,
-		POST_TYPE,
+		array( POST_TYPE, PATTERN ), // The taxonomy will also get applied to patterns when they get unlisted.
 		array(
 			'labels'             => $taxonomy_labels,
 			'description'        => 'Flag reason indicates why a flag was added to a pattern.',

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -432,8 +432,8 @@ function register_post_statuses() {
 /**
  * Do things when certain status transitions happen.
  *
- * @param string $new_status
- * @param string $old_status
+ * @param string   $new_status
+ * @param string   $old_status
  * @param \WP_Post $post
  *
  * @return void

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -5,7 +5,7 @@ namespace WordPressdotorg\Pattern_Directory\Pattern_Post_Type;
 use Error, WP_Block_Type_Registry;
 use function WordPressdotorg\Locales\{ get_locales, get_locales_with_english_names, get_locales_with_native_names };
 use function WordPressdotorg\Pattern_Directory\Favorite\get_favorite_count;
-use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\TAX_TYPE;
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\TAX_TYPE as FLAG_REASON;
 
 const POST_TYPE       = 'wporg-pattern';
 const UNLISTED_STATUS = 'unlisted';
@@ -444,8 +444,8 @@ function status_transitions( $new_status, $old_status, $post ) {
 	}
 
 	// If a pattern gets relisted, remove the reason that it was originally unlisted.
-	if ( UNLISTED_STATUS === $old_status && in_array( $new_status, array( 'publish', 'pending' ), true ) ) {
-		wp_delete_object_term_relationships( $post->ID, array( TAX_TYPE ) );
+	if ( UNLISTED_STATUS === $old_status && UNLISTED_STATUS !== $new_status ) {
+		wp_delete_object_term_relationships( $post->ID, array( FLAG_REASON ) );
 	}
 }
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -5,6 +5,7 @@ namespace WordPressdotorg\Pattern_Directory\Pattern_Post_Type;
 use Error, WP_Block_Type_Registry;
 use function WordPressdotorg\Locales\{ get_locales, get_locales_with_english_names, get_locales_with_native_names };
 use function WordPressdotorg\Pattern_Directory\Favorite\get_favorite_count;
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\TAX_TYPE;
 
 const POST_TYPE       = 'wporg-pattern';
 const UNLISTED_STATUS = 'unlisted';
@@ -13,6 +14,7 @@ const SPAM_STATUS     = 'pending-review';
 add_action( 'init', __NAMESPACE__ . '\register_post_type_data' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_fields' );
 add_action( 'init', __NAMESPACE__ . '\register_post_statuses' );
+add_action( 'transition_post_status', __NAMESPACE__ . '\status_transitions', 10, 3 );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_assets' );
 add_filter( 'allowed_block_types_all', __NAMESPACE__ . '\remove_disallowed_blocks', 10, 2 );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\disable_block_directory', 0 );
@@ -425,6 +427,26 @@ function register_post_statuses() {
 			'show_in_admin_all_list' => true,
 		)
 	);
+}
+
+/**
+ * Do things when certain status transitions happen.
+ *
+ * @param string $new_status
+ * @param string $old_status
+ * @param \WP_Post $post
+ *
+ * @return void
+ */
+function status_transitions( $new_status, $old_status, $post ) {
+	if ( POST_TYPE !== get_post_type( $post ) ) {
+		return;
+	}
+
+	// If a pattern gets relisted, remove the reason that it was originally unlisted.
+	if ( UNLISTED_STATUS === $old_status && in_array( $new_status, array( 'publish', 'pending' ), true ) ) {
+		wp_delete_object_term_relationships( $post->ID, array( TAX_TYPE ) );
+	}
 }
 
 /**

--- a/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/index.js
+++ b/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/index.js
@@ -26,9 +26,7 @@ export const UnlistButton = () => {
 	const onSubmit = ( reasonId ) => {
 		editPost( {
 			status: UNLISTED_STATUS,
-			meta: {
-				wpop_unlisted_reason: reasonId,
-			},
+			'wporg-pattern-flag-reason': [ reasonId ],
 		} );
 		savePost();
 	};

--- a/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/utils.js
+++ b/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/utils.js
@@ -22,7 +22,7 @@ export const getUnlistedReasons = ( { onSuccess = noop, onFailure = noop } ) => 
 							return 0;
 					}
 				} )
-				.map( ( i ) => ( { label: i.name, value: i.slug } ) );
+				.map( ( i ) => ( { label: i.name, value: i.id + '' } ) ); // `value` must be a string.
 			onSuccess( reasonList );
 		} )
 		.catch( onFailure );

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
@@ -158,7 +158,7 @@ export default function ( { pattern } ) {
 							</p>
 							<p>
 								{ __(
-									'You can update your pattern to resubmitt it for approval at any time.',
+									'You can update your pattern to resubmit it for approval at any time.',
 									'wporg-patterns'
 								) }
 							</p>


### PR DESCRIPTION
Changes how a reason for unlisting a pattern is stored, from postmeta to taxonomy term, using the same registered taxonomy that the Pattern Flag post type uses.

Fixes #446 

### How to test the changes in this Pull Request:

1. Edit a pattern in WP Admin. There should now be a sidebar section for the Flag Reasons taxonomy.
2. Unlist the pattern and fill out the modal form. Upon completing the form, the chosen reason should get a check next to it in the Flag Reasons section of the sidebar.
3. (If you try to re-publish the pattern here, you might get an error saying the status must be set to `pending-review`. After refreshing, the pattern will indeed be set to spam instead of publish. Haven't figured this out yet.)
4. From the Patterns list table, try unlisting one or more patterns using the row actions or bulk edit. Afterward, if you edit one of those patterns, the Flag Reason should be set to spam.

