### PR TITLE
Validation: Avoid status validation if the user is a moderator or admin

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -190,6 +190,11 @@ function validate_status( $prepared_post, $request ) {
 		return $prepared_post;
 	}
 
+	// Skip validation if the user is a moderator.
+	if ( current_user_can( $post_type->cap->edit_others_posts ) ) {
+		return $prepared_post;
+	}
+
 	$default_status = get_option( 'wporg-pattern-default_status', 'publish' );
 	$valid_states   = array_unique( array( 'pending', SPAM_STATUS, $default_status ) );
 
@@ -206,11 +211,7 @@ function validate_status( $prepared_post, $request ) {
 	}
 
 	// Do not allow for non-privledged users to move a spam post to another status.
-	if (
-		SPAM_STATUS === $current_status &&
-		SPAM_STATUS !== $target_status &&
-		! current_user_can( $post_type->cap->edit_others_patterns )
-	) {
+	if ( SPAM_STATUS === $current_status && SPAM_STATUS !== $target_status ) {
 		return new \WP_Error(
 			'rest_pattern_invalid_status',
 			sprintf(


### PR DESCRIPTION
Fixes #450 — Skip the status validation entirely if the user can edit others' posts (patterns). This will allow moderators to publish patterns regardless of the setting for "Default status of new patterns".

### How to test the changes in this Pull Request:

With an editor or admin user…

1. Set the default status to "pending"
2. Try to publish an unlisted pattern from within wp-admin
3. The pattern should correctly be set to "publish" with no error

With a subscriber…

1. Submit a new pattern
2. It should submit as the expected default status
3. Try to change it via an API request, it should fail with the validation error
