### PR TITLE
Search: Filter the search results based on block types

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/search.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/search.php
@@ -163,12 +163,16 @@ function modify_es_query_args( $es_query_args, $wp_query ) {
 	// If there is an allowed_blocks meta_query, use it to filter the ES query.
 	if ( isset( $meta_query['allowed_blocks'] ) && ! empty( $meta_query['allowed_blocks']['value'] ) ) {
 		// Parse it out of the regex format.
-		$regex       = $meta_query['allowed_blocks']['value'];
-		$list        = substr( $regex, 3, -6 );
-		$block_types = explode( '|', $list );
+		$regex = $meta_query['allowed_blocks']['value'];
+		$regex = substr( $regex, 1, -1 ); // Strips the ^$, which are not supported in ES regex (and not needed).
 
 		$filter['bool']['must'][] = [
-			'terms' => [ 'meta.wpop_contains_block_types.value.raw' => $block_types ],
+			'regexp' => [
+				'meta.wpop_contains_block_types.value.raw' => [
+					'value'            => $regex,
+					'case_insensitive' => true,
+				],
+			],
 		];
 	}
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/search.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/search.php
@@ -160,6 +160,18 @@ function modify_es_query_args( $es_query_args, $wp_query ) {
 		}
 	}
 
+	// If there is an allowed_blocks meta_query, use it to filter the ES query.
+	if ( isset( $meta_query['allowed_blocks'] ) && ! empty( $meta_query['allowed_blocks']['value'] ) ) {
+		// Parse it out of the regex format.
+		$regex       = $meta_query['allowed_blocks']['value'];
+		$list        = substr( $regex, 3, -6 );
+		$block_types = explode( '|', $list );
+
+		$filter['bool']['must'][] = [
+			'terms' => [ 'meta.wpop_contains_block_types.value.raw' => $block_types ],
+		];
+	}
+
 	$parser->add_query( $must_query, 'must' );
 	$parser->add_query( $should_query, 'should' );
 	$parser->add_filter( $filter );


### PR DESCRIPTION
If the `allowed_blocks` meta filter is set, we should also pass that through to the ElasticSearch filters. Currently, if you make a request via the API with the `allowed_blocks` parameter, it will correctly return only patterns with those blocks. If you add a search term, it skips the filtering and returns all matching patterns. Searches should also return only patterns with matching blocks.

I've already added the `wpop_contains_block_types` meta to the synced data in https://github.com/WordPress/pattern-directory/commit/8ac046deba60d42feeba728e06a4a117743a3df2. This PR adds the filter to the ES query so that it should do the same regex matching to return only patterns with a subset of blocks in the given `allowed_blocks`.

See https://github.com/WordPress/pattern-directory/pull/540#issuecomment-1375377118. Fixes #547.

### How to test the changes in this Pull Request:

No idea 😓  this is my best guess based on the ES docs. @iandunn you've worked on the search code here before, how can I test this either locally or on a sandbox?

Note - search queries without `allowed_blocks` should still work, as the pattern directory itself doesn't supply `allowed_blocks`.