### PR TITLE
My Pattern: Display the reason on unlisted patterns

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -229,23 +229,6 @@ function register_post_type_data() {
 			),
 		)
 	);
-
-	register_post_meta(
-		POST_TYPE,
-		'wpop_unlisted_reason',
-		array(
-			'type'              => 'string',
-			'description'       => 'The ID of a flag reason, used to indicate why a pattern was unlisted.',
-			'single'            => true,
-			'sanitize_callback' => 'sanitize_text_field',
-			'auth_callback'     => __NAMESPACE__ . '\can_edit_this_pattern',
-			'show_in_rest'      => array(
-				'schema' => array(
-					'type'     => 'string',
-				),
-			),
-		)
-	);
 }
 
 /**

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -388,6 +388,44 @@ function register_rest_fields() {
 			),
 		)
 	);
+
+	register_rest_field(
+		POST_TYPE,
+		'unlisted_reason',
+		array(
+			'get_callback' => function() {
+				$reasons = wp_get_object_terms( get_the_ID(), FLAG_REASON );
+				if ( count( $reasons ) > 0 ) {
+					$reason = array_shift( $reasons );
+					return array(
+						'term_id' => absint( $reason->term_id ),
+						'name' => esc_attr( $reason->name ),
+						'slug' => esc_attr( $reason->slug ),
+						'description' => wp_kses_post( $reason->description ),
+					);
+				}
+
+				return array();
+			},
+			'schema' => array(
+				'type'  => 'object',
+				'properties' => array(
+					'term_id' => array(
+						'type'  => 'number',
+					),
+					'name' => array(
+						'type'  => 'string',
+					),
+					'slug' => array(
+						'type'  => 'string',
+					),
+					'description' => array(
+						'type'  => 'string',
+					),
+				),
+			),
+		)
+	);
 }
 
 /**

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
@@ -139,7 +139,7 @@ export default function ( { pattern } ) {
 										__html:
 											pattern.unlisted_reason?.description ||
 											__(
-												'Additional review has been requested for this pattern.',
+												"This pattern doesn't meet the guidelines for the pattern directory.",
 												'wporg-patterns'
 											),
 									} }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern/status-notice.js
@@ -5,26 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { Modal, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
-function getUnlistedReason( pattern ) {
-	const reasonSlug = pattern.meta.wpop_unlisted_reason || '';
-	switch ( reasonSlug ) {
-		case '1-inappropriate':
-			return __(
-				'This pattern contains content deemed inappropriate for a general audience.',
-				'wporg-patterns'
-			);
-		case '2-copyright':
-			return __(
-				'This pattern contains copyrighted material or uses a trademark without permission.',
-				'wporg-patterns'
-			);
-		case '3-broken':
-			return __( 'This pattern is broken or does not display correctly.', 'wporg-patterns' );
-		default:
-			return __( 'Additional review has been requested for this pattern.', 'wporg-patterns' );
-	}
-}
-
 export default function ( { pattern } ) {
 	const [ showModal, setShowModal ] = useState( false );
 	const openModal = () => setShowModal( true );
@@ -154,7 +134,16 @@ export default function ( { pattern } ) {
 								) }
 							</p>
 							<p>
-								<em>{ getUnlistedReason( pattern ) }</em>
+								<em
+									dangerouslySetInnerHTML={ {
+										__html:
+											pattern.unlisted_reason?.description ||
+											__(
+												'Additional review has been requested for this pattern.',
+												'wporg-patterns'
+											),
+									} }
+								/>
 							</p>
 							<p>
 								{ __(


### PR DESCRIPTION
This updates the unlisted modal to display the "reason" description on unlisted patterns. I've copied the existing strings into the terms on w.org/patterns and my local environment:

<img width="727" alt="Screen Shot 2022-03-22 at 1 44 50 PM" src="https://user-images.githubusercontent.com/541093/159543064-0accf84b-dc97-4028-a595-6f19c7a04692.png">

Fixes #437.

I also removed the meta registration for `wpop_unlisted_reason`, as this is not used anymore.

### Screenshots

Not in English:
<img width="400" alt="" src="https://user-images.githubusercontent.com/541093/159542506-598a9cd5-fdf3-4fe5-b1ad-6e2e6acd36af.png">

Spam:
<img width="406" alt="" src="https://user-images.githubusercontent.com/541093/159542507-f2cd048d-4b32-44ad-99ee-ab444461e958.png">

No reason set:
<img width="421" alt="" src="https://user-images.githubusercontent.com/541093/159542508-d6509521-58f6-4303-8d93-4e5a52e6acfe.png">

### How to test the changes in this Pull Request:

0. Add the reason strings to the term descriptions
1. Make sure you have some unlisted patterns with the tax term set — this command is helpful: `yarn wp-env run cli "post term set [POST_ID] wporg-pattern-flag-reason 2-copyright"`
2. View an unlisted pattern that you're author of
3. See the red notice, click the Learn more button
4. The modal should contain 3 paragraphs, the middle italicized one should be the term description
