### PR TITLE
Add meta and query parameter to fetch patterns matching a list of allowed blocks

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/bin/update-contains-block-types.php
+++ b/public_html/wp-content/plugins/pattern-directory/bin/update-contains-block-types.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Update all patterns with the "contains block types" meta field.
+ *
+ * To run locally, use `wp-env`, ex:
+ * yarn wp-env run cli "php wp-content/plugins/pattern-directory/bin/update-contains-block-types.php --all --per_page=100 --apply"
+ *
+ * To run in a sandbox, use php directly, ex:
+ * php ./bin/update-contains-block-types.php --all --apply
+ */
+
+namespace WordPressdotorg\Pattern_Directory;
+
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE };
+
+// This script should only be called in a CLI environment.
+if ( 'cli' != php_sapi_name() ) {
+	die();
+}
+
+$opts = getopt( '', array( 'post:', 'url:', 'abspath:', 'per_page:', 'all', 'apply', 'verbose' ) );
+
+if ( empty( $opts['url'] ) ) {
+	$opts['url'] = 'https://wordpress.org/patterns/';
+}
+
+if ( empty( $opts['abspath'] ) && false !== strpos( __DIR__, 'wp-content' ) ) {
+	$opts['abspath'] = substr( __DIR__, 0, strpos( __DIR__, 'wp-content' ) );
+}
+
+$opts['apply']   = isset( $opts['apply'] );
+$opts['verbose'] = isset( $opts['verbose'] );
+$opts['all']     = isset( $opts['all'] );
+
+// Bootstrap WordPress
+$_SERVER['HTTP_HOST']   = parse_url( $opts['url'], PHP_URL_HOST );
+$_SERVER['REQUEST_URI'] = parse_url( $opts['url'], PHP_URL_PATH );
+
+require rtrim( $opts['abspath'], '/' ) . '/wp-load.php';
+
+if ( ! $opts['all'] && ! isset( $opts['post'] ) ) {
+	fwrite( STDERR, "Error! Either specify a post ID with --post=<ID> or explicitly run over --all.\n" );
+	die();
+}
+
+if ( ! $opts['apply'] ) {
+	echo "Dry run, will not update any patterns.\n";
+}
+
+$args = array(
+	'post_type'      => POST_TYPE,
+	'post_status'    => array( 'publish', 'pending' ),
+	'posts_per_page' => isset( $opts['per_page'] ) ? $opts['per_page'] : -1,
+	'post_parent'    => 0,
+	'orderby'        => 'date',
+	'order'          => 'DESC',
+	'meta_query'     => array(
+		// Only update patterns without this meta.
+		array(
+			'key'     => 'wpop_contains_block_types',
+			'compare' => 'NOT EXISTS',
+		),
+	),
+);
+if ( isset( $opts['post'] ) ) {
+	$args = array(
+		'post_type' => POST_TYPE,
+		'p' => absint( $opts['post'] ),
+	);
+}
+
+$query = new \WP_Query( $args );
+$meta_updated = 0;
+
+while ( $query->have_posts() ) {
+	$query->the_post();
+	$pattern    = get_post();
+	$pattern_id = $pattern->ID;
+	$blocks     = parse_blocks( $pattern->post_content );
+	$all_blocks = _flatten_blocks( $blocks );
+
+	// Get the list of block names and convert it to a single string.
+	$block_names = wp_list_pluck( $all_blocks, 'blockName' );
+	$block_names = array_filter( $block_names );
+	$block_names = array_unique( $block_names );
+	sort( $block_names );
+	$used_blocks = implode( ',', $block_names );
+
+	if ( $opts['apply'] ) {
+		$result = update_post_meta( $pattern_id, 'wpop_contains_block_types', $used_blocks );
+		if ( $result ) {
+			$meta_updated++;
+		} else if ( $opts['verbose'] ) {
+			echo "Error updating {$pattern_id}.\n"; // phpcs:ignore
+		}
+	} else if ( $opts['verbose'] ) {
+		echo "Will update {$pattern_id} with '{$used_blocks}'.\n"; // phpcs:ignore
+	}
+}
+
+echo "Updated {$meta_updated} patterns.\n"; // phpcs:ignore
+echo "Done.\n\n"; // phpcs:ignore

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -653,6 +653,14 @@ function filter_patterns_collection_params( $query_params ) {
 		'type'        => 'string',
 	);
 
+	$query_params['allowed_blocks'] = array(
+		'description' => __( 'Filter the request to only return patterns with blocks on this list.', 'wporg-patterns' ),
+		'type'        => 'array',
+		'items'       => array(
+			'type' => 'string',
+		),
+	);
+
 	return $query_params;
 }
 
@@ -715,6 +723,16 @@ function filter_patterns_rest_query( $args, $request ) {
 				'key'     => 'wpop_wp_version',
 				'compare' => 'NOT EXISTS',
 			),
+		);
+	}
+
+	$allowed_blocks = $request->get_param( 'allowed_blocks' );
+	if ( $allowed_blocks ) {
+		// Only return a pattern if all contained blocks are in the allowed blocks list.
+		$args['meta_query']['allowed_blocks'] = array(
+			'key'     => 'wpop_contains_block_types',
+			'compare' => 'REGEXP',
+			'value'   => '^((' . implode( '|', $allowed_blocks ) . '),?)+$',
 		);
 	}
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -249,6 +249,24 @@ function register_post_type_data() {
 			),
 		)
 	);
+
+	register_post_meta(
+		POST_TYPE,
+		'wpop_contains_block_types',
+		array(
+			'type'              => 'string',
+			'description'       => 'A list of block types used in this pattern',
+			'single'            => true,
+			'default'           => '',
+			'sanitize_callback' => 'sanitize_text_field',
+			'auth_callback'     => __NAMESPACE__ . '\can_edit_this_pattern',
+			'show_in_rest'      => array(
+				'schema' => array(
+					'type'     => 'string',
+				),
+			),
+		)
+	);
 }
 
 /**

--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -47,10 +47,14 @@ function create_or_update_translated_pattern( Pattern $pattern ) {
 		'post_author'  => $parent->post_author ?? 0,
 		'post_status'  => $parent->post_status ?? 'pending',
 		'meta_input'   => [
-			'wpop_description'    => $pattern->description,
-			'wpop_locale'         => $pattern->locale,
-			'wpop_viewport_width' => $parent->wpop_viewport_width,
-			'wpop_is_translation' => true,
+			'wpop_description'          => $pattern->description,
+			'wpop_locale'               => $pattern->locale,
+			'wpop_keywords'             => $pattern->keywords,
+			'wpop_viewport_width'       => $parent->wpop_viewport_width,
+			'wpop_block_types'          => $parent->wpop_block_types,
+			'wpop_contains_block_types' => $parent->wpop_contains_block_types,
+			'wpop_wp_version'           => $parent->wpop_wp_version,
+			'wpop_is_translation'       => true,
 		],
 	];
 


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/45237

> Another really important issue is that if we make any request to the PD, the eligible patterns to be inserted are subject to the `allowedBlocks` in the editor or a block. What this means is that we could fetch 10 patterns for example where none of them could be inserted.

This PR aims to add an API parameter `allowed_blocks` to the local endpoint<sup>[1]</sup> so that sites with restrictions can pass through the list of valid blocks, and the pattern directory will return only patterns with blocks on the list.

To do this, a new meta value is used to track the blocks in a pattern, `wpop_contains_block_types`. There's also a migration script which can be run on a sandbox to update all existing patterns, a hook to update the meta when a pattern is updated, and the meta is set on translated patterns when those are updated.

cc @ntsekouras 

-----

**[1]** Once merged, it should be available in `api.w.org`, but will need another Gutenberg PR before it can be used in the editor.

### How to test the changes in this Pull Request:

**Test the migration script**

1. You can run the script on your docker wp-env using the `cli` container.
2. To dry-run over all posts, use:
  `yarn wp-env run cli "php wp-content/plugins/pattern-directory/bin/update-contains-block-types.php --all --verbose"`
3. To apply the changes, use:
  `yarn wp-env run cli "php wp-content/plugins/pattern-directory/bin/update-contains-block-types.php --all --verbose --apply"`
4. You can also run on just one post by using `--post=[id]` instead of `--all`
5. The updated meta should be visible in the API, or via wp-cli `yarn wp-env run cli "wp post meta list [ID]"`
6. Spot check some posts that the meta value reflects the post content

**Test the pattern update hook**

1. Create or update a pattern, change the block types used
2. Check the post meta
3. The meta value should exist, and reflect the blocks used

**Test the API endpoint**

This requires some patterns having the meta set, which is why it's last.

Make a request to your site using a list of block types, ex:

```
http://localhost:8888/wp-json/wp/v2/wporg-pattern?locale=en_US&allowed_blocks[]=core/cover&allowed_blocks[]=core/heading&allowed_blocks[]=core/spacer&allowed_blocks[]=core/paragraph
```
This requests only patterns with `core/cover, core/heading, core/spacer, core/paragraph`. Any pattern with other blocks should not be returned in the list.