### PR TITLE
Pattern Preview: Add a placeholder for empty media blocks

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/views/view.php
+++ b/public_html/wp-content/plugins/pattern-directory/views/view.php
@@ -26,6 +26,13 @@ remove_action( 'wp_footer', 'stats_footer', 101 );
 			margin-top: 0;
 			margin-bottom: 0;
 		}
+		.wp-block-image svg,
+		.wp-block-video svg,
+		.wp-block-media-text__media svg {
+			vertical-align: middle;
+			width: 100%;
+			max-height: 200px;
+		}
 	</style>
 </head>
 

--- a/public_html/wp-content/plugins/pattern-directory/views/view.php
+++ b/public_html/wp-content/plugins/pattern-directory/views/view.php
@@ -33,6 +33,13 @@ remove_action( 'wp_footer', 'stats_footer', 101 );
 			width: 100%;
 			max-height: 200px;
 		}
+		/*
+		 * Workaround for placeholder color when used in a white-background cover block.
+		 * TT1 sets the color in covers to white, which makes the placeholder invisible.
+		 */
+		.wp-block-cover__background.has-white-background-color + .wp-block-cover__inner-container {
+			color: var(--global--color-primary);
+		}
 	</style>
 </head>
 


### PR DESCRIPTION
If a pattern uses an empty media block, it should show a placeholder in the pattern preview. This applies to Gallery, Image, Media & Text, and Video blocks.

I've copied the styles from the current Gutenberg placeholder, but it's not the dashed lines in the original issue — @beafialho do you want me to customize this to use the dashed lines of the mockup, or should it match the editor?

Fixes #524.

### Screenshots

Replacing an image

| Light background | Dark background |
|------------------|------------------|
| ![](https://user-images.githubusercontent.com/541093/200016319-0af592b7-cb39-480d-ae6e-470c12ead874.png) | ![](https://user-images.githubusercontent.com/541093/200016316-e0e01414-978c-4d97-8a4e-c5abbba017a2.png) |

Replacing 2 galleries — an empty gallery doesn't have a placeholder in the editor, but I thought replacing it like this, with 3 placeholder images, worked well.

![](https://user-images.githubusercontent.com/541093/200016189-82eced59-832c-43bb-9eb8-1cb2e24f4de0.png)

In context in the pattern previewer

![](https://user-images.githubusercontent.com/541093/200020958-4465c933-8173-4066-80c7-7e5b08e67a63.png)

### How to test the changes in this Pull Request:

1. Create a pattern, add a media block (Gallery, Image, Media & Text, or Video)
2. Don't set any media in it
3. Save it and view the preview
4. There should be a placeholder box where the image goes
5. If you add a classname or other settings (ex, border radius) they should be reflected on the placeholder

This won't affect the previews in the thumbnails until after it's deployed and the cachebuster is updated. See #528.
