### PR TITLE
Use `mshots` service to generate pattern screenshots

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-grid.scss
@@ -46,6 +46,10 @@
 
 	.pattern-grid__preview {
 		overflow: hidden;
+
+		&.has-error {
+			color: color(red-60);
+		}
 	}
 
 	.pattern-grid__status {

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -79,7 +79,7 @@ function enqueue_assets() {
 		wp_add_inline_script(
 			'wporg-pattern-script',
 			sprintf(
-				"var wporgLocale = JSON.parse( decodeURIComponent( '%s' ) )",
+				"var wporgLocale = JSON.parse( decodeURIComponent( '%s' ) );",
 				rawurlencode( wp_json_encode( array(
 					'id' => get_locale(),
 					'displayName' => is_rosetta_site() ? get_rosetta_name() : '',
@@ -91,10 +91,11 @@ function enqueue_assets() {
 		wp_add_inline_script(
 			'wporg-pattern-script',
 			sprintf(
-				"var wporgPatternsData = JSON.parse( decodeURIComponent( '%s' ) )",
+				"var wporgPatternsData = JSON.parse( decodeURIComponent( '%s' ) );",
 				rawurlencode( wp_json_encode( array(
-					'userId' => get_current_user_id(),
 					'currentAuthorName' => esc_html( get_the_author_meta( 'display_name' ) ),
+					'thumbnailVersion' => 1, // cachebuster for the generated thumbnail image.
+					'userId' => get_current_user_id(),
 				) ) ),
 			),
 			'before'
@@ -103,7 +104,7 @@ function enqueue_assets() {
 		wp_add_inline_script(
 			'wporg-pattern-script',
 			sprintf(
-				"var wporgPatternsUrl = JSON.parse( decodeURIComponent( '%s' ) )",
+				"var wporgPatternsUrl = JSON.parse( decodeURIComponent( '%s' ) );",
 				rawurlencode( wp_json_encode( array(
 					'assets' => esc_url( get_stylesheet_directory_uri() ),
 					'site' => esc_url( home_url() ),

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -94,6 +94,7 @@ function enqueue_assets() {
 				"var wporgPatternsData = JSON.parse( decodeURIComponent( '%s' ) );",
 				rawurlencode( wp_json_encode( array(
 					'currentAuthorName' => esc_html( get_the_author_meta( 'display_name' ) ),
+					'env' => esc_js( wp_get_environment_type() ),
 					'thumbnailVersion' => 1, // cachebuster for the generated thumbnail image.
 					'userId' => get_current_user_id(),
 				) ) ),

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
 
 /**
@@ -9,14 +9,14 @@ import { useEffect, useRef, useState } from '@wordpress/element';
  */
 import getCardFrameHeight from '../../utils/get-card-frame-height';
 import useInView from '../../hooks/in-view';
+import Screenshot from './screenshot';
 
 const VIEWPORT_WIDTH = 1200;
 
-export default function ( { url } ) {
+export default function ( { alt, url } ) {
 	const wrapperRef = useRef();
-	const [ frameHeight, setFrameHeight ] = useState( '1px' );
-	const [ frameScale, setFrameScale ] = useState( 0.3125 );
 	const isVisible = useInView( { element: wrapperRef } );
+	const [ frameHeight, setFrameHeight ] = useState( '1px' );
 	const [ shouldLoad, setShouldLoad ] = useState( false );
 
 	useEffect( () => {
@@ -29,7 +29,6 @@ export default function ( { url } ) {
 		const handleOnResize = () => {
 			try {
 				setFrameHeight( getCardFrameHeight( wrapperRef.current.clientWidth ) );
-				setFrameScale( wrapperRef.current.clientWidth / VIEWPORT_WIDTH );
 			} catch ( err ) {}
 		};
 
@@ -40,32 +39,27 @@ export default function ( { url } ) {
 		return () => {
 			window.removeEventListener( 'resize', handleOnResize );
 		};
-	}, [] );
+	}, [ isVisible ] );
 
 	const style = {
 		border: 'none',
-		width: `${ VIEWPORT_WIDTH }px`,
+		width: '100%',
 		maxWidth: 'none',
-		height: `${ getCardFrameHeight( VIEWPORT_WIDTH ) }px`,
-		transform: `scale(${ frameScale })`,
-		transformOrigin: isRTL() ? 'top right' : 'top left',
-		pointerEvents: 'none',
+		height: `${ frameHeight }px`,
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
 	};
 
 	return (
-		<div
-			ref={ wrapperRef }
-			style={ {
-				height: frameHeight,
-				overflow: 'hidden',
-			} }
-		>
-			<iframe
+		<div ref={ wrapperRef }>
+			<Screenshot
 				className="pattern-grid__preview"
-				title={ __( 'Pattern Preview', 'wporg-patterns' ) }
-				tabIndex="-1"
+				alt={ alt || __( 'Pattern Preview', 'wporg-patterns' ) }
 				style={ style }
-				src={ shouldLoad ? url : '' }
+				size={ { width: VIEWPORT_WIDTH, height: getCardFrameHeight( VIEWPORT_WIDTH ) } }
+				isReady={ shouldLoad }
+				src={ url }
 			/>
 		</div>
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
@@ -11,8 +11,6 @@ import getCardFrameHeight from '../../utils/get-card-frame-height';
 import useInView from '../../hooks/in-view';
 import Screenshot from './screenshot';
 
-const VIEWPORT_WIDTH = 1200;
-
 export default function ( { alt, url } ) {
 	const wrapperRef = useRef();
 	const isVisible = useInView( { element: wrapperRef } );
@@ -57,7 +55,6 @@ export default function ( { alt, url } ) {
 				className="pattern-grid__preview"
 				alt={ alt || __( 'Pattern Preview', 'wporg-patterns' ) }
 				style={ style }
-				size={ { width: VIEWPORT_WIDTH, height: getCardFrameHeight( VIEWPORT_WIDTH ) } }
 				isReady={ shouldLoad }
 				src={ url }
 			/>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
@@ -56,7 +56,11 @@ export default function ( { alt, url } ) {
 				alt={ alt || __( 'Pattern Preview', 'wporg-patterns' ) }
 				style={ style }
 				isReady={ shouldLoad }
-				src={ url }
+				src={
+					wporgPatternsData.env === 'local'
+						? url.replace( wporgPatternsUrl.site, 'https://wordpress.org/patterns' )
+						: url
+				}
 			/>
 		</div>
 	);

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
@@ -34,7 +34,13 @@ function PatternThumbnail( { pattern, showAvatar, showOptions } ) {
 			<div className="pattern-grid__pattern-frame">
 				<a href={ pattern.link } rel="bookmark">
 					<span className="screen-reader-text">{ decodeEntities( pattern.title.rendered ) }</span>
-					<Canvas url={ addQueryArgs( pattern.link, { view: true, modified: pattern.modified_gmt } ) } />
+					<Canvas
+						url={ addQueryArgs( pattern.link, {
+							view: true,
+							modified: pattern.modified_gmt,
+							version: wporgPatternsData.thumbnailVersion,
+						} ) }
+					/>
 				</a>
 				{ statusLabel ? (
 					<div className={ `pattern-grid__status is-${ pattern.status }` }>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
@@ -34,7 +34,7 @@ function PatternThumbnail( { pattern, showAvatar, showOptions } ) {
 			<div className="pattern-grid__pattern-frame">
 				<a href={ pattern.link } rel="bookmark">
 					<span className="screen-reader-text">{ decodeEntities( pattern.title.rendered ) }</span>
-					<Canvas url={ addQueryArgs( pattern.link, { view: true } ) } />
+					<Canvas url={ addQueryArgs( pattern.link, { view: true, modified: pattern.modified_gmt } ) } />
 				</a>
 				{ statusLabel ? (
 					<div className={ `pattern-grid__status is-${ pattern.status }` }>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
@@ -3,7 +3,6 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { Disabled } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -35,9 +34,7 @@ function PatternThumbnail( { pattern, showAvatar, showOptions } ) {
 			<div className="pattern-grid__pattern-frame">
 				<a href={ pattern.link } rel="bookmark">
 					<span className="screen-reader-text">{ decodeEntities( pattern.title.rendered ) }</span>
-					<Disabled>
-						<Canvas url={ addQueryArgs( pattern.link, { view: true } ) } />
-					</Disabled>
+					<Canvas url={ addQueryArgs( pattern.link, { view: true } ) } />
 				</a>
 				{ statusLabel ? (
 					<div className={ `pattern-grid__status is-${ pattern.status }` }>

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
@@ -1,0 +1,117 @@
+/* global FileReader, fetch */
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { Spinner } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useInterval from '../../hooks/use-interval';
+
+/**
+ * Module constants
+ */
+const MAX_ATTEMPTS = 10;
+const RETRY_DELAY = 1000;
+
+/**
+ *
+ * We are using mShots which is a project that generates a screenshot from a webpage.
+ * Since the screenshot generation takes some time, for never seen websites,
+ * we need to do some custom handling.
+ *
+ * @param {Object}  props
+ * @param {string}  props.alt       The alt text for the screenshot image.
+ * @param {string}  props.className Any extra class names for the wrapper div.
+ * @param {boolean} props.isReady   Whether we should start try to show the image.
+ * @param {Object}  props.size      The viewport size to take the screenshot at.
+ * @param {Object}  props.style     Styles for the wrapper div.
+ * @param {string}  props.src       The url of the page to screenshot.
+ * @return {Object} React component
+ */
+export default function ( { alt, className, isReady = false, size, src, style } ) {
+	const fullUrl = addQueryArgs( `https://s0.wp.com/mshots/v1/${ encodeURIComponent( src ) }`, {
+		vpw: size.width,
+		vph: size.height,
+	} );
+
+	const [ attempts, setAttempts ] = useState( 0 );
+	const [ hasLoaded, setHasLoaded ] = useState( false );
+	const [ hasError, setHasError ] = useState( false );
+	const [ base64Img, setBase64Img ] = useState( '' );
+
+	// We don't want to keep trying infinitely.
+	const hasAborted = attempts > MAX_ATTEMPTS;
+
+	// The derived loading state
+	const isLoading = isReady && ! hasLoaded && ! hasAborted && ! hasError;
+
+	/**
+	 * Since we already made the request, we'll use the response to be frugal.
+	 *
+	 * @param {string} res
+	 */
+	const convertResponseToBase64 = async ( res ) => {
+		const blob = await res.blob();
+
+		const reader = new FileReader();
+		reader.onload = ( event ) => {
+			setBase64Img( event.target.result );
+		};
+		reader.readAsDataURL( blob );
+	};
+
+	/**
+	 * The Snapshot service will redirect when its generating an image.
+	 * We want to continue requesting the image until it doesn't redirect.
+	 */
+	useInterval(
+		async () => {
+			try {
+				const res = await fetch( fullUrl );
+
+				if ( res.status === 200 && ! res.redirected ) {
+					await convertResponseToBase64( res );
+
+					setHasLoaded( true );
+				} else {
+					setAttempts( attempts + 1 );
+				}
+			} catch ( error ) {
+				setHasError( true );
+			}
+		},
+		isLoading ? RETRY_DELAY : null
+	);
+
+	if ( ! isReady ) {
+		return null;
+	}
+
+	if ( isLoading ) {
+		return (
+			<div className={ `${ className } is-loading` } style={ style }>
+				<Spinner style={ { width: '33%', height: '33%' } } />
+				<span className="screen-reader-text">{ __( 'Loading', 'wporg-patterns' ) }</span>
+			</div>
+		);
+	}
+
+	if ( hasError || hasAborted ) {
+		return (
+			<div className={ `${ className } has-error` } style={ style }>
+				{ __( 'Error', 'wporg-patterns' ) }
+			</div>
+		);
+	}
+
+	return (
+		<div className={ className }>
+			<img src={ base64Img } alt={ alt } style={ { ...style, verticalAlign: 'middle' } } />
+		</div>
+	);
+}

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
@@ -95,7 +95,7 @@ export default function ( { alt, className, isReady = false, size, src, style } 
 	if ( isLoading ) {
 		return (
 			<div className={ `${ className } is-loading` } style={ style }>
-				<Spinner style={ { width: '33%', height: '33%' } } />
+				<Spinner style={ { width: '32px', height: '32px' } } />
 				<span className="screen-reader-text">{ __( 'Loading', 'wporg-patterns' ) }</span>
 			</div>
 		);

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
@@ -10,6 +10,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import getCardFrameHeight from '../../utils/get-card-frame-height';
 import useInterval from '../../hooks/use-interval';
 
 /**
@@ -17,6 +18,8 @@ import useInterval from '../../hooks/use-interval';
  */
 const MAX_ATTEMPTS = 10;
 const RETRY_DELAY = 1000;
+const VIEWPORT_WIDTH = 1200;
+const IMAGE_WIDTH = 600;
 
 /**
  *
@@ -28,15 +31,15 @@ const RETRY_DELAY = 1000;
  * @param {string}  props.alt       The alt text for the screenshot image.
  * @param {string}  props.className Any extra class names for the wrapper div.
  * @param {boolean} props.isReady   Whether we should start try to show the image.
- * @param {Object}  props.size      The viewport size to take the screenshot at.
  * @param {Object}  props.style     Styles for the wrapper div.
  * @param {string}  props.src       The url of the page to screenshot.
  * @return {Object} React component
  */
-export default function ( { alt, className, isReady = false, size, src, style } ) {
+export default function ( { alt, className, isReady = false, src, style } ) {
 	const fullUrl = addQueryArgs( `https://s0.wp.com/mshots/v1/${ encodeURIComponent( src ) }`, {
-		vpw: size.width,
-		vph: size.height,
+		w: IMAGE_WIDTH, // eslint-disable-line id-length
+		vpw: VIEWPORT_WIDTH,
+		vph: getCardFrameHeight( VIEWPORT_WIDTH ),
 	} );
 
 	const [ attempts, setAttempts ] = useState( 0 );

--- a/public_html/wp-content/themes/pattern-directory/src/hooks/use-interval.js
+++ b/public_html/wp-content/themes/pattern-directory/src/hooks/use-interval.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Thanks! https://overreacted.io/making-setinterval-declarative-with-react-hooks/.
+ *
+ * @param {Function} callback
+ * @param {number}   delay
+ */
+export default function ( callback, delay ) {
+	const savedCallback = useRef();
+
+	useEffect( () => {
+		savedCallback.current = callback;
+	}, [ callback ] );
+
+	useEffect( () => {
+		function tick() {
+			savedCallback.current();
+		}
+		if ( delay !== null ) {
+			const id = setInterval( tick, delay );
+			return () => clearInterval( id );
+		}
+	}, [ delay ] );
+}


### PR DESCRIPTION
See https://github.com/WordPress/pattern-directory/pull/521#discussion_r979500622 — This swaps out the iframes in the pattern grid in favor of an mshots request. This does improve the number and overall size of requests, but it doesn't work on local sites.

**Stats** for loading the homepage (and scrolling down to load all pattern previews)

`trunk`: 416 requests, 30.75 MB / 9.35 MB transferred.
`try/mshots`: 177 requests, 5.91 MB / 3.28 MB transferred.

I forked [the ScreenShotImg component from `wporg-mu-plugins`](https://github.com/WordPress/wporg-mu-plugins/blob/trunk/mu-plugins/blocks/screenshot-preview/src/screenshot.js) so it could be used here, and added a few more props.

Fixes #349

### Screenshots

| Before | After |
|--------|------|
| <video src="https://user-images.githubusercontent.com/541093/194179167-04a45eed-9ecd-4daa-bacb-b8d4058762eb.mp4"> | <video src="https://user-images.githubusercontent.com/541093/194179174-d3c48a65-8580-4d06-bcd2-616d8b64d68f.mp4"> |

On local sites it just returns this 403 image. This is not great, but I'm not sure if this should be a blocker.

![Screen Shot 2022-10-05 at 19 08 47](https://user-images.githubusercontent.com/541093/194180097-cdfcd059-66f3-4296-b1e9-12ba441efc23.png)

### How to test the changes in this Pull Request:

1. Apply this to a sandbox
2. View assorted pattern grids — categories, my patterns, etc
3. The small pattern previews should look correct & match the larger preview on the pattern detail page
