### PR TITLE
Patterns: Remove the ref from pattern content

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/includes/mock-blocks.php
+++ b/public_html/wp-content/plugins/pattern-creator/includes/mock-blocks.php
@@ -12,6 +12,7 @@ defined( 'WPINC' ) || die();
 add_action( 'render_block_core/archives', __NAMESPACE__ . '\render_archives', 10, 3 );
 add_action( 'render_block_core/latest-comments', __NAMESPACE__ . '\render_latest_comments', 10, 3 );
 add_filter( 'block_core_navigation_render_fallback', __NAMESPACE__ . '\provide_fallback_nav_items' );
+add_filter( 'render_block_data', __NAMESPACE__ . '\update_block_data' );
 add_filter( 'get_custom_logo', __NAMESPACE__ . '\provide_mock_logo' );
 
 /**
@@ -255,6 +256,20 @@ function provide_fallback_nav_items( $fallback_blocks ) {
 			),
 		),
 	);
+}
+
+/**
+ * Remove the `ref` from the navigation block to ensure it renders the fallback.
+ *
+ * @param array $parsed_block The block being rendered.
+ * @return array Updated block data.
+ */
+function update_block_data( $parsed_block ) {
+	if ( 'core/navigation' === $parsed_block['blockName'] ) {
+		unset( $parsed_block['attrs']['ref'] );
+	}
+
+	return $parsed_block;
 }
 
 /**

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -963,7 +963,7 @@ add_action(
 );
 
 /**
- * Process post content, replacing broken encoding.
+ * Process post content, replacing broken encoding & removing refs.
  *
  * Some image URLs have &s, which are double-encoded and sanitized to become malformed,
  * for example, `https://img.rawpixel.com/s3fs-private/rawpixel_images/website_content/a010-markuss-0964.jpg?w=1200\u0026amp;h=1200\u0026amp;fit=clip\u0026amp;crop=default\u0026amp;dpr=1\u0026amp;q=75\u0026amp;vib=3\u0026amp;con=3\u0026amp;usm=15\u0026amp;cs=srgb\u0026amp;bg=F4F4F3\u0026amp;ixlib=js-2.2.1\u0026amp;s=7d494bd5db8acc2a34321c15ed18ace5`.
@@ -974,5 +974,8 @@ add_action(
  */
 function decode_pattern_content( $content ) {
 	// Sometimes the initial `\` is missing, so look for both versions.
-	return str_replace( [ '\u0026amp;', 'u0026amp;' ], '&', $content );
+	$content = str_replace( [ '\u0026amp;', 'u0026amp;' ], '&', $content );
+	// Remove `ref` from all content.
+	$content = preg_replace( '/"ref":\d+,?/', '', $content );
+	return $content;
 }


### PR DESCRIPTION
Fixes #545 — This removes the Navigation's `ref` property from patterns on output, so that it's never added in the copyable pattern code. The `ref` is an ID for the nav menu, which only exists on the local site. When added to a user's site, it errors. There should be no ref so that the default behavior takes over when it's added.

Patterns _should_ never have a ref, but in some rare cases they do— patterns created by users with more permissions on the w.org/patterns site, not using the pattern creator, or patterns copied in from external sites.

I decided to fix this by filtering out the ref on the output, rather than just updating the pattern content - this way if someone updates these patterns again or adds new patterns, they'll never have a `ref` value.

The following is a complete list of published patterns with a `ref`.

- [centered-header-with-logo](https://wordpress.org/patterns/pattern/centered-header-with-logo)
- [header-with-large-font-size](https://wordpress.org/patterns/pattern/header-with-large-font-size)
- [simple-header](https://wordpress.org/patterns/pattern/simple-header)
- [header-inside-full-width-background-image](https://wordpress.org/patterns/pattern/header-inside-full-width-background-image)
- [simple-header-with-dark-background](https://wordpress.org/patterns/pattern/simple-header-with-dark-background)
- [text-only-header-with-tagline](https://wordpress.org/patterns/pattern/text-only-header-with-tagline)
- [simple-header-with-tagline](https://wordpress.org/patterns/pattern/simple-header-with-tagline)
- [site-title-and-menu-button](https://wordpress.org/patterns/pattern/site-title-and-menu-button)
- [header-with-hero-image](https://wordpress.org/patterns/pattern/header-with-hero-image)
- [footer-with-navigation-and-credit-line](https://wordpress.org/patterns/pattern/footer-with-navigation-and-credit-line)
- [footer-with-credit-line-and-navigation](https://wordpress.org/patterns/pattern/footer-with-credit-line-and-navigation)

### Screenshots

The pattern now correctly displays the fallback (mocked) nav menu:

| Before | After |
|-----|------|
| <img width="511" alt="Screenshot 2023-01-24 at 10 44 58 AM" src="https://user-images.githubusercontent.com/541093/214339967-1dd25c90-9b79-4d7b-ad41-84d573618e2c.png"> | <img width="523" alt="Screenshot 2023-01-24 at 10 33 00 AM" src="https://user-images.githubusercontent.com/541093/214337077-f8457d2a-16a2-4618-9349-2a1439a336f2.png"> |

and when you copy the code, there is no `ref`.

```html
<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"2em","bottom":"4em"}}}} -->
<div class="wp-block-group alignfull" style="padding-top:2em;padding-bottom:4em"><!-- wp:site-logo {"align":"center"} /-->

<!-- wp:site-title {"textAlign":"center","fontSize":"large"} /-->

<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"center"}} /--></div>
<!-- /wp:group -->
```

### How to test the changes in this Pull Request:

This is easiest to test on a wporg sandbox, since it already has the `ref`'d patterns. Otherwise create some patterns in wp-admin with Navigation blocks so that they have local `ref`.

1. View a pattern with a ref, like [Centered header with logo](https://wordpress.org/patterns/pattern/centered-header-with-logo/)
2. There should be a visible menu, with "Home About Contact"
3. Copy the pattern, look at the `wp:navigation` code, it should not include the `ref`
4. Get the pattern via the API, ex `https://api.wordpress.org/patterns/1.0/?slug=centered-header-with-logo`
5. Look at the `pattern_content` value — this is what the core editor uses to display patterns
6. The `wp:navigation` code should not have a ref
