### PR TITLE
Use alternate source for embedding author data in internal notes

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/logging.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/logging.php
@@ -23,8 +23,8 @@ add_action( 'transition_post_status', __NAMESPACE__ . '\flag_status_change', 10,
  * @return \WP_REST_Response
  */
 function replace_rest_controller_author_link( $response ) {
-	$resonse_data = $response->get_data();
-	$author = get_user_by( 'id', $resonse_data['author'] ?? 0 );
+	$response_data = $response->get_data();
+	$author = get_user_by( 'id', $response_data['author'] ?? 0 );
 
 	if ( ! $author ) {
 		return $response;

--- a/public_html/wp-content/plugins/pattern-directory/includes/logging.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/logging.php
@@ -9,7 +9,7 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\{ PENDING_STA
 /**
  * Actions and filters.
  */
-add_filter( 'wporg_internal_notes_rest_prepare_response', __NAMESPACE__ . '\replace_rest_controller_author_link', 10, 3 );
+add_filter( 'wporg_internal_notes_rest_prepare_response', __NAMESPACE__ . '\replace_rest_controller_author_link' );
 add_action( 'transition_post_status', __NAMESPACE__ . '\flag_status_change', 10, 3 );
 
 /**


### PR DESCRIPTION
Currently the Internal Notes plugin retrieves embedded data about note authors using the standard `wp/v2/users` endpoint. However, this endpoint returns nothing if the specified user isn't a member of the site (which is most users on the Pattern Directory). This replaces that embeddable link with a wporg-specific endpoint that can get the data on any wporg user, regardless of site membership.

Depends on:
* https://github.com/WordPress/wporg-mu-plugins/pull/184
* https://github.com/WordPress/wporg-internal-notes/pull/12

### Screenshots

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/916023/160028849-15260d88-bdf5-44c4-910d-43e80d48ddb2.jpg) | ![after](https://user-images.githubusercontent.com/916023/160028864-40fca73c-c583-45b1-8df5-dd4dd391a2cf.jpg) |

### How to test the changes in this Pull Request:

1. Upload this change to your sandbox
2. Try viewing the Internal Notes sidebar for any pattern
