### PR TITLE
solved issue of select options in patterns page

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-order-select.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-order-select.scss
@@ -11,6 +11,7 @@
 	// Over qualified to override other styles
 	select.components-select-control__input.components-select-control__input {
 		width: auto;
+		line-height: 30px;
 	}
 
 	body.rtl & {


### PR DESCRIPTION
I have solved the issue select option issue by adding the line-height to the specific class.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #495 

<!-- List out anyone who helped with this task. -->
Props [kajalgohel](https://profiles.wordpress.org/kajalgohel/)

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
before:
![CleanShot 2022-05-31 at 12 44 26@2x](https://user-images.githubusercontent.com/88495218/171397842-bd27347b-cb5b-4ff4-8293-592437908066.png)

After: 
![CleanShot 2022-06-01 at 17 21 04@2x](https://user-images.githubusercontent.com/88495218/171398210-e0f24fee-04e1-4c88-a078-9345f8c0cb28.png)



<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Visit https://wordpress.org/patterns/
2. see the select drop-down options
3. You can clearly seen that the text (Newest) is not showing properly, It has some line-height issue
4. I have fixed the issue by adding line-height: 30px; for specific class 
 

<!-- If you can, add the appropriate [Component] label(s). -->
[Component] Theme
