### PR TITLE
Pattern Creator: Try to make the guidelines more clear

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/package.json
+++ b/public_html/wp-content/plugins/pattern-creator/package.json
@@ -52,7 +52,8 @@
 	"eslintConfig": {
 		"extends": "../../../../.eslintrc.js",
 		"globals": {
-			"wporgBlockPattern": "readonly"
+			"wporgBlockPattern": "readonly",
+			"wporgLocale": "readonly"
 		}
 	},
 	"stylelint": {

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -98,9 +98,18 @@ function pattern_creator_init() {
 	wp_add_inline_script(
 		'wp-pattern-creator',
 		sprintf(
+			'var wporgLocale = JSON.parse( decodeURIComponent( \'%s\' ) );',
+			rawurlencode( wp_json_encode( get_locale() ) )
+		),
+		'before'
+	);
+
+	wp_add_inline_script(
+		'wp-pattern-creator',
+		sprintf(
 			'var wporgBlockPattern = JSON.parse( decodeURIComponent( \'%s\' ) );',
 			rawurlencode( wp_json_encode( array(
-				'siteUrl'       => esc_url( home_url() ),
+				'siteUrl' => esc_url( home_url() ),
 			) ) )
 		),
 		'before'

--- a/public_html/wp-content/plugins/pattern-creator/src/components/editor/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/editor/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { AsyncModeProvider, useDispatch, useSelect } from '@wordpress/data';
 import { BlockBreadcrumb } from '@wordpress/block-editor';
-import { useCallback, useState } from '@wordpress/element';
+import { createInterpolateElement, useCallback, useEffect, useState } from '@wordpress/element';
 import {
 	ComplementaryArea,
 	FullscreenMode,
@@ -12,6 +12,7 @@ import {
 	store as interfaceStore,
 } from '@wordpress/interface';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
 import {
 	EditorNotices,
 	EditorProvider,
@@ -55,12 +56,21 @@ function Editor( { onError, postId } ) {
 		};
 	}, [] );
 	const { setIsInserterOpened } = useDispatch( patternStore );
+	const { createInfoNotice } = useDispatch( noticesStore );
 	const [ isEntitiesSavedStatesOpen, setIsEntitiesSavedStatesOpen ] = useState( false );
 	const closeEntitiesSavedStates = useCallback( () => {
 		setIsEntitiesSavedStatesOpen( false );
 	}, [] );
 	const openEntitiesSavedStates = useCallback( () => {
 		setIsEntitiesSavedStatesOpen( true );
+	}, [] );
+
+	useEffect( () => {
+		if ( ! wporgLocale.id.startsWith( 'en_' ) ) {
+			createInfoNotice( __( 'Patterns should be submitted in English.', 'wporg-patterns' ), {
+				isDismissible: false,
+			} );
+		}
 	}, [] );
 
 	// Don't render the Editor until the settings are set and loaded

--- a/public_html/wp-content/plugins/pattern-creator/src/components/editor/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/editor/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { AsyncModeProvider, useDispatch, useSelect } from '@wordpress/data';
 import { BlockBreadcrumb } from '@wordpress/block-editor';
-import { createInterpolateElement, useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import {
 	ComplementaryArea,
 	FullscreenMode,

--- a/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/index.js
@@ -99,7 +99,7 @@ export default function SubmissionModal( { onClose, onSubmit, status } ) {
 					<p>
 						{ createInterpolateElement(
 							__(
-								'<a>Check the guidelines</a> for how to be successful when submitting your pattern.',
+								'<a>Check the guidelines</a> for successfully submitting your pattern.',
 								'wporg-patterns'
 							),
 							{

--- a/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/index.js
@@ -103,6 +103,7 @@ export default function SubmissionModal( { onClose, onSubmit, status } ) {
 								'wporg-patterns'
 							),
 							{
+								/* eslint-disable-next-line jsx-a11y/anchor-has-content */
 								a: <a href={ `${ wporgBlockPattern.siteUrl }/about/` } />,
 							}
 						) }
@@ -116,6 +117,7 @@ export default function SubmissionModal( { onClose, onSubmit, status } ) {
 										'wporg-patterns'
 									),
 									{
+										/* eslint-disable-next-line jsx-a11y/anchor-has-content */
 										a: <a href="https://translate.wordpress.org" />,
 									}
 								) }

--- a/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/index.js
@@ -5,10 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { Button, CheckboxControl, Modal, TextControl, TextareaControl } from '@wordpress/components';
+import { createInterpolateElement, useEffect, useRef, useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useRef, useState } from '@wordpress/element';
 
 const ForwardButton = ( { children, disabled, onClick } ) => (
 	<Button className="pattern-modal-publish__button" isPrimary disabled={ disabled } onClick={ onClick }>
@@ -96,6 +96,59 @@ export default function SubmissionModal( { onClose, onSubmit, status } ) {
 			header: __( 'Publish your pattern', 'wporg-patterns' ),
 			content: (
 				<div>
+					<p>
+						{ createInterpolateElement(
+							__(
+								'<a>Check the guidelines</a> for how to be successful when submitting your pattern.',
+								'wporg-patterns'
+							),
+							{
+								a: <a href={ `${ wporgBlockPattern.siteUrl }/about/` } />,
+							}
+						) }
+					</p>
+					<ul>
+						{ ! wporgLocale.id.startsWith( 'en_' ) && (
+							<li>
+								{ createInterpolateElement(
+									__(
+										'Patterns should be submitted in English, any patterns submitted in other languages will be declined. Patterns will be translated through <a>translate.wordpress.org</a>.',
+										'wporg-patterns'
+									),
+									{
+										a: <a href="https://translate.wordpress.org" />,
+									}
+								) }
+							</li>
+						) }
+						<li>
+							{ __(
+								'Keep placeholder content to a minimum, a few lines will be enough to demonstrate most blocks.',
+								'wporg-patterns'
+							) }
+						</li>
+						<li>
+							{ __(
+								'Use a descriptive name for your pattern. Names like “Test” or “My Pattern” will be declined.',
+								'wporg-patterns'
+							) }
+						</li>
+					</ul>
+				</div>
+			),
+			footer: (
+				<>
+					<span />
+					<ForwardButton disabled={ ! title.length } onClick={ goForward }>
+						{ __( 'Next', 'wporg-patterns' ) }
+					</ForwardButton>
+				</>
+			),
+		},
+		{
+			header: __( 'Publish your pattern', 'wporg-patterns' ),
+			content: (
+				<div>
 					<TextControl
 						className="submission-modal__control"
 						label={ __( 'Title (Required)', 'wporg-patterns' ) }
@@ -119,7 +172,7 @@ export default function SubmissionModal( { onClose, onSubmit, status } ) {
 			),
 			footer: (
 				<>
-					<span />
+					<Button onClick={ goBack }>{ __( 'Previous', 'wporg-patterns' ) }</Button>
 					<ForwardButton disabled={ ! title.length } onClick={ goForward }>
 						{ __( 'Next', 'wporg-patterns' ) }
 					</ForwardButton>

--- a/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/style.scss
@@ -33,6 +33,10 @@ $modal-height: 375px;
 	.components-modal__content {
 		padding: 0;
 		margin-top: 0;
+
+		ul {
+			list-style: disc;
+		}
 	}
 
 	.components-modal__content::before {


### PR DESCRIPTION
Fixes #471 — This tries to solve #471 (users submit patterns in non-English languages via Rosetta sites) by making the guidelines more clear, in two ways:

1. When a user is on a non-English Rosetta site, add a banner to the creator which says:
    > Patterns should be submitted in English.
2. Add a screen to the submission modal for all users. The modal says:
    > [Check the guidelines](https://wordpress.org/patterns/about/) for how to be successful when submitting your pattern.
    > 
    > - Patterns should be submitted in English, any patterns submitted in other languages will be declined. Patterns will be translated through [translate.wordpress.org](https://translate.wordpress.org).
    > - Keep placeholder content to a minimum, a few lines will be enough to demonstrate most blocks.
    > - Use a descriptive name for your pattern. Names like “Test” or “My Pattern” will be declined.

### Screenshots

A persistent banner on non-English sites:
![ja-banner](https://user-images.githubusercontent.com/541093/162828619-0dffd2ca-7158-4084-8466-7426936b71f1.png)

New screen in the modal (English site)
![en-modal](https://user-images.githubusercontent.com/541093/162828611-b1302bd9-2db5-4323-bbb3-743264aa2a95.png)

New screen in the modal (Japanese site)
![ja-modal](https://user-images.githubusercontent.com/541093/162828620-e4053ec5-c111-44e9-9e90-43687cb47ba0.png)

### How to test the changes in this Pull Request:

1. Load this branch on a sandbox
2. Edit a pattern on a rosetta domain
3. You should see the banner
4. Submit the pattern
5. You should see the new first modal screen
6. Go to an English site & edit a pattern
7. There should be no banner
8. Submit the pattern
9. You should see the new first modal screen, but without the note about English & translations
