### PR TITLE
Fix 2 add/remove event listener typos.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
@@ -39,7 +39,7 @@ function PatternThumbnail( { className, html } ) {
 		window.addEventListener( 'resize', handleOnResize );
 
 		return () => {
-			window.addEventListener( 'resize', handleOnResize );
+			window.removeEventListener( 'resize', handleOnResize );
 		};
 	}, [] );
 

--- a/public_html/wp-content/themes/pattern-directory/src/hooks/in-view.js
+++ b/public_html/wp-content/themes/pattern-directory/src/hooks/in-view.js
@@ -26,7 +26,7 @@ const useInView = ( { element } ) => {
 
 		return () => {
 			window.removeEventListener( 'scroll', debouncedIsVisible );
-			window.addEventListener( 'resize', debouncedIsVisible );
+			window.removeEventListener( 'resize', debouncedIsVisible );
 		};
 	}, [ element ] );
 


### PR DESCRIPTION
This PR updates 2 _typos_ that lead to significantly more `resize` event listeners on the `window`.

### How to test the changes in this Pull Request:

1. Load the pattern homepage in the Chrome Developer Tools console, run `getEventListeners(window).resize`.
2. Choose a different category (will the same number of patterns)
3. run `getEventListeners(window).resize`, expect to see the same number of resize events.

