### PR TITLE
Pattern Validation: Try checking block count, flagged title words

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -99,29 +99,61 @@ function validate_content( $prepared_post, $request ) {
 	// The editor adds in linebreaks between blocks, but parse_blocks thinks those are invalid blocks.
 	$content = str_replace( "\n\n", '', $content );
 	$blocks = parse_blocks( $content );
-	$registry = \WP_Block_Type_Registry::get_instance();
+	$blocks_queue = $blocks;
+	$all_blocks = array();
 
-	// $blocks contains a list of the blocks in the content. By default it will always have one item, even if it's
-	// not valid block content. Instead, we should check that each block in the list has a blockName.
-	$invalid_blocks = array_filter( $blocks, function( $block ) use ( $registry ) {
+	// Loop over all the nested blocks to flatten the block list into 1 dimension.
+	while ( count( $blocks_queue ) > 0 ) { // phpcs:ignore -- inline count OK.
+		$block = array_shift( $blocks_queue );
+		array_push( $all_blocks, $block );
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			foreach ( $block['innerBlocks'] as $inner_block ) {
+				array_push( $blocks_queue, $inner_block );
+			}
+		}
+	}
+
+	// Check that each block in the list has a blockName and is registered.
+	$registry = \WP_Block_Type_Registry::get_instance();
+	$invalid_blocks = array_filter( $all_blocks, function( $block ) use ( $registry ) {
 		$block_type = $registry->get_registered( $block['blockName'] );
 		return is_null( $block['blockName'] ) || is_null( $block_type );
 	} );
+
 	if ( count( $invalid_blocks ) ) {
 		return new \WP_Error(
 			'rest_pattern_invalid_blocks',
-			__( 'Pattern content contains invalid blocks.', 'wporg-patterns' ),
+			__( 'Pattern content contains invalid blocks. Patterns shared on the Pattern Directory can only use core blocks.', 'wporg-patterns' ),
 			array( 'status' => 400 )
 		);
 	}
 
-	// Next, we should check that we have at least one non-empty block.
-	$real_blocks = array_filter( $blocks, __NAMESPACE__ . '\is_not_empty_block' );
+	// Next, filter out any empty blocks
+	$real_blocks = array_filter( $all_blocks, __NAMESPACE__ . '\is_not_empty_block' );
 
+	// Check that we have at least one non-empty block.
 	if ( ! count( $real_blocks ) ) {
 		return new \WP_Error(
 			'rest_pattern_empty_blocks',
 			__( 'Pattern content contains only empty or default blocks.', 'wporg-patterns' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	// Check that we have at least three non-empty blocks (and show a different error message).
+	if ( count( $real_blocks ) < 3 ) {
+		return new \WP_Error(
+			'rest_pattern_insufficient_blocks',
+			__( 'Pattern content contains less than three blocks. Patterns should combine multiple blocks for interesting layouts.', 'wporg-patterns' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	// Check that there are fewer than 75 blocks.
+	if ( count( $real_blocks ) > 75 ) {
+		return new \WP_Error(
+			'rest_pattern_extra_blocks',
+			__( 'Pattern content contains over 75 blocks. Patterns should not replicate full pages or blog posts, try breaking your pattern into smaller submissions.', 'wporg-patterns' ),
 			array( 'status' => 400 )
 		);
 	}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -60,15 +60,17 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_valid_content() {
+		$two_paragraphs = "<!-- wp:paragraph -->\n<p>One.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Two.</p>\n<!-- /wp:paragraph -->";
+		$three_paragraphs = "$two_paragraphs\n\n<!-- wp:paragraph -->\n<p>Three.</p>\n<!-- /wp:paragraph -->";
+
 		return array(
-			array( "<!-- wp:paragraph -->\n<p>This is a block.</p>\n<!-- /wp:paragraph -->" ),
-			array( "<!-- wp:paragraph -->\n<p><img class=\"wp-image-63\" style=\"width: 150px;\" src=\"./image.png\" alt=\"\"></p>\n<!-- /wp:paragraph -->" ),
-			array( "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p>Some block content</p>\n<!-- /wp:paragraph -->" ),
-			array( "<!-- wp:paragraph -->\n<p>Some block content</p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->" ),
-			array( "<!-- wp:group -->\n<div class=\"wp-block-group\"><div class=\"wp-block-group__inner-container\"><!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://s.w.org/style/images/wporg-logo.svg?3\" alt=\"\"/></figure>\n<!-- /wp:image --></div></div>\n<!-- /wp:group -->" ),
-			array( "<!-- wp:group {\"backgroundColor\":\"black\",\"textColor\":\"cyan-bluish-gray\"} -->\n<div class=\"wp-block-group has-cyan-bluish-gray-color has-black-background-color has-text-color has-background\"><div class=\"wp-block-group__inner-container\"><!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://s.w.org/style/images/wporg-logo.svg?3\" alt=\"\"/></figure>\n<!-- /wp:image --></div></div>\n<!-- /wp:group -->" ),
-			array( "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:spacer -->\n<div style=\"height:100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:paragraph {\"style\":{\"typography\":{\"fontSize\":\"21px\"},\"color\":{\"text\":\"#000000\"}}} -->\n<p class=\"has-text-color\" style=\"color:#000000;font-size:21px\"><strong>We have worked with:</strong></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"style\":{\"typography\":{\"fontSize\":\"24px\",\"lineHeight\":\"1.2\"}}} -->\n<p style=\"font-size:24px;line-height:1.2\"><a href=\"https://wordpress.org\">EARTHFUND™<br>ARCHWEEKLY<br>FUTURE ROADS<br>BUILDING NY</a></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:spacer -->\n<div style=\"height:100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->" ),
-			array( "<!-- wp:audio {\"id\":9} -->\n<figure class=\"wp-block-audio\"><audio controls src=\"./song.mp3\"></audio></figure>\n<!-- /wp:audio -->" ),
+			array( $three_paragraphs ),
+			array( "<!-- wp:paragraph -->\n<p><img class=\"wp-image-63\" style=\"width: 150px;\" src=\"./image.png\" alt=\"\"></p>\n<!-- /wp:paragraph -->\n\n$two_paragraphs" ),
+			array( "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->\n\n$three_paragraphs" ),
+			array( "$three_paragraphs\n\n<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->" ),
+			array( "<!-- wp:group -->\n<div class=\"wp-block-group\">$three_paragraphs</div>\n<!-- /wp:group -->" ),
+			array( "<!-- wp:group {\"layout\":{\"type\":\"flex\",\"justifyContent\":\"space-between\"}} -->\n<div class=\"wp-block-group\"><!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:heading -->\n<h2>Heading</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Paragraph</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->\n\n<!-- wp:image {\"id\":null} -->\n<figure class=\"wp-block-image\"><img src=\"./pear.png\" alt=\"\"/></figure>\n<!-- /wp:image --></div>\n<!-- /wp:group -->" ),
+			array( "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"width\":\"66.66%\"} -->\n<div class=\"wp-block-column\" style=\"flex-basis:66.66%\"><!-- wp:spacer -->\n<div style=\"height:100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":\"33.33%\"} -->\n<div class=\"wp-block-column\" style=\"flex-basis:33.33%\"><!-- wp:spacer {\"height\":\"51px\"} -->\n<div style=\"height:51px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:paragraph -->\n<p>One</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->" ),
 		);
 	}
 
@@ -97,17 +99,42 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_invalid_content() {
+		$two_paragraphs = "<!-- wp:paragraph -->\n<p>One.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Two.</p>\n<!-- /wp:paragraph -->";
+		$three_paragraphs = "$two_paragraphs\n\n<!-- wp:paragraph -->\n<p>Three.</p>\n<!-- /wp:paragraph -->";
+
 		return array(
 			array( 'rest_pattern_empty', '' ),
+
+			// Single empty paragraph.
 			array( 'rest_pattern_empty_blocks', "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->" ),
+			// Multiple empty paragraphs.
 			array( 'rest_pattern_empty_blocks', "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->" ),
+			// Empty paragraph with custom class.
 			array( 'rest_pattern_empty_blocks', "<!-- wp:paragraph {\"className\":\"foo\"} -->\n<p class=\"foo\"></p>\n<!-- /wp:paragraph -->" ),
+			// Empty list.
 			array( 'rest_pattern_empty_blocks', "<!-- wp:list -->\n<ul><li></li></ul>\n<!-- /wp:list -->" ),
+			// Empty image block.
 			array( 'rest_pattern_empty_blocks', "<!-- wp:image -->\n<figure class=\"wp-block-image\"><img alt=\"\"/></figure>\n<!-- /wp:image -->" ),
-			array( 'rest_pattern_empty_blocks', "<!-- wp:group -->\n<div class=\"wp-block-group\"><div class=\"wp-block-group__inner-container\"></div></div>\n<!-- /wp:group -->" ),
+			// Empty group.
+			array( 'rest_pattern_empty_blocks', "<!-- wp:group -->\n<div class=\"wp-block-group\"></div>\n<!-- /wp:group -->" ),
+			// Empty media & text block.
 			array( 'rest_pattern_empty_blocks', "<!-- wp:media-text -->\n<div class=\"wp-block-media-text alignwide is-stacked-on-mobile\"><figure class=\"wp-block-media-text__media\"></figure><div class=\"wp-block-media-text__content\"><!-- wp:paragraph {\"placeholder\":\"Content…\",\"fontSize\":\"large\"} -->\n<p class=\"has-large-font-size\"></p>\n<!-- /wp:paragraph --></div></div>\n<!-- /wp:media-text -->" ),
+
 			array( 'rest_pattern_invalid_blocks', '<p>This is not blocks.</p>' ),
 			array( 'rest_pattern_invalid_blocks', "<!-- wp:plugin/fake -->\n<p>This is some content.</p>\n<!-- /wp:plugin/fake -->" ),
+			array( 'rest_pattern_invalid_blocks', "<!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:plugin/fake -->\n<p>Fake nested block.</p>\n<!-- /wp:plugin/fake --></div>\n<!-- /wp:group -->" ),
+
+			// Only 2 paragraphs.
+			array( 'rest_pattern_insufficient_blocks', $two_paragraphs ),
+			// Single group with a heading.
+			array( 'rest_pattern_insufficient_blocks', "<!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:heading -->\n<h2>One</h2>\n<!-- /wp:heading --></div>\n<!-- /wp:group -->" ),
+			// Default query loop — not considered totally empty because the query loop's settings make it "not empty".
+			array( 'rest_pattern_insufficient_blocks', "<!-- wp:query {\"queryId\":1,\"query\":{\"perPage\":3,\"pages\":0,\"offset\":0,\"postType\":\"post\",\"order\":\"desc\",\"orderBy\":\"date\",\"author\":\"\",\"search\":\"\",\"exclude\":[],\"sticky\":\"\",\"inherit\":false}} -->\n<div class=\"wp-block-query\"><!-- wp:post-template -->\n<!-- wp:post-title /-->\n\n<!-- wp:post-date /-->\n\n<!-- wp:post-excerpt /-->\n<!-- /wp:post-template -->\n\n<!-- wp:query-pagination -->\n<!-- wp:query-pagination-previous /-->\n\n<!-- wp:query-pagination-numbers /-->\n\n<!-- wp:query-pagination-next /-->\n<!-- /wp:query-pagination -->\n\n<!-- wp:query-no-results -->\n<!-- wp:paragraph {\"placeholder\":\"Add a text or blocks that will display when the query returns no results.\"} -->\n<p></p>\n<!-- /wp:paragraph -->\n<!-- /wp:query-no-results --></div>\n<!-- /wp:query -->" ),
+
+			// 26 * 3 paragraphs = 78 blocks.
+			array( 'rest_pattern_extra_blocks', str_repeat( $three_paragraphs, 26 ) ),
+			// 25 * 3 paragraphs + 1 group = 76 blocks.
+			array( 'rest_pattern_extra_blocks', "<!-- wp:group -->\n<div class=\"wp-block-group\">" . str_repeat( $three_paragraphs, 25 ) . "</div>\n<!-- /wp:group -->" ),
 		);
 	}
 
@@ -121,7 +148,7 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( array(
 			'title'   => 'Spam Check',
-			'content' => "<!-- wp:heading -->\n<h2 id=\"spam-check\">Spam Check.</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Paragraph: PatternDirectorySpamTest</p>\n<!-- /wp:paragraph -->",
+			'content' => "<!-- wp:heading -->\n<h2 id=\"spam-check\">Spam Check.</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Paragraph: PatternDirectorySpamTest</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Third block.</p>\n<!-- /wp:paragraph -->",
 			'status'  => 'publish',
 		) ) );
 
@@ -142,7 +169,7 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( array(
 			'title'   => 'Spam Check',
-			'content' => "<!-- wp:paragraph -->\n<p>Paragraph one.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Paragraph two.</p>\n<!-- /wp:paragraph -->",
+			'content' => "<!-- wp:paragraph -->\n<p>Paragraph one.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Paragraph two.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Paragraph three.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Paragraph four.</p>\n<!-- /wp:paragraph -->",
 			'status'  => 'publish',
 		) ) );
 

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -19,7 +19,10 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$pattern_id = $factory->post->create(
-			array( 'post_type' => POST_TYPE )
+			array(
+				'post_title' => 'Three paragraphs',
+				'post_type' => POST_TYPE,
+			)
 		);
 		self::$user = $factory->user->create(
 			array(

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -7,6 +7,8 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, SPAM_
 
 /**
  * Test pattern validation.
+ *
+ * @group content-validation
  */
 class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	protected static $pattern_id;
@@ -36,227 +38,77 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Helper function to handle REST requests to save the pattern.
+	 * Test valid block content.
+	 *
+	 * @dataProvider data_valid_content
 	 */
-	protected function save_block_content( $content ) {
-		return $this->save_block_pattern( compact( 'content' ) );
-	}
+	public function test_valid_content( $content ) {
+		wp_set_current_user( self::$user );
 
-	/**
-	 * Helper function to handle a REST request to save a full pattern.
-	 */
-	protected function save_block_pattern( $attributes ) {
-		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern' . ( self::$pattern_id ? '/' . self::$pattern_id : '' ) );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
 		$request->set_header( 'content-type', 'application/json' );
-		$request->set_body( json_encode( $attributes ) );
+		$request->set_body( json_encode( array( 'content' => $content ) ) );
 
-		return rest_do_request( $request );
-	}
+		$response = rest_do_request( $request );
 
-	/**
-	 * Test valid block content: simple paragraph.
-	 */
-	public function test_valid_simple_block() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:paragraph -->\n<p>This is a block.</p>\n<!-- /wp:paragraph -->"
-		);
 		$this->assertFalse( $response->is_error() );
 	}
 
 	/**
-	 * Test valid block content: paragraph with only an image.
+	 * Data provider to test valid block content.
+	 *
+	 * @return array
 	 */
-	public function test_valid_block_with_image() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:paragraph -->\n<p><img class=\"wp-image-63\" style=\"width: 150px;\" src=\"./image.png\" alt=\"\"></p>\n<!-- /wp:paragraph -->"
+	public function data_valid_content() {
+		return array(
+			array( "<!-- wp:paragraph -->\n<p>This is a block.</p>\n<!-- /wp:paragraph -->" ),
+			array( "<!-- wp:paragraph -->\n<p><img class=\"wp-image-63\" style=\"width: 150px;\" src=\"./image.png\" alt=\"\"></p>\n<!-- /wp:paragraph -->" ),
+			array( "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p>Some block content</p>\n<!-- /wp:paragraph -->" ),
+			array( "<!-- wp:paragraph -->\n<p>Some block content</p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->" ),
+			array( "<!-- wp:group -->\n<div class=\"wp-block-group\"><div class=\"wp-block-group__inner-container\"><!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://s.w.org/style/images/wporg-logo.svg?3\" alt=\"\"/></figure>\n<!-- /wp:image --></div></div>\n<!-- /wp:group -->" ),
+			array( "<!-- wp:group {\"backgroundColor\":\"black\",\"textColor\":\"cyan-bluish-gray\"} -->\n<div class=\"wp-block-group has-cyan-bluish-gray-color has-black-background-color has-text-color has-background\"><div class=\"wp-block-group__inner-container\"><!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://s.w.org/style/images/wporg-logo.svg?3\" alt=\"\"/></figure>\n<!-- /wp:image --></div></div>\n<!-- /wp:group -->" ),
+			array( "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:spacer -->\n<div style=\"height:100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:paragraph {\"style\":{\"typography\":{\"fontSize\":\"21px\"},\"color\":{\"text\":\"#000000\"}}} -->\n<p class=\"has-text-color\" style=\"color:#000000;font-size:21px\"><strong>We have worked with:</strong></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"style\":{\"typography\":{\"fontSize\":\"24px\",\"lineHeight\":\"1.2\"}}} -->\n<p style=\"font-size:24px;line-height:1.2\"><a href=\"https://wordpress.org\">EARTHFUND™<br>ARCHWEEKLY<br>FUTURE ROADS<br>BUILDING NY</a></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:spacer -->\n<div style=\"height:100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->" ),
+			array( "<!-- wp:audio {\"id\":9} -->\n<figure class=\"wp-block-audio\"><audio controls src=\"./song.mp3\"></audio></figure>\n<!-- /wp:audio -->" ),
 		);
-		$this->assertFalse( $response->is_error() );
 	}
 
 	/**
-	 * Test valid block content: real content with an extra empty paragraph (beginning).
+	 * Test invalid block content.
+	 *
+	 * @dataProvider data_invalid_content
 	 */
-	public function test_valid_extra_empty_paragraph_initial() {
+	public function test_invalid_empty_content( $expected_error_code, $content ) {
 		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p>Some block content</p>\n<!-- /wp:paragraph -->"
-		);
-		$this->assertFalse( $response->is_error() );
-	}
 
-	/**
-	 * Test valid block content: real content with an extra empty paragraph (end).
-	 */
-	public function test_valid_extra_empty_paragraph_end() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:paragraph -->\n<p>Some block content</p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->"
-		);
-		$this->assertFalse( $response->is_error() );
-	}
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( array( 'content' => $content ) ) );
 
-	/**
-	 * Test valid block content: a group block with an image.
-	 */
-	public function test_valid_group_block() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:group -->\n<div class=\"wp-block-group\"><div class=\"wp-block-group__inner-container\"><!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://s.w.org/style/images/wporg-logo.svg?3\" alt=\"\"/></figure>\n<!-- /wp:image --></div></div>\n<!-- /wp:group -->"
-		);
-		$this->assertFalse( $response->is_error() );
-	}
+		$response = rest_do_request( $request );
 
-	/**
-	 * Test valid block content: a group block with an image and a background color.
-	 */
-	public function test_valid_group_block_with_color() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:group {\"backgroundColor\":\"black\",\"textColor\":\"cyan-bluish-gray\"} -->\n<div class=\"wp-block-group has-cyan-bluish-gray-color has-black-background-color has-text-color has-background\"><div class=\"wp-block-group__inner-container\"><!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://s.w.org/style/images/wporg-logo.svg?3\" alt=\"\"/></figure>\n<!-- /wp:image --></div></div>\n<!-- /wp:group -->"
-		);
-		$this->assertFalse( $response->is_error() );
-	}
-
-	/**
-	 * Test valid block content: two columns, one empty, should still be valid.
-	 */
-	public function test_valid_columns_block() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:spacer -->\n<div style=\"height:100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:paragraph {\"style\":{\"typography\":{\"fontSize\":\"21px\"},\"color\":{\"text\":\"#000000\"}}} -->\n<p class=\"has-text-color\" style=\"color:#000000;font-size:21px\"><strong>We have worked with:</strong></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"style\":{\"typography\":{\"fontSize\":\"24px\",\"lineHeight\":\"1.2\"}}} -->\n<p style=\"font-size:24px;line-height:1.2\"><a href=\"https://wordpress.org\">EARTHFUND™<br>ARCHWEEKLY<br>FUTURE ROADS<br>BUILDING NY</a></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:spacer -->\n<div style=\"height:100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->"
-		);
-		$this->assertFalse( $response->is_error() );
-	}
-
-	/**
-	 * Test valid block content: an audio block.
-	 */
-	public function test_valid_audio_block() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:audio {\"id\":9} -->\n<figure class=\"wp-block-audio\"><audio controls src=\"./song.mp3\"></audio></figure>\n<!-- /wp:audio -->"
-		);
-		$this->assertFalse( $response->is_error() );
-	}
-
-	/**
-	 * Test invalid block content: empty content.
-	 */
-	public function test_invalid_empty_content() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content( '' );
 		$this->assertTrue( $response->is_error() );
 		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_empty', $data['code'] );
+		$this->assertSame( $expected_error_code, $data['code'] );
 	}
 
 	/**
-	 * Test invalid block content: not blocks.
+	 * Data provider to test valid block content.
+	 *
+	 * @return array
 	 */
-	public function test_invalid_not_blocks() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content( '<p>This is not blocks.</p>' );
-		$this->assertTrue( $response->is_error() );
-		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_invalid_blocks', $data['code'] );
-	}
-
-	/**
-	 * Test invalid block content: empty paragraph (default block).
-	 */
-	public function test_invalid_empty_paragraph() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content( "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->" );
-		$this->assertTrue( $response->is_error() );
-		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_empty_blocks', $data['code'] );
-	}
-
-	/**
-	 * Test invalid block content: empty paragraphs (multiple).
-	 */
-	public function test_invalid_empty_paragraphs() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content( "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->" );
-		$this->assertTrue( $response->is_error() );
-		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_empty_blocks', $data['code'] );
-	}
-
-	/**
-	 * Test invalid block content: empty paragraph, with a class.
-	 */
-	public function test_invalid_block_with_class() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:paragraph {\"className\":\"foo\"} -->\n<p class=\"foo\"></p>\n<!-- /wp:paragraph -->"
+	public function data_invalid_content() {
+		return array(
+			array( 'rest_pattern_empty', '' ),
+			array( 'rest_pattern_empty_blocks', "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->" ),
+			array( 'rest_pattern_empty_blocks', "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph --><!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->" ),
+			array( 'rest_pattern_empty_blocks', "<!-- wp:paragraph {\"className\":\"foo\"} -->\n<p class=\"foo\"></p>\n<!-- /wp:paragraph -->" ),
+			array( 'rest_pattern_empty_blocks', "<!-- wp:list -->\n<ul><li></li></ul>\n<!-- /wp:list -->" ),
+			array( 'rest_pattern_empty_blocks', "<!-- wp:image -->\n<figure class=\"wp-block-image\"><img alt=\"\"/></figure>\n<!-- /wp:image -->" ),
+			array( 'rest_pattern_empty_blocks', "<!-- wp:group -->\n<div class=\"wp-block-group\"><div class=\"wp-block-group__inner-container\"></div></div>\n<!-- /wp:group -->" ),
+			array( 'rest_pattern_empty_blocks', "<!-- wp:media-text -->\n<div class=\"wp-block-media-text alignwide is-stacked-on-mobile\"><figure class=\"wp-block-media-text__media\"></figure><div class=\"wp-block-media-text__content\"><!-- wp:paragraph {\"placeholder\":\"Content…\",\"fontSize\":\"large\"} -->\n<p class=\"has-large-font-size\"></p>\n<!-- /wp:paragraph --></div></div>\n<!-- /wp:media-text -->" ),
+			array( 'rest_pattern_invalid_blocks', '<p>This is not blocks.</p>' ),
+			array( 'rest_pattern_invalid_blocks', "<!-- wp:plugin/fake -->\n<p>This is some content.</p>\n<!-- /wp:plugin/fake -->" ),
 		);
-		$this->assertTrue( $response->is_error() );
-		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_empty_blocks', $data['code'] );
-	}
-
-	/**
-	 * Test invalid block content: empty list (not default).
-	 */
-	public function test_invalid_empty_list() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content( "<!-- wp:list -->\n<ul><li></li></ul>\n<!-- /wp:list -->" );
-		$this->assertTrue( $response->is_error() );
-		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_empty_blocks', $data['code'] );
-	}
-
-	/**
-	 * Test invalid block content: empty image.
-	 */
-	public function test_invalid_empty_image() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content( "<!-- wp:image -->\n<figure class=\"wp-block-image\"><img alt=\"\"/></figure>\n<!-- /wp:image -->" );
-		$this->assertTrue( $response->is_error() );
-		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_empty_blocks', $data['code'] );
-	}
-
-	/**
-	 * Test invalid block content: a group block with an image.
-	 */
-	public function test_invalid_empty_group_block() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:group -->\n<div class=\"wp-block-group\"><div class=\"wp-block-group__inner-container\"></div></div>\n<!-- /wp:group -->"
-		);
-		$this->assertTrue( $response->is_error() );
-		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_empty_blocks', $data['code'] );
-	}
-
-	/**
-	 * Test invalid block content: an empty media & text block.
-	 */
-	public function test_invalid_empty_media_text_block() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:media-text -->\n<div class=\"wp-block-media-text alignwide is-stacked-on-mobile\"><figure class=\"wp-block-media-text__media\"></figure><div class=\"wp-block-media-text__content\"><!-- wp:paragraph {\"placeholder\":\"Content…\",\"fontSize\":\"large\"} -->\n<p class=\"has-large-font-size\"></p>\n<!-- /wp:paragraph --></div></div>\n<!-- /wp:media-text -->"
-		);
-		$this->assertTrue( $response->is_error() );
-		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_empty_blocks', $data['code'] );
-	}
-
-	/**
-	 * Test invalid block content: a block that doesn't exist on this site.
-	 */
-	public function test_invalid_fake_block() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block_content(
-			"<!-- wp:plugin/fake -->\n<p>This is some content.</p>\n<!-- /wp:plugin/fake -->"
-		);
-		$this->assertTrue( $response->is_error() );
-		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_invalid_blocks', $data['code'] );
 	}
 
 	/**
@@ -264,12 +116,16 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	 */
 	public function test_spam_should_be_pending() {
 		wp_set_current_user( self::$user );
-		$response = $this->save_block_pattern( array(
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( array(
 			'title'   => 'Spam Check',
 			'content' => "<!-- wp:heading -->\n<h2 id=\"spam-check\">Spam Check.</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Paragraph: PatternDirectorySpamTest</p>\n<!-- /wp:paragraph -->",
 			'status'  => 'publish',
-		) );
+		) ) );
 
+		$response = rest_do_request( $request );
 		$this->assertFalse( $response->is_error() );
 		$data = $response->get_data();
 
@@ -281,16 +137,19 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	 */
 	public function test_only_paragraphs_are_spam() {
 		wp_set_current_user( self::$user );
-		$response = $this->save_block_pattern( array(
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( array(
 			'title'   => 'Spam Check',
 			'content' => "<!-- wp:paragraph -->\n<p>Paragraph one.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Paragraph two.</p>\n<!-- /wp:paragraph -->",
 			'status'  => 'publish',
-		) );
+		) ) );
 
+		$response = rest_do_request( $request );
 		$this->assertFalse( $response->is_error() );
 		$data = $response->get_data();
 
 		$this->assertSame( SPAM_STATUS, $data['status'] );
 	}
 }
-

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
@@ -7,10 +7,14 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 
 /**
  * Test pattern validation.
+ *
+ * @group title-validation
  */
 class Pattern_Title_Validation_Test extends WP_UnitTestCase {
 	protected static $pattern_id;
 	protected static $user;
+
+	protected static $valid_content = "<!-- wp:paragraph -->\n<p>This is a block.</p>\n<!-- /wp:paragraph -->";
 
 	/**
 	 * Setup fixtures that are shared across all tests.
@@ -27,38 +31,46 @@ class Pattern_Title_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Helper function to handle REST requests to save the pattern.
+	 * Test valid pattern title.
+	 *
+	 * @dataProvider data_valid_title
 	 */
-	protected function save_block( $args = array() ) {
+	public function test_valid_title( $pattern ) {
+		wp_set_current_user( self::$user );
+
 		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
 		$request->set_header( 'content-type', 'application/json' );
-		$request_args = wp_parse_args( $args, array(
+		$request->set_body( json_encode( $pattern ) );
+
+		$response = rest_do_request( $request );
+		$this->assertFalse( $response->is_error() );
+	}
+
+	/**
+	 * Data provider to test valid block titles.
+	 *
+	 * @return array
+	 */
+	public function data_valid_title() {
+		$defaults = array(
 			'status' => 'publish',
-			'content' => "<!-- wp:paragraph -->\n<p>This is a block.</p>\n<!-- /wp:paragraph -->",
-		) );
-		$request->set_body( json_encode( $request_args ) );
-		return rest_do_request( $request );
-	}
-
-	/**
-	 * Test valid pattern title: Add a new title.
-	 */
-	public function test_valid_create_title() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block( array( 'title' => 'Default Paragraph' ) );
-		$this->assertFalse( $response->is_error() );
-	}
-
-	/**
-	 * Test valid pattern title: empty title for a draft pattern.
-	 */
-	public function test_valid_empty_title_draft() {
-		wp_set_current_user( self::$user );
-		$response = $this->save_block( array(
-			'title' => '',
-			'status' => 'draft',
-		) );
-		$this->assertFalse( $response->is_error() );
+			'content' => self::$valid_content,
+		);
+		return array(
+			array(
+				array_merge( $defaults, array( 'title' => 'Default Paragraph' ) ),
+			),
+			array(
+				array_merge( $defaults, array( 'title' => 'Testimonial' ) ),
+			),
+			array(
+				array(
+					'title' => '',
+					'status' => 'draft',
+					'content' => self::$valid_content,
+				),
+			),
+		);
 	}
 
 	/**
@@ -68,24 +80,52 @@ class Pattern_Title_Validation_Test extends WP_UnitTestCase {
 		wp_set_current_user( self::$user );
 		wp_update_post( array(
 			'ID' => self::$pattern_id,
-			'post_title' => 'Test Title',
+			'post_title' => 'Stylized Quote and Citation',
 		) );
-		$response = $this->save_block();
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( array( 'content' => self::$valid_content ) ) );
+
+		$response = rest_do_request( $request );
 		$this->assertFalse( $response->is_error() );
 	}
 
 	/**
-	 * Test invalid pattern title: Published pattern, setting empty title.
+	 * Test invalid pattern titles
+	 *
+	 * @dataProvider data_invalid_title
 	 */
-	public function test_invalid_empty_new_title() {
+	public function test_invalid_title( $expected_error_code, $pattern ) {
 		wp_set_current_user( self::$user );
-		$response = $this->save_block( array(
-			'status' => 'publish',
-			'title' => '',
-		) );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $pattern ) );
+
+		$response = rest_do_request( $request );
 		$this->assertTrue( $response->is_error() );
+
 		$data = $response->get_data();
-		$this->assertSame( 'rest_pattern_empty_title', $data['code'] );
+		$this->assertSame( $expected_error_code, $data['code'] );
+	}
+
+	/**
+	 * Data provider to test invalid block titles.
+	 *
+	 * @return array
+	 */
+	public function data_invalid_title() {
+		$defaults = array(
+			'status' => 'publish',
+			'content' => self::$valid_content,
+		);
+		return array(
+			array(
+				'rest_pattern_empty_title',
+				array_merge( $defaults, array( 'title' => '' ) ),
+			),
+		);
 	}
 
 	/**
@@ -97,8 +137,14 @@ class Pattern_Title_Validation_Test extends WP_UnitTestCase {
 			'ID' => self::$pattern_id,
 			'post_title' => '',
 		) );
-		$response = $this->save_block();
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( array( 'content' => self::$valid_content ) ) );
+
+		$response = rest_do_request( $request );
 		$this->assertTrue( $response->is_error() );
+
 		$data = $response->get_data();
 		$this->assertSame( 'rest_pattern_empty_title', $data['code'] );
 	}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
@@ -13,8 +13,7 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 class Pattern_Title_Validation_Test extends WP_UnitTestCase {
 	protected static $pattern_id;
 	protected static $user;
-
-	protected static $valid_content = "<!-- wp:paragraph -->\n<p>This is a block.</p>\n<!-- /wp:paragraph -->";
+	protected static $valid_content;
 
 	/**
 	 * Setup fixtures that are shared across all tests.
@@ -28,6 +27,7 @@ class Pattern_Title_Validation_Test extends WP_UnitTestCase {
 				'role' => 'administrator',
 			)
 		);
+		self::$valid_content = str_repeat( "<!-- wp:paragraph -->\n<p>This is a block.</p>\n<!-- /wp:paragraph -->\n\n", 3 );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
@@ -125,6 +125,18 @@ class Pattern_Title_Validation_Test extends WP_UnitTestCase {
 				'rest_pattern_empty_title',
 				array_merge( $defaults, array( 'title' => '' ) ),
 			),
+			array(
+				'rest_pattern_invalid_title',
+				array_merge( $defaults, array( 'title' => 'Testing' ) ),
+			),
+			array(
+				'rest_pattern_invalid_title',
+				array_merge( $defaults, array( 'title' => 'My Pattern' ) ),
+			),
+			array(
+				'rest_pattern_invalid_title',
+				array_merge( $defaults, array( 'title' => 'Test' ) ),
+			),
 		);
 	}
 


### PR DESCRIPTION
See #449 — Adds some automated checks based on the comments in this issue.

1. Check if there are more than 3 non-empty blocks
2. Check if there are less than 75 non-empty blocks
3. Check if the title contains any flagged words, like "test" or "my pattern"

This uses the same validation format as the other content validation, where submitting a pattern is totally blocked.

I also updated the tests a bit to clean up some of the repeated pattern-saving code (TIL about phpunit's `dataProvider` feature).

### Screenshots

When invalid content is submitted, it shows up in the submission modal and as a banner above the title, so it's clear how to fix the issue even when the modal is closed.

![error-notice](https://user-images.githubusercontent.com/541093/163271929-7de0424e-caed-47de-8219-243f41ec82d1.png)

### How to test the changes in this Pull Request:

1. Create or edit a pattern
2. Use some combination of invalid content
3. You should see the error both in the modal and above the title
4. Fix the issue & resubmit, it should work
