### PR TITLE
Enable navigation and site blocks, add API workarounds

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/includes/mock-blocks.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/mock-blocks.php
@@ -14,6 +14,7 @@ add_action( 'render_block_core/latest-comments', __NAMESPACE__ . '\render_latest
 add_filter( 'render_block_data', __NAMESPACE__ . '\attach_site_data_filters' );
 add_filter( 'render_block', __NAMESPACE__ . '\remove_site_data_filters' );
 add_filter( 'block_core_navigation_render_fallback', __NAMESPACE__ . '\provide_fallback_nav_items' );
+add_filter( 'get_custom_logo', __NAMESPACE__ . '\provide_mock_logo' );
 
 /**
  * Mock the Archives block.
@@ -259,5 +260,19 @@ function provide_fallback_nav_items( $fallback_blocks ) {
 				'isTopLevelLink' => true,
 			),
 		),
+	);
+}
+
+/**
+ * Replace the custom logo output with the WordPress W.
+ * This serves to provide a placeholder for the Site Logo block.
+ *
+ * @param string $html Custom logo HTML output.
+ */
+function provide_mock_logo( $html ) {
+	return sprintf(
+		'<span class="custom-logo-link"><img src="%s" class="custom-logo" alt="%s"></span>',
+		'https://s.w.org/images/wmark.png',
+		__( 'Site logo', 'wporg-patterns' )
 	);
 }

--- a/public_html/wp-content/plugins/pattern-creator/includes/mock-blocks.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/mock-blocks.php
@@ -13,6 +13,7 @@ add_action( 'render_block_core/archives', __NAMESPACE__ . '\render_archives', 10
 add_action( 'render_block_core/latest-comments', __NAMESPACE__ . '\render_latest_comments', 10, 3 );
 add_filter( 'render_block_data', __NAMESPACE__ . '\attach_site_data_filters' );
 add_filter( 'render_block', __NAMESPACE__ . '\remove_site_data_filters' );
+add_filter( 'block_core_navigation_render_fallback', __NAMESPACE__ . '\provide_fallback_nav_items' );
 
 /**
  * Mock the Archives block.
@@ -221,4 +222,42 @@ function replace_site_info( $value, $option, $default ) {
 			return __( 'Site Title placeholder', 'wporg-patterns' );
 	}
 	return $value;
+}
+
+/**
+ * Provide custom links as default for empty Navigation blocks.
+ *
+ * @param array[] $fallback_blocks default fallback blocks provided by the default block mechanic.
+ * @return array[]
+ */
+function provide_fallback_nav_items( $fallback_blocks ) {
+	return array(
+		array(
+			'blockName' => 'core/navigation-link',
+			'attrs' => array(
+				'label' => 'Home',
+				'url' => '#',
+				'kind' => 'custom',
+				'isTopLevelLink' => true,
+			),
+		),
+		array(
+			'blockName' => 'core/navigation-link',
+			'attrs' => array(
+				'label' => 'About',
+				'url' => '#',
+				'kind' => 'custom',
+				'isTopLevelLink' => true,
+			),
+		),
+		array(
+			'blockName' => 'core/navigation-link',
+			'attrs' => array(
+				'label' => 'Contact',
+				'url' => '#',
+				'kind' => 'custom',
+				'isTopLevelLink' => true,
+			),
+		),
+	);
 }

--- a/public_html/wp-content/plugins/pattern-creator/includes/mock-blocks.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/mock-blocks.php
@@ -11,6 +11,8 @@ defined( 'WPINC' ) || die();
 
 add_action( 'render_block_core/archives', __NAMESPACE__ . '\render_archives', 10, 3 );
 add_action( 'render_block_core/latest-comments', __NAMESPACE__ . '\render_latest_comments', 10, 3 );
+add_filter( 'render_block_data', __NAMESPACE__ . '\attach_site_data_filters' );
+add_filter( 'render_block', __NAMESPACE__ . '\remove_site_data_filters' );
 
 /**
  * Mock the Archives block.
@@ -176,4 +178,47 @@ function render_latest_comments( $block_content, $block, $block_instance ) {
 		$wrapper_attributes,
 		$list_items_markup
 	);
+}
+
+/**
+ * Helper function to attach some filters only during the render_callback calls.
+ */
+function attach_site_data_filters( $value ) {
+	add_filter( 'pre_option_blogdescription', __NAMESPACE__ . '\replace_site_info', 10, 3 );
+	add_filter( 'pre_option_blogname', __NAMESPACE__ . '\replace_site_info', 10, 3 );
+
+	return $value;
+}
+
+/**
+ * Helper function to remove filters after the render function runs.
+ *
+ * @see attach_site_data_filters.
+ */
+function remove_site_data_filters( $value ) {
+	remove_filter( 'pre_option_blogdescription', __NAMESPACE__ . '\replace_site_info', 10, 3 );
+	remove_filter( 'pre_option_blogname', __NAMESPACE__ . '\replace_site_info', 10, 3 );
+
+	return $value;
+}
+
+/**
+ * Filter site options to return placeholder content for title & tagline.
+ *
+ * These placeholders should be the same as returned in `src/api-middleware/mock-site-data.js`.
+ *
+ * @param mixed  $value   Value to return.
+ * @param string $option  Option name.
+ * @param mixed  $default The fallback value to return if the option does not exist.
+ *                           Default false.
+ * @return string
+ */
+function replace_site_info( $value, $option, $default ) {
+	switch ( $option ) {
+		case 'blogdescription':
+			return __( 'Site Tagline placeholder', 'wporg-patterns' );
+		case 'blogname':
+			return __( 'Site Title placeholder', 'wporg-patterns' );
+	}
+	return $value;
 }

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -233,6 +233,22 @@ function rest_api_init() {
 	require_once __DIR__ . '/includes/openverse-rest-controller.php';
 	$controller = new \Openverse_REST_Controller();
 	$controller->register_routes();
+
+	// Allow the post type labels through the `types` endpoint when viewing.
+	// This passes the value back to unauthenticated users, which prevents JS
+	// errors when the post-date block tries to use them.
+	register_rest_field(
+		'type', // The object-type for the `types` endpoint.
+		'labels',
+		array(
+			'schema' => array(
+				'description' => __( 'Human-readable labels for the post type for various contexts.', 'wporg-patterns' ),
+				'type'        => 'object',
+				'context'     => array( 'edit', 'view' ),
+				'readonly'    => true,
+			),
+		)
+	);
 }
 add_action( 'rest_api_init', __NAMESPACE__ . '\rest_api_init' );
 

--- a/public_html/wp-content/plugins/pattern-creator/src/api-middleware/filter-endpoints.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/api-middleware/filter-endpoints.js
@@ -1,9 +1,41 @@
+/**
+ * Update the `context` query parameter to view for a set of endpoints.
+ *
+ * @param {string} path The endpoint path (possibly with a query string).
+ * @return {string} The path with the updated context.
+ */
+function maybeUpdateContext( path ) {
+	if ( ! path.includes( 'context=' ) ) {
+		return path;
+	}
+
+	const endpointRegexes = [
+		// All post endpoints.
+		/^\/wp\/v2\/posts/,
+		/^\/wp\/v2\/blocks/,
+		/^\/wp\/v2\/tags/,
+		/^\/wp\/v2\/categories/,
+		// Category and tag taxonomies.
+		/^\/wp\/v2\/taxonomies\/(category|post_tag)/,
+		// All post type endpoints except `wporg-pattern`, which needs to keep the `edit` context.
+		/^\/wp\/v2\/types(?!\/wporg-pattern)/,
+	];
+
+	if ( endpointRegexes.some( ( regex ) => regex.test( path ) ) ) {
+		return path.replace( 'context=edit', 'context=view' );
+	}
+
+	return path;
+}
+
 // Use a middleware provider to intercept and modify API calls.
 // Short-circuit POST requests, bound queries, allow media, etc.
 export default function ( options, next ) {
 	if ( options.path ) {
 		// Add limits to all GET queries which attempt unbound queries
 		options.path = options.path.replace( 'per_page=-1', 'per_page=50' );
+
+		options.path = maybeUpdateContext( options.path );
 	}
 
 	return next( options );

--- a/public_html/wp-content/plugins/pattern-creator/src/api-middleware/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/api-middleware/index.js
@@ -7,6 +7,8 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import filterEndpoints from './filter-endpoints';
+import mockSiteData from './mock-site-data';
 
 // Set up API middleware.
 apiFetch.use( filterEndpoints );
+apiFetch.use( mockSiteData );

--- a/public_html/wp-content/plugins/pattern-creator/src/api-middleware/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/api-middleware/index.js
@@ -1,1 +1,12 @@
-export { default as filterEndpoints } from './filter-endpoints';
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import filterEndpoints from './filter-endpoints';
+
+// Set up API middleware.
+apiFetch.use( filterEndpoints );

--- a/public_html/wp-content/plugins/pattern-creator/src/api-middleware/mock-site-data.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/api-middleware/mock-site-data.js
@@ -7,17 +7,29 @@ import apiFetch from '@wordpress/api-fetch';
 export default apiFetch.createPreloadingMiddleware( {
 	'/?_fields=description,gmt_offset,home,name,site_icon,site_icon_url,site_logo,timezone_string,url': {
 		body: {
-			// Set up default values for use in site-* blocks (site-title, site-tagline).
-			// These placeholders should be the same as returned in `includes/mock-blocks.php`.
+			// Set up default values for use in site-* blocks (site-title,
+			// site-tagline, site-logo). These placeholders should be the same
+			// as content returned in `includes/mock-blocks.php`.
 			name: __( 'Site Title placeholder', 'wporg-patterns' ),
 			description: __( 'Site Tagline placeholder', 'wporg-patterns' ),
 			url: 'https://wordpress.org/patterns',
 			home: 'https://wordpress.org/patterns',
 			gmt_offset: '0',
 			timezone_string: '',
-			site_logo: false, // This needs to be a valid media ID, or false for the placeholder view.
+			// Technically this should be an int (ID), but it's not validated
+			// since the API reponse is preloaded below. Using "logo" to avoid
+			// collision with a real media item.
+			site_logo: 'logo',
 			site_icon: 0,
 			site_icon_url: 'https://s.w.org/images/wmark.png',
+		},
+	},
+	// Replace the custom logo output with the WordPress W.
+	'/wp/v2/media/logo?context=view': {
+		body: {
+			id: 'logo',
+			alt_text: __( 'Site logo', 'wporg-patterns' ),
+			source_url: 'https://s.w.org/images/wmark.png',
 		},
 	},
 } );

--- a/public_html/wp-content/plugins/pattern-creator/src/api-middleware/mock-site-data.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/api-middleware/mock-site-data.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+export default apiFetch.createPreloadingMiddleware( {
+	'/?_fields=description,gmt_offset,home,name,site_icon,site_icon_url,site_logo,timezone_string,url': {
+		body: {
+			// Set up default values for use in site-* blocks (site-title, site-tagline).
+			// These placeholders should be the same as returned in `includes/mock-blocks.php`.
+			name: __( 'Site Title placeholder', 'wporg-patterns' ),
+			description: __( 'Site Tagline placeholder', 'wporg-patterns' ),
+			url: 'https://wordpress.org/patterns',
+			home: 'https://wordpress.org/patterns',
+			gmt_offset: '0',
+			timezone_string: '',
+			site_logo: false, // This needs to be a valid media ID, or false for the placeholder view.
+			site_icon: 0,
+			site_icon_url: 'https://s.w.org/images/wmark.png',
+		},
+	},
+} );

--- a/public_html/wp-content/plugins/pattern-creator/src/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
 /* eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- Experimental is OK. */
 import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
@@ -14,11 +13,8 @@ import { render, unmountComponentAtNode } from '@wordpress/element';
 import { store as patternStore } from './store';
 import './hooks/media';
 import Editor from './components/editor';
-import { filterEndpoints } from './api-middleware';
+import './api-middleware';
 import './style.scss';
-
-// Set up API middleware.
-apiFetch.use( filterEndpoints );
 
 /**
  * Reinitializes the editor after the user chooses to reboot the editor after

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -553,9 +553,6 @@ function remove_disallowed_blocks( $allowed_block_types, $block_editor_context )
 		'core/navigation-submenu',
 		'core/page-list',
 		'core/template-part',
-		'core/site-logo',
-		'core/site-tagline',
-		'core/site-title',
 	);
 
 	if ( isset( $block_editor_context->post ) && POST_TYPE === $block_editor_context->post->post_type ) {

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -547,10 +547,6 @@ function remove_disallowed_blocks( $allowed_block_types, $block_editor_context )
 		'core/nextpage',
 		'core/block', // Reusable blocks
 		'core/shortcode',
-		'core/navigation-area',
-		'core/navigation',
-		'core/navigation-link',
-		'core/navigation-submenu',
 		'core/page-list',
 		'core/template-part',
 	);

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -547,7 +547,6 @@ function remove_disallowed_blocks( $allowed_block_types, $block_editor_context )
 		'core/nextpage',
 		'core/block', // Reusable blocks
 		'core/shortcode',
-		'core/page-list',
 		'core/template-part',
 	);
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
@@ -107,6 +107,11 @@ function Iframe(
         /* Override the Twenty Twenty-One sizes with our custom sizes. */
         --responsive--aligndefault-width: 800px;
         --responsive--alignwide-width: 1000px;
+        --global--color-background: #ffffff;
+        --global--color-primary: #000;
+        --global--color-secondary: #000;
+        --button--color-background: #000;
+        --button--color-text-hover: #000; 
     }
     .${ BODY_CLASS_NAME } {
         padding: 0;


### PR DESCRIPTION
This enables the navigation blocks and site blocks, `core/navigation-area`, `core/navigation`, `core/navigation-link`, `core/navigation-submenu`, `core/site-logo`, `core/site-tagline`, `core/site-title`.

Since most wp.org users won't have permissions to edit menus, posts, or site data, there are added API workarounds.

- API generally: Override context on some endpoints to `view` so they succeed with the level of permissions for a wporg user. Fixes #441.
- Query Loop: Specify that only the `posts` are viewable so only these can be selected. Allow `labels` through the view context so the post date block doesn't break.
- Site blocks: Mock the settings endpoint so we can return placeholder text & logo.
- Navigation: Enable the block, but it still tells the user they can't create menus. If left in, it will show 3 example menu items on the frontend.

## Screenshots

An example pattern with site logo, title, and a nav (frontend view) — technically possible to paste these blocks in, but it displays poorly.

| Before | After |
|--------|------|
| <img width="1014" alt="before" src="https://user-images.githubusercontent.com/541093/184713379-be5ae508-f99b-409b-8d2b-4cc1007710de.png"> | <img width="990" alt="after" src="https://user-images.githubusercontent.com/541093/184713378-6e08869e-dd98-4226-92c9-51534f7898a2.png"> |

Example of site blocks, nav, and query loop (there's an issue with alignment in the row/stack block in the editor, will make an issue for that).

| Editor | Front end |
|--------|------|
| <img width="973" alt="Screen Shot 2022-08-10 at 6 56 27 PM" src="https://user-images.githubusercontent.com/541093/184037251-c4be257d-1640-4a41-b716-793916c9035b.png"> | <img width="932" alt="Screen Shot 2022-08-10 at 6 56 57 PM" src="https://user-images.githubusercontent.com/541093/184037246-be8f5aa4-b1ed-4426-97b9-1d9a3f50ea74.png"> |

### How to test the changes in this Pull Request:

1. Insert any Site blocks (title, logo, tagline), they should work & show placeholder content, not real site content (ex, "Site Title placeholder", not "Block Pattern Directory"
2. Add a Query Loop to show posts, try different blocks in the post template
3. Add a navigation block, it will tell you "You do not have permissions to create Navigation Menus", but if you save the block you'll see a demo menu in the pattern

Try building or copying patterns from https://github.com/WordPress/gutenberg/pull/43157