### PR TITLE
6343: Fix issue with positioning of Related Patterns title and author on small screens

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -19,10 +19,10 @@
 
 .pattern-grid {
 	display: grid;
-	margin: 1.5rem 1.5rem 4rem;
+	margin: $gutter-default $gutter-default 4rem;
 	max-width: 960px;
 	grid-template-columns: repeat(auto-fill, minmax(225px, 1fr));
-	gap: 1.5rem;
+	gap: $gutter-default;
 	align-items: start;
 
 	@include breakpoint( $breakpoint-large ) {

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern.scss
@@ -110,6 +110,16 @@ body.single-wporg-pattern {
 		max-width: $size__site-main;
 		margin-left: auto;
 		margin-right: auto;
+
+		> * {
+			margin-left: $gutter-default;
+			margin-right: $gutter-default;
+
+			@include breakpoint( $breakpoint-large ) {
+				margin-left: auto;
+				margin-right: auto;
+			}
+		}
 	}
 
 	.pattern__meta {


### PR DESCRIPTION
This PR adds margin to the Related Patterns section on smaller screens (iPad and below). The margin added matches that applied to the nested pattern grid.

Fixes https://meta.trac.wordpress.org/ticket/6343

### Screenshots

Before:
<img width="800" alt="Screen Shot 2022-06-22 at 1 54 50 PM" src="https://user-images.githubusercontent.com/1017872/174926673-0dc13220-3083-4cb8-ae33-a7a590ccc10d.png">

After:
<img width="807" alt="Screen Shot 2022-06-22 at 1 55 38 PM" src="https://user-images.githubusercontent.com/1017872/174926704-fa409512-9f47-438c-a471-f6059973ef6d.png">

### How to test the changes in this Pull Request:

1. Add 2 patterns to the directory from the same author
2. Navigate to the single page of one of the patterns, eg. http://localhost:8888/pattern/instagram-hero/ and scroll to the bottom so that the section titled 'More from this designer' with a grid of other patterns is visible
3. Resize the window checking that above and below the breakpoint at 960px all the content within this section (title, author and grid) is aligned left