### PR TITLE
Fix boosted locale queries

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/search.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/search.php
@@ -126,8 +126,8 @@ function modify_es_query_args( $es_query_args, $wp_query ) {
 					],
 				],
 				'negative_boost' => 0.001,
- 			],
- 		];
+			],
+		];
 	}
 
 	$filter = [

--- a/public_html/wp-content/plugins/pattern-directory/includes/search.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/search.php
@@ -114,19 +114,20 @@ function modify_es_query_args( $es_query_args, $wp_query ) {
 
 		// Boost the primary locale over the `en_US` fallback.
 		$should_query[] = [
-			'term' => [
-				'meta.wpop_locale.value.raw' => $primary_locale,
-				'boost'                      => 2,
-			],
-		];
-
-		$should_query[] = [
-			'term' => [
-				'meta.wpop_locale.value.raw' => 'en_US',
-				'boost'                      => 0.00001,
-				// todo ^ isn't working. might not need the positive boost on $primary_locale once this works.
-			],
-		];
+			'boosting' => [
+				'positive' => [
+					'term' => [
+						'meta.wpop_locale.value.raw' => $primary_locale,
+					],
+				],
+				'negative' => [
+					'term' => [
+						'meta.wpop_locale.value.raw' => 'en_US',
+					],
+				],
+				'negative_boost' => 0.001,
+ 			],
+ 		];
 	}
 
 	$filter = [


### PR DESCRIPTION
The boosted locale queries result in a fallback to MYSQL due to what appears to be a change in syntax.

Switching to the `boosting` element appears to fix this.

Fixes #563