### PR TITLE
Set Pattern Author & Patterns Team badges automatically.

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/bootstrap.php
+++ b/public_html/wp-content/plugins/pattern-directory/bootstrap.php
@@ -19,3 +19,4 @@ require_once __DIR__ . '/includes/favorite.php';
 require_once __DIR__ . '/includes/stats.php';
 require_once __DIR__ . '/includes/admin.php';
 require_once __DIR__ . '/includes/notifications.php';
+require_once __DIR__ . '/includes/badges.php';

--- a/public_html/wp-content/plugins/pattern-directory/includes/badges.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/badges.php
@@ -24,12 +24,12 @@ function status_transitions( $new_status, $old_status, $post ) {
 
 	if ( 'publish' === $new_status ) {
 		assign_badge( 'pattern-author', $post->post_author );
-	} else {
+	} elseif ( 'publish' === $old_status ) {
 		// If the user has no published patterns, remove the badge.
 		$other_posts = get_posts( [
 			'post_type'   => PATTERN_POST_TYPE,
 			'post_status' => 'publish',
-			'post_author' => $post->post_author,
+			'author'      => $post->post_author,
 			'exclude'     => $post->ID,
 			'numberposts' => 1,
 			'fields'      => 'ids',

--- a/public_html/wp-content/plugins/pattern-directory/includes/badges.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/badges.php
@@ -1,0 +1,60 @@
+<?php
+namespace WordPressdotorg\Pattern_Directory\Badges;
+
+use function WordPressdotorg\Profiles\{ assign_badge, remove_badge };
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTERN_POST_TYPE;
+
+/**
+ * Actions and filters.
+ */
+add_action( 'transition_post_status', __NAMESPACE__ . '\status_transitions', 10, 3 );
+add_action( 'remove_user_from_blog', __NAMESPACE__ . '\remove_user_from_blog', 10, 1 );
+add_action( 'set_user_role', __NAMESPACE__ . '\set_user_role', 10, 2 );
+
+function status_transitions( $new_status, $old_status, $post ) {
+	$post = get_post( $post );
+
+	if ( PATTERN_POST_TYPE !== get_post_type( $post ) ) {
+		return;
+	}
+
+	if ( ! function_exists( 'WordPressdotorg\Profiles\assign_badge' ) ) {
+		return;
+	}
+
+	if ( 'publish' === $new_status ) {
+		assign_badge( 'pattern-author', $post->post_author );
+	} else {
+		// If the user has no published patterns, remove the badge.
+		$other_posts = get_posts( [
+			'post_type'   => PATTERN_POST_TYPE,
+			'post_status' => 'publish',
+			'post_author' => $post->post_author,
+			'exclude'     => $post->ID,
+			'numberposts' => 1,
+			'fields'      => 'ids',
+		] );
+
+		if ( ! $other_posts ) {
+			remove_badge( 'pattern-author', $post->post_author );
+		}
+	}
+}
+
+function remove_user_from_blog( $user_id ) {
+	if ( function_exists( 'WordPressdotorg\Profiles\remove_badge' ) ) {
+		remove_badge( 'patterns-team', $user_id );
+	}
+}
+
+function set_user_role( $user_id, $role ) {
+	if ( ! function_exists( 'WordPressdotorg\Profiles\assign_badge' ) ) {
+		return;
+	}
+
+	if ( 'subscriber' === $role || 'contributor' === $role ) {
+		remove_badge( 'patterns-team', $user_id );
+	} else {
+		assign_badge( 'patterns-team', $user_id );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/includes/badges.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/badges.php
@@ -11,6 +11,9 @@ add_action( 'transition_post_status', __NAMESPACE__ . '\status_transitions', 10,
 add_action( 'remove_user_from_blog', __NAMESPACE__ . '\remove_user_from_blog', 10, 1 );
 add_action( 'set_user_role', __NAMESPACE__ . '\set_user_role', 10, 2 );
 
+/**
+ * Watch for pattern status changes, and assign (or remove) the Pattern Author badge as appropriate.
+ */
 function status_transitions( $new_status, $old_status, $post ) {
 	$post = get_post( $post );
 
@@ -24,7 +27,7 @@ function status_transitions( $new_status, $old_status, $post ) {
 
 	if ( 'publish' === $new_status ) {
 		assign_badge( 'pattern-author', $post->post_author );
-	} elseif ( 'publish' === $old_status ) {
+	} elseif ( 'publish' === $old_status && 'publish' !== $new_status ) {
 		// If the user has no published patterns, remove the badge.
 		$other_posts = get_posts( [
 			'post_type'   => PATTERN_POST_TYPE,
@@ -41,12 +44,21 @@ function status_transitions( $new_status, $old_status, $post ) {
 	}
 }
 
+/**
+ * Remove the 'Patterns Team' badge from a user when they're removed from the Patterns site.
+ */
 function remove_user_from_blog( $user_id ) {
 	if ( function_exists( 'WordPressdotorg\Profiles\remove_badge' ) ) {
 		remove_badge( 'patterns-team', $user_id );
 	}
 }
 
+/**
+ * Add/Remove the 'Patterns Team' badge from a user when their role changes.
+ *
+ * The badge is added for all roles except for Contributor and Subscriber.
+ * The badge is removed when the role is set to Contributor or Subscriber.
+ */
 function set_user_role( $user_id, $role ) {
 	if ( ! function_exists( 'WordPressdotorg\Profiles\assign_badge' ) ) {
 		return;


### PR DESCRIPTION
This uses some global functions from https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/profile-helpers.php to automatically assign the `Pattern Author` and `Patterns Team` badges when appropriate.

Author:
 - Added when a pattern is published
 - Removed when a pattern is unpublished, and they have no other published patterns

Team:
 - Added when a user is added with a role > contributor
 - Removed when a user is removed from the site, or set to subscriber/contributor.

Fixes #472

### How to test the changes in this Pull Request:

1. Apply PR to sandbox
2. Add a user to the site, check they get the badge. Remove user. Check.
3. Publish a pattern, check the user gets the badge.
4. Unpublish a pattern, if that was the only pattern by the author, badge should be removed.

<!-- If you can, add the appropriate [Component] label(s). -->
