### PR TITLE
Notifications: Trigger emails after post update is finished

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -31,7 +31,6 @@ function trigger_notifications( $post_id, $post, $update, $post_before ) {
 	}
 
 	if ( ! $update || is_null( $post_before ) ) {
-		// @todo Maybe notify of submission recieved.
 		return;
 	}
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -16,7 +16,7 @@ const RESOLVED_STATUS = 'resolved';
  * Actions and filters.
  */
 add_action( 'init', __NAMESPACE__ . '\register_post_type_data' );
-add_action( 'wp_insert_post', __NAMESPACE__ . '\check_flag_threshold', 10, 3 );
+add_action( 'wp_after_insert_post', __NAMESPACE__ . '\check_flag_threshold', 10, 3 );
 
 /**
  * Register entities for block pattern flags.
@@ -152,6 +152,13 @@ function check_flag_threshold( $post_ID, $post, $update ) {
 			'ID'          => $pattern->ID,
 			'post_status' => PENDING_STATUS,
 		) );
+
+		/**
+		 * Fires after a pattern is automatically unlisted.
+		 *
+		 * @param WP_Post $pattern The just-unlisted pattern.
+		 */
+		do_action( 'wporg_unlist_pattern', $pattern );
 	}
 }
 


### PR DESCRIPTION
This updates the logic for when to send a notification email to run on the `wp_after_insert_post` hook. This hook also gets the before & after post object, so we can compare post status like on the transition hook, but at this point the flag reasons have been saved.

I've added a custom action which fires when a pattern is unlisted, so we can attach the `notify_pattern_flagged` call to that action specifically, rather than checking for the publish -> pending switch (which fixes #468).

The logic for `notify_pattern_flagged` was changed slightly, now it checks for the spam status first, and sends the spam reason, rather than checking for flags first. It's also using `array_merge` instead of the array union operator (`+`), because the union op overwrites values at the same index, so if there were multiple reasons, each `term[0]` was overwriting the previous value.

Fixes #468, fixes #459.

### How to test the changes in this Pull Request:

Try to generate each email, and catch them with mailcatcher or similar (I used [the email log plugin](https://wordpress.org/plugins/email-log/) for my testing).

In Settings -> Block Patterns, make sure submitted patterns are saved as pending, and the flag threshold should be 2 for testing. Have two users to test with.

1. Submit a new pattern, it should save as pending
2. In wp-admin, publish the pattern
3. 📧 You should see a "Pattern published" email
4. View the pattern, and report it with both your users
5. The pattern should automatically unlist
6. 📧 You should see the "Pattern being reviewed" email, with the reason(s) chosen
7. Create another pattern
8. In wp-admin, mark it as spam
9. 📧 You should see the "Pattern being reviewed" email, with spam as the reason
10. Create another pattern
11. Go into wp-admin and manually unlist it
12.  📧 You should see the "Pattern unlisted" email, with the reason chosen

