### PR TITLE
Send email notifications to pattern authors when certain status changes happen

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -18,3 +18,4 @@ require_once __DIR__ . '/includes/search.php';
 require_once __DIR__ . '/includes/favorite.php';
 require_once __DIR__ . '/includes/stats.php';
 require_once __DIR__ . '/includes/admin.php';
+require_once __DIR__ . '/includes/notifications.php';

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -15,8 +15,8 @@ add_action( 'transition_post_status', __NAMESPACE__ . '\monitor_post_status_tran
 /**
  * Hook into post status transitions to detect changes that warrant a notification.
  *
- * @param string $new_status
- * @param string $old_status
+ * @param string   $new_status
+ * @param string   $old_status
  * @param \WP_Post $post
  *
  * @return void
@@ -195,7 +195,15 @@ If you would like to resubmit your pattern, please make sure it follows the guid
 	send_email( $email, $subject, $message );
 }
 
-
+/**
+ * Wrapper for wp_mail.
+ *
+ * @param string $to
+ * @param string $subject
+ * @param string $message
+ *
+ * @return void
+ */
 function send_email( $to, $subject, $message ) {
 	$message = html_entity_decode( $message );
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -2,6 +2,7 @@
 
 namespace WordPressdotorg\Pattern_Directory\Notifications;
 
+use function WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\get_default_reason_description;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE as PATTERN, UNLISTED_STATUS, SPAM_STATUS };
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\{ POST_TYPE as FLAG, TAX_TYPE as REASON, PENDING_STATUS };
 
@@ -103,13 +104,14 @@ function notify_pattern_flagged( $post ) {
 		switch_to_locale( $locale );
 	}
 
-	$reasons = array();
 	$flags = get_posts( array(
 		'post_type' => FLAG,
 		'post_parent' => $post->ID,
 		'post_status' => PENDING_STATUS,
 	) );
+	$reason = '';
 	if ( ! empty( $flags ) ) {
+		$reasons = array();
 		foreach ( $flags as $flag ) {
 			$terms = get_the_terms( $flag, REASON );
 			if ( is_array( $terms ) ) {
@@ -118,16 +120,20 @@ function notify_pattern_flagged( $post ) {
 		}
 		$reasons = array_map(
 			function( \WP_Term $reason ) {
-				return $reason->name;
+				return wp_strip_all_tags( $reason->description );
 			},
 			$reasons
 		);
 		$reasons = array_unique( $reasons );
-		// translators: used between list items, there is a space after the comma.
-		$reasons = implode( __( ', ', 'wporg-patterns' ), $reasons );
+		$reason = trim( implode( "\n", $reasons ) );
 	} else {
 		// If it doesn't have flags, it must have gotten here by getting marked as spam.
-		$reasons = __( 'Spam', 'wporg-patterns' );
+		$spam_term = get_term_by( 'slug', '4-spam' );
+		$reason = wp_strip_all_tags( $spam_term->description );
+	}
+
+	if ( ! $reason ) {
+		$reason = get_default_reason_description();
 	}
 
 	$subject = esc_html__( 'Pattern being reviewed', 'wporg-patterns' );
@@ -142,7 +148,7 @@ Thanks for submitting your pattern. Unfortunately, your pattern, %1$s, has been 
 
 Your pattern has been unpublished from the Block Pattern Directory at this time, and will receive further review. If the pattern meets the guidelines, we will re-publish it to the Block Pattern Directory. Thanks for your patience with us volunteer reviewers!', 'wporg-patterns' ),
 		esc_html( html_entity_decode( $pattern_title ) ),
-		esc_html( html_entity_decode( $reasons ) )
+		esc_html( html_entity_decode( $reason ) )
 	);
 
 	if ( $locale ) {
@@ -171,11 +177,14 @@ function notify_pattern_unlisted( $post ) {
 	$pattern_title = get_the_title( $post );
 
 	$reasons = get_the_terms( $post, REASON );
+	$reason = '';
 	if ( ! empty( $reasons ) ) {
 		$reason_term = reset( $reasons );
-		$reason = $reason_term->name;
-	} else {
-		$reason = __( 'Other', 'wporg-patterns' );
+		$reason = wp_strip_all_tags( $reason_term->description );
+	}
+
+	if ( ! $reason ) {
+		$reason = get_default_reason_description();
 	}
 
 	if ( $locale ) {

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -226,7 +226,7 @@ If you would like to resubmit your pattern, please make sure it follows the guid
  * @return void
  */
 function send_email( $to, $subject, $message ) {
-	$message = html_entity_decode( $message );
+	$message = html_entity_decode( $message, ENT_QUOTES );
 
 	wp_mail(
 		$to,

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -176,6 +176,10 @@ function notify_pattern_unlisted( $post ) {
 
 	$pattern_title = get_the_title( $post );
 
+	if ( $locale ) {
+		switch_to_locale( $locale );
+	}
+
 	$reasons = get_the_terms( $post, REASON );
 	$reason = '';
 	if ( ! empty( $reasons ) ) {
@@ -185,10 +189,6 @@ function notify_pattern_unlisted( $post ) {
 
 	if ( ! $reason ) {
 		$reason = get_default_reason_description();
-	}
-
-	if ( $locale ) {
-		switch_to_locale( $locale );
 	}
 
 	$subject = esc_html__( 'Pattern unlisted', 'wporg-patterns' );

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -27,7 +27,11 @@ function monitor_post_status_transitions( $new_status, $old_status, $post ) {
 		return;
 	}
 
-	if ( 'publish' === $new_status && in_array( $old_status, array( 'pending', SPAM_STATUS ) ) ) {
+	if ( $new_status === $old_status ) {
+		return;
+	}
+
+	if ( 'publish' === $new_status && in_array( $old_status, array( 'pending', SPAM_STATUS, UNLISTED_STATUS ) ) ) {
 		notify_pattern_approved( $post );
 	} elseif (
 		SPAM_STATUS === $new_status

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -47,6 +47,10 @@ function monitor_post_status_transitions( $new_status, $old_status, $post ) {
  */
 function notify_pattern_approved( $post ) {
 	$author = get_user_by( 'id', $post->post_author );
+	if ( ! $author ) {
+		return;
+	}
+
 	$email  = $author->user_email;
 	$locale = get_user_locale( $author );
 
@@ -86,6 +90,10 @@ Thank you for submitting your pattern, %1$s. It is now live in the Block Pattern
  */
 function notify_pattern_flagged( $post ) {
 	$author = get_user_by( 'id', $post->post_author );
+	if ( ! $author ) {
+		return;
+	}
+
 	$email  = $author->user_email;
 	$locale = get_user_locale( $author );
 
@@ -153,6 +161,10 @@ Your pattern has been unpublished from the Block Pattern Directory at this time,
  */
 function notify_pattern_unlisted( $post ) {
 	$author = get_user_by( 'id', $post->post_author );
+	if ( ! $author ) {
+		return;
+	}
+
 	$email  = $author->user_email;
 	$locale = get_user_locale( $author );
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -128,7 +128,7 @@ function notify_pattern_flagged( $post ) {
 		$reason = trim( implode( "\n", $reasons ) );
 	} else {
 		// If it doesn't have flags, it must have gotten here by getting marked as spam.
-		$spam_term = get_term_by( 'slug', '4-spam' );
+		$spam_term = get_term_by( 'slug', '4-spam', REASON );
 		$reason = wp_strip_all_tags( $spam_term->description );
 	}
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -206,7 +206,7 @@ If you would like to resubmit your pattern, please make sure it follows the guid
 %3$s', 'wporg-patterns' ),
 		esc_html( html_entity_decode( $pattern_title ) ),
 		esc_html( html_entity_decode( $reason ) ),
-		'https://wordpress.org/patterns/' // TODO: get the actual URL.
+		'https://wordpress.org/patterns/about/'
 	);
 
 	if ( $locale ) {

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace WordPressdotorg\Pattern_Directory\Notifications;
+
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE as PATTERN, UNLISTED_STATUS, SPAM_STATUS };
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\{ POST_TYPE as FLAG, TAX_TYPE as REASON, PENDING_STATUS };
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_action( 'transition_post_status', __NAMESPACE__ . '\monitor_post_status_transitions', 20, 3 );
+
+/**
+ * Hook into post status transitions to detect changes that warrant a notification.
+ *
+ * @param string $new_status
+ * @param string $old_status
+ * @param \WP_Post $post
+ *
+ * @return void
+ */
+function monitor_post_status_transitions( $new_status, $old_status, $post ) {
+	if ( PATTERN !== get_post_type( $post ) ) {
+		return;
+	}
+
+	if ( 'publish' === $new_status && in_array( $old_status, array( 'pending', SPAM_STATUS ) ) ) {
+		notify_pattern_approved( $post );
+	} elseif (
+		SPAM_STATUS === $new_status
+		|| ( 'pending' === $new_status && 'publish' === $old_status )
+	) {
+		notify_pattern_flagged( $post );
+	} elseif ( UNLISTED_STATUS === $new_status ) {
+		notify_pattern_unlisted( $post );
+	}
+}
+
+/**
+ * Notify when a pattern has been approved.
+ *
+ * @param \WP_Post $post
+ *
+ * @return void
+ */
+function notify_pattern_approved( $post ) {
+	$author = get_user_by( 'id', $post->post_author );
+	$email  = $author->user_email;
+	$locale = get_user_locale( $author );
+
+	$pattern_title = get_the_title( $post );
+	$pattern_url = get_permalink( $post );
+
+	if ( $locale ) {
+		switch_to_locale( $locale );
+	}
+
+	$subject = esc_html__( 'Pattern published', 'wporg-patterns' );
+
+	$message = sprintf(
+		// translators: Plaintext email message. Note the line breaks. 1. Pattern title; 2. Pattern URL;
+		esc_html__( 'Hello!
+
+Thank you for submitting your pattern, %1$s. It is now live in the Block Pattern Directory!
+
+%2$s', 'wporg-patterns' ),
+		esc_html( html_entity_decode( $pattern_title ) ),
+		esc_url_raw( $pattern_url )
+	);
+
+	if ( $locale ) {
+		restore_current_locale();
+	}
+
+	send_email( $email, $subject, $message );
+}
+
+/**
+ * Notify when a pattern has been unpublished for review.
+ *
+ * @param \WP_Post $post
+ *
+ * @return void
+ */
+function notify_pattern_flagged( $post ) {
+	$author = get_user_by( 'id', $post->post_author );
+	$email  = $author->user_email;
+	$locale = get_user_locale( $author );
+
+	$pattern_title = get_the_title( $post );
+
+	if ( $locale ) {
+		switch_to_locale( $locale );
+	}
+
+	$reasons = array();
+	$flags = get_posts( array(
+		'post_type' => FLAG,
+		'post_parent' => $post->ID,
+		'post_status' => PENDING_STATUS,
+	) );
+	if ( ! empty( $flags ) ) {
+		foreach ( $flags as $flag ) {
+			$terms = get_the_terms( $flag, REASON );
+			if ( is_array( $terms ) ) {
+				$reasons += $terms;
+			}
+		}
+		$reasons = array_map(
+			function( \WP_Term $reason ) {
+				return $reason->name;
+			},
+			$reasons
+		);
+		$reasons = array_unique( $reasons );
+		// translators: used between list items, there is a space after the comma.
+		$reasons = implode( __( ', ', 'wporg-patterns' ), $reasons );
+	} else {
+		// If it doesn't have flags, it must have gotten here by getting marked as spam.
+		$reasons = __( 'Spam', 'wporg-patterns' );
+	}
+
+	$subject = esc_html__( 'Pattern being reviewed', 'wporg-patterns' );
+
+	$message = sprintf(
+		// translators: Plaintext email message. Note the line breaks. 1. Pattern title; 2. Pattern URL;
+		esc_html__( 'Hi there!
+
+Thanks for submitting your pattern. Unfortunately, your pattern, %1$s, has been flagged for review due to the following reason(s):
+
+%2$s
+
+Your pattern has been unpublished from the Block Pattern Directory at this time, and will receive further review. If the pattern meets the guidelines, we will re-publish it to the Block Pattern Directory. Thanks for your patience with us volunteer reviewers!', 'wporg-patterns' ),
+		esc_html( html_entity_decode( $pattern_title ) ),
+		esc_html( html_entity_decode( $reasons ) )
+	);
+
+	if ( $locale ) {
+		restore_current_locale();
+	}
+
+	send_email( $email, $subject, $message );
+}
+
+/**
+ * Notify when a pattern has been unlisted.
+ *
+ * @param \WP_Post $post
+ *
+ * @return void
+ */
+function notify_pattern_unlisted( $post ) {
+	$author = get_user_by( 'id', $post->post_author );
+	$email  = $author->user_email;
+	$locale = get_user_locale( $author );
+
+	$pattern_title = get_the_title( $post );
+
+	$reasons = get_the_terms( $post, REASON );
+	if ( ! empty( $reasons ) ) {
+		$reason_term = reset( $reasons );
+		$reason = $reason_term->name;
+	} else {
+		$reason = __( 'Other', 'wporg-patterns' );
+	}
+
+	if ( $locale ) {
+		switch_to_locale( $locale );
+	}
+
+	$subject = esc_html__( 'Pattern unlisted', 'wporg-patterns' );
+
+	$message = sprintf(
+		// translators: Plaintext email message. Note the line breaks. 1. Pattern title; 2. Pattern URL;
+		esc_html__( 'Hello,
+
+Your pattern, %1$s, has been unlisted from the Block Pattern Directory due to the following reason:
+
+%2$s
+
+If you would like to resubmit your pattern, please make sure it follows the guidelines:
+
+%3$s', 'wporg-patterns' ),
+		esc_html( html_entity_decode( $pattern_title ) ),
+		esc_html( html_entity_decode( $reason ) ),
+		'https://wordpress.org/patterns/' // TODO: get the actual URL.
+	);
+
+	if ( $locale ) {
+		restore_current_locale();
+	}
+
+	send_email( $email, $subject, $message );
+}
+
+
+function send_email( $to, $subject, $message ) {
+	$message = html_entity_decode( $message );
+
+	wp_mail(
+		$to,
+		$subject,
+		$message,
+		array(
+			'From: WordPress Pattern Directory <noreply@wordpress.org>',
+			'Reply-To: <themes@wordpress.org>',
+		)
+	);
+}
+
+
+

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -75,7 +75,7 @@ function notify_pattern_approved( $post ) {
 Thank you for submitting your pattern, %1$s. It is now live in the Block Pattern Directory!
 
 %2$s', 'wporg-patterns' ),
-		esc_html( html_entity_decode( $pattern_title ) ),
+		esc_html( $pattern_title ),
 		esc_url_raw( $pattern_url )
 	);
 
@@ -151,8 +151,8 @@ Thanks for submitting your pattern. Unfortunately, your pattern, %1$s, has been 
 %2$s
 
 Your pattern has been unpublished from the Block Pattern Directory at this time, and will receive further review. If the pattern meets the guidelines, we will re-publish it to the Block Pattern Directory. Thanks for your patience with us volunteer reviewers!', 'wporg-patterns' ),
-		esc_html( html_entity_decode( $pattern_title ) ),
-		esc_html( html_entity_decode( $reason ) )
+		esc_html( $pattern_title ),
+		esc_html( $reason )
 	);
 
 	if ( $locale ) {
@@ -208,8 +208,8 @@ Your pattern, %1$s, has been unlisted from the Block Pattern Directory due to th
 If you would like to resubmit your pattern, please make sure it follows the guidelines:
 
 %3$s', 'wporg-patterns' ),
-		esc_html( html_entity_decode( $pattern_title ) ),
-		esc_html( html_entity_decode( $reason ) ),
+		esc_html( $pattern_title ),
+		esc_html( $reason ),
 		'https://wordpress.org/patterns/about/'
 	);
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -112,6 +112,15 @@ function register_post_type_data() {
 }
 
 /**
+ * If a pattern or flag doesn't have a reason term added, but needs to show a reason description.
+ *
+ * @return string
+ */
+function get_default_reason_description() {
+	return __( "This pattern doesn't meet the guidelines for the pattern directory.", 'wporg-patterns' );
+}
+
+/**
  * Automatically unpublish a pattern if it receives a certain number of flags.
  *
  * @param int     $post_ID


### PR DESCRIPTION
Hooks into `transition_post_status` to detect when pattern status changes happen, which will mostly be due to moderators and flags.

Fixes #58 

### How to test the changes in this Pull Request:

1. Upload this changeset to your wporg sandbox so you can test whether the emails actually get sent.
2. Create a test pattern.
3. If it's clearly test content, it might get immediately marked as spam (like mine did). In which case you should receive an email telling you as much.
4. From the Patterns list table, try switching the pattern's status between publish / spam / unlisted. Each time you should get an email.
