### PR TITLE
Use `REST_REQUEST` over `wp_is_json_request()`

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/search.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/search.php
@@ -45,13 +45,7 @@ function sync_pattern_meta( $post_meta_safelist ) {
  * @return bool
  */
 function should_handle_query( $handle_query, $query ) {
-	/*
-	 * This isn't really what `wp_is_json_request()` is meant for, but it's the best option until something like
-	 * `wp_doing_rest()` is available.
-	 *
-	 * @link https://core.trac.wordpress.org/ticket/42061
-	 */
-	return wp_is_json_request() && $query->is_search() && POST_TYPE === $query->get( 'post_type' );
+	return defined( 'REST_REQUEST' ) && REST_REQUEST && $query->is_search() && POST_TYPE === $query->get( 'post_type' );
 }
 
 /**


### PR DESCRIPTION
When accessing REST API's via the browser, `wp_is_json_request()` is false which causes the ES modification args not to kick in.

By changing to the `REST_REQUEST` constant it should affect it, while also catching the same scenario's.

The one case that this won't catch, is when a PHP function is making a rest-api call from within a non-rest-api request. However. The existing check also doesn't work in that case, unless it was an XHR request with the appropriate json headers.

I think this change is safe, but PR'ing incase there's something else preventing this.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #, See #

<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] label(s). -->
