### PR TITLE
API: Get the pattern content directly from the post object

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -336,8 +336,9 @@ function register_rest_fields() {
 		POST_TYPE,
 		'pattern_content',
 		array(
-			'get_callback' => function() {
-				return decode_pattern_content( get_the_content() );
+			'get_callback' => function( $response_data ) {
+				$pattern = get_post( $response_data['id'] );
+				return decode_pattern_content( $pattern->post_content );
 			},
 
 			'schema' => array(


### PR DESCRIPTION
Fixes #552 — The query in the query block is affecting the core globals used by `get_the_content`, returning the content for the last post in the query, rather than the pattern content itself. This switches to getting the post object directly, using the response ID to ensure the correct post is picked.

The single-wporg-pattern.php template uses `decode_pattern_content( get_the_content() )` too, but I think because it runs before `the_content()` it's not affected.

