### PR TITLE
Fix the missing locale name in title

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -4,6 +4,7 @@ namespace WordPressdotorg\Pattern_Directory\Theme;
 
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG_POST_TYPE;
+use function WordPressdotorg\MU_Plugins\Global_Header_Footer\{ is_rosetta_site, get_rosetta_name };
 
 require_once __DIR__ . '/includes/inline-styles.php';
 
@@ -80,7 +81,13 @@ function enqueue_assets() {
 
 		wp_add_inline_script(
 			'wporg-pattern-script',
-			sprintf( "var wporgLocale = '%s';", wp_json_encode( get_locale() ) ),
+			sprintf(
+				"var wporgLocale = JSON.parse( decodeURIComponent( '%s' ) )",
+				rawurlencode( wp_json_encode( array(
+					'id' => get_locale(),
+					'displayName' => is_rosetta_site() ? get_rosetta_name() : '',
+				) ) ),
+			),
 			'before'
 		);
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/document-title-monitor/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/document-title-monitor/index.js
@@ -48,7 +48,7 @@ const DocumentTitleMonitor = () => {
 			);
 		}
 
-		parts.push( __( 'WordPress.org', 'wporg-patterns' ) );
+		parts.push( __( 'WordPress.org', 'wporg-patterns' ) + ` ${ wporgLocale.displayName }` );
 		return parts.join( ' | ' );
 	} );
 

--- a/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/resolvers.js
@@ -46,7 +46,7 @@ export function* getPatternsByQuery( query ) {
 	try {
 		yield fetchPatterns( queryString );
 		const response = yield apiFetch( {
-			path: addQueryArgs( '/wp/v2/wporg-pattern', { ...query, locale: JSON.parse( wporgLocale ) } ),
+			path: addQueryArgs( '/wp/v2/wporg-pattern', { ...query, locale: wporgLocale.id } ),
 			parse: false,
 		} );
 		const { total, totalPages, results } = yield __unstableAwaitPromise( parseResponse( response ) );

--- a/public_html/wp-content/themes/pattern-directory/src/store/test/resolvers.js
+++ b/public_html/wp-content/themes/pattern-directory/src/store/test/resolvers.js
@@ -7,7 +7,7 @@ import apiPatternFlagReasons from './fixtures/pattern-flag-reasons';
 import { getCategories, getFavorites, getPattern, getPatternFlagReasons, getPatternsByQuery } from '../resolvers';
 
 // Set up the global.
-global.wporgLocale = '"en_US"';
+global.wporgLocale = { id: 'en_US' };
 
 describe( 'getPatternsByQuery', () => {
 	it( 'yields with the requested patterns & query meta', async () => {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR
1. Restructure `wporgLocale` to include more locale info:
    a. locale base id
    b. locale display name
2. Fix the logic affected by the restruction
3. Add functions to get the rosetta name (locale display name)

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #404 

<!-- List out anyone who helped with this task. -->


<!-- Don't forget to update the title with something descriptive. -->

### Screencasts
Before:
https://d.pr/v/466P0M
After:
https://d.pr/v/2SsuBI

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Go to any rosetta site
2. Open Chrome devTools
3. Search for <title>
4. Check if the locale name is appended

<!-- If you can, add the appropriate [Component] label(s). -->
