### PR TITLE
Add gutenberg_get_editor_styles() from Gutenberg 13.6

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -266,3 +266,40 @@ function add_theme_styles_to_editor( $settings ) {
 	return $settings;
 }
 add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\add_theme_styles_to_editor', 20 );
+
+/**
+ * Load editor styles (this is copied from Gutenberg 13.6).
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/release/13.6/lib/compat/wordpress-5.9/edit-site-page.php#L43-L77
+ *
+ * @return array Editor Styles Setting.
+ */
+function gutenberg_get_editor_styles() {
+	global $editor_styles;
+
+	// Ideally the code is extracted into a reusable function.
+	$styles = array();
+
+	if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {
+		foreach ( $editor_styles as $style ) {
+			if ( preg_match( '~^(https?:)?//~', $style ) ) {
+				$response = wp_remote_get( $style );
+				if ( ! is_wp_error( $response ) ) {
+					$styles[] = array(
+						'css' => wp_remote_retrieve_body( $response ),
+					);
+				}
+			} else {
+				$file = get_theme_file_path( $style );
+				if ( is_file( $file ) ) {
+					$styles[] = array(
+						'css'     => file_get_contents( $file ),
+						'baseURL' => get_theme_file_uri( $style ),
+					);
+				}
+			}
+		}
+	}
+
+	return $styles;
+}


### PR DESCRIPTION
Resolves a fatal error temporarily in the Pattern Creator.

See #508

<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] label(s). -->
