### PR TITLE
Theme: Fix layout style bleed from previews into main theme

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -150,13 +150,6 @@ function generate_block_editor_styles_html() {
 	wp_styles()->do_items( $handles );
 	wp_styles()->done = $done;
 
-	// Build up the alignment styles to match the layout set in theme.json.
-	// See https://github.com/WordPress/gutenberg/blob/9d4b83cbbafcd6c6cbd20c86b572f458fc65ff16/lib/block-supports/layout.php#L38
-	$block_gap = wp_get_global_styles( array( 'spacing', 'blockGap' ) );
-	$layout = wp_get_global_settings( array( 'layout' ) );
-	$style = gutenberg_get_layout_style( 'body > div', $layout, true, $block_gap );
-	echo '<style>' . $style . '</style>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-
 	wp_add_inline_script(
 		'wporg-pattern-script',
 		sprintf(

--- a/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/iframe/index.js
@@ -104,6 +104,9 @@ function Iframe(
         align-items: center;
         justify-content: center;
         background-color: white;
+        /* Override the Twenty Twenty-One sizes with our custom sizes. */
+        --responsive--aligndefault-width: 800px;
+        --responsive--alignwide-width: 1000px;
     }
     .${ BODY_CLASS_NAME } {
         padding: 0;
@@ -136,7 +139,6 @@ function Iframe(
 			}
 
 			setHead( contentDocument, headHTML );
-			setBodyClassName( contentDocument );
 			bubbleEvents( contentDocument );
 			setBodyClassName( contentDocument );
 			setIframeDocument( contentDocument );

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-preview/canvas.js
@@ -19,6 +19,7 @@ function Canvas( { html } ) {
 				headHTML={ window.__editorStyles.html }
 			>
 				<div
+					className="entry-content"
 					dangerouslySetInnerHTML={ {
 						__html: html,
 					} }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
@@ -69,6 +69,7 @@ function PatternThumbnail( { className, html } ) {
 				headHTML={ window.__editorStyles.html }
 			>
 				<div
+					className="entry-content"
 					dangerouslySetInnerHTML={ {
 						__html: shouldLoad ? html : '',
 					} }


### PR DESCRIPTION
Fixes #513 — Any styles added via `gutenberg_get_layout_style` will be added to the global `block-supports` store in the style engine (definitely new in GB 13.9, possibly from https://github.com/WordPress/gutenberg/pull/42880). The pattern previews used to need a workaround to support layout width (see #428), which was generating the styles injected via `window.__editorStyles`. This function now also has a side effect of adding that rule to the main site too, which is breaking the admin bar.

The fix added here is to use `entry-content` class on the preview & thumbnail container divs, so that the theme & default styles are correctly applied. Then we can remove the call to `gutenberg_get_layout_style`. Removing old workarounds 👍🏻 

Props kafleg, dd32

### Screenshots

| Before | After |
|--------|-------|
| ![list-before](https://user-images.githubusercontent.com/541093/185496231-3f6dda6a-4c17-45a9-8c2b-5596a27200f6.png) | ![list-after](https://user-images.githubusercontent.com/541093/185496228-3ef68a02-a281-4a15-90bb-69b32d69a23d.png) |
| ![preview-before](https://user-images.githubusercontent.com/541093/185497693-33f27817-cb7c-4a95-88fb-8aad9c59ca72.png) | ![preview-after](https://user-images.githubusercontent.com/541093/185496234-2df78f08-715e-4202-a4ae-a5d1c881ccfb.png) |

This also adds the block spacing between the groups ^ which matches the editor UI, so I think that's overall a good thing.

### How to test the changes in this Pull Request:

1. View the front end, the admin bar should not appear centered
2. Create or view some patterns with varying widths
3. The default width should be 800px wide, wide should be 1000px wide, and full width should be edge-to-edge
4. Block spacing matches the editor
5. There should be no regressions in style

