### PR TITLE
Patterns: Decode potentially-malformed ampersands in block content

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -298,7 +298,7 @@ function register_rest_fields() {
 		'pattern_content',
 		array(
 			'get_callback' => function() {
-				return wp_kses_post( get_the_content() );
+				return decode_pattern_content( get_the_content() );
 			},
 
 			'schema' => array(
@@ -793,3 +793,28 @@ add_action(
 		exit;
 	}
 );
+
+/**
+ * Intercept the post object and decode the content.
+ */
+add_action(
+	'the_post',
+	function( $post ) {
+		$post->post_content = decode_pattern_content( $post->post_content );
+	}
+);
+
+/**
+ * Process post content, replacing broken encoding.
+ *
+ * Some image URLs have &s, which are double-encoded and sanitized to become malformed,
+ * for example, `https://img.rawpixel.com/s3fs-private/rawpixel_images/website_content/a010-markuss-0964.jpg?w=1200\u0026amp;h=1200\u0026amp;fit=clip\u0026amp;crop=default\u0026amp;dpr=1\u0026amp;q=75\u0026amp;vib=3\u0026amp;con=3\u0026amp;usm=15\u0026amp;cs=srgb\u0026amp;bg=F4F4F3\u0026amp;ixlib=js-2.2.1\u0026amp;s=7d494bd5db8acc2a34321c15ed18ace5`.
+ *
+ * @param string $content The raw post content.
+ *
+ * @return string
+ */
+function decode_pattern_content( $content ) {
+	// Sometimes the initial `\` is missing, so look for both versions.
+	return str_replace( [ '\u0026amp;', 'u0026amp;' ], '&', $content );
+}

--- a/public_html/wp-content/themes/pattern-directory/functions.php
+++ b/public_html/wp-content/themes/pattern-directory/functions.php
@@ -214,26 +214,6 @@ function user_has_flagged_pattern() {
 }
 
 /**
- * Get the full, filtered content of a post, ignoring more and noteaser tags and pagination.
- *
- * See https://github.com/WordPress/wordcamp.org/blob/442ea26d8e6a1b39f97114e933842b1ec4f8eef9/public_html/wp-content/mu-plugins/blocks/includes/content.php#L21
- *
- * @param int|WP_Post $post Post ID or post object.
- * @return string The full, filtered post content.
- */
-function get_all_the_content( $post ) {
-	$post = get_post( $post );
-
-	$content = wp_kses_post( $post->post_content );
-
-	/** This filter is documented in wp-includes/post-template.php */
-	$content = apply_filters( 'the_content', $content );
-	$content = str_replace( ']]>', ']]&gt;', $content );
-
-	return $content;
-}
-
-/**
  * Set up redirects for the site.
  *
  * @return void

--- a/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
+++ b/public_html/wp-content/themes/pattern-directory/single-wporg-pattern.php
@@ -8,43 +8,42 @@
  */
 
 namespace WordPressdotorg\Pattern_Directory\Theme;
-use function WordPressdotorg\Pattern_Directory\Theme\get_all_the_content;
+use function WordPressdotorg\Pattern_Directory\Pattern_Post_Type\decode_pattern_content;
 
 get_header();
 
-$user_has_reported = is_user_logged_in() ? user_has_flagged_pattern() : false;
-$raw_block_content = get_the_content();
-?>
+while ( have_posts() ) :
+	the_post();
+
+	$user_has_reported = is_user_logged_in() ? user_has_flagged_pattern() : false;
+	$raw_block_content = decode_pattern_content( get_the_content() );
+	?>
+
 	<input id="block-data" type="hidden" value="<?php echo rawurlencode( wp_json_encode( $raw_block_content ) ); ?>" />
 	<main id="main" class="site-main col-12" role="main">
 
-		<?php
-		while ( have_posts() ) :
-			the_post();
-			?>
+		<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<div
+				hidden
+				class="pattern__container"
+				data-post-id="<?php echo intval( get_the_ID() ); ?>"
+				data-user-has-reported="<?php echo json_encode( $user_has_reported ); ?>"
+			></div><!-- .pattern__container -->
 
-			<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-				<div
-					hidden
-					class="pattern__container"
-					data-post-id="<?php echo intval( get_the_ID() ); ?>"
-					data-user-has-reported="<?php echo json_encode( $user_has_reported ); ?>"
-				></div><!-- .pattern__container -->
+			<div class="entry-content hide-if-pattern-loaded">
+				<?php the_content(); ?>
 
-				<div class="entry-content hide-if-pattern-loaded">
-					<?php the_content(); ?>
+				<hr />
 
-					<hr />
+				<label for="pattern-code"><?php esc_html_e( 'Pattern Code', 'wporg-patterns' ); ?></label>
+				<textarea id="pattern-code" class="pattern-code"><?php echo esc_attr( $raw_block_content ); ?></textarea>
+			</div>
 
-					<label for="pattern-code"><?php esc_html_e( 'Pattern Code', 'wporg-patterns' ); ?></label>
-					<textarea id="pattern-code" class="pattern-code"><?php echo esc_attr( $raw_block_content ); ?></textarea>
-				</div>
-
-			</article><!-- #post-## -->
-
-		<?php endwhile; ?>
+		</article><!-- #post-## -->
 
 	</main><!-- #main -->
 
-<?php
+	<?php
+endwhile;
+
 get_footer();


### PR DESCRIPTION
Fixes #488 — As described there, sometimes images are saved with the ampersands multiply-encoded, resulting in strings like `…img.jpg?w=1200\u0026amp;h=1200\u0026amp;fit=clip`. When used in the editor, the first encoding is decoded, but then `…img.jpg?w=1200&amp;h=1200&amp;fit=clip` is not decoded, and causes a 403 error from rawpixel.

Additionally, sometimes the slash is stripped, leading to these URLs `…img.jpg?w=1200u0026amp;h=1200u0026amp;fit=clip`, which cause a block validation error.

This PR does a very simple string-replacement for these two cases, only on output. Looking for review to make sure this doesn't have any unexpected side effects.

I also removed `get_all_the_content`, it isn't used in this project after all.

### How to test the changes in this Pull Request:

1. Apply to your sandbox
2. Try copying this pattern: https://wordpress.org/patterns/pattern/step-by-step-process/
3. It should load with no validation error
4. Try copying this pattern: https://wordpress.org/patterns/pattern/shark-hero-banner/
5. The image should show up, with no 403 errors in the console
6. Make sure other patterns still work

Copy patterns using both copy buttons — the one on the single pattern page and in the grid view.
