### PR TITLE
Pattern Grid: Use mshots for published patterns only

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/canvas.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
 
 /**
@@ -11,10 +11,11 @@ import getCardFrameHeight from '../../utils/get-card-frame-height';
 import useInView from '../../hooks/in-view';
 import Screenshot from './screenshot';
 
-export default function ( { alt, url } ) {
+export default function ( { alt, url, useMShot = true } ) {
 	const wrapperRef = useRef();
 	const isVisible = useInView( { element: wrapperRef } );
-	const [ frameHeight, setFrameHeight ] = useState( '1px' );
+	const [ frameHeight, setFrameHeight ] = useState( 1 );
+	const [ frameWidth, setFrameWidth ] = useState( 1 );
 	const [ shouldLoad, setShouldLoad ] = useState( false );
 
 	useEffect( () => {
@@ -27,6 +28,7 @@ export default function ( { alt, url } ) {
 		const handleOnResize = () => {
 			try {
 				setFrameHeight( getCardFrameHeight( wrapperRef.current.clientWidth ) );
+				setFrameWidth( wrapperRef.current.clientWidth );
 			} catch ( err ) {}
 		};
 
@@ -51,17 +53,42 @@ export default function ( { alt, url } ) {
 
 	return (
 		<div ref={ wrapperRef }>
-			<Screenshot
-				className="pattern-grid__preview"
-				alt={ alt || __( 'Pattern Preview', 'wporg-patterns' ) }
-				style={ style }
-				isReady={ shouldLoad }
-				src={
-					wporgPatternsData.env === 'local'
-						? url.replace( wporgPatternsUrl.site, 'https://wordpress.org/patterns' )
-						: url
-				}
-			/>
+			{ useMShot ? (
+				<Screenshot
+					className="pattern-grid__preview"
+					alt={ alt || __( 'Pattern Preview', 'wporg-patterns' ) }
+					style={ style }
+					isReady={ shouldLoad }
+					src={
+						wporgPatternsData.env === 'local'
+							? url.replace( wporgPatternsUrl.site, 'https://wordpress.org/patterns' )
+							: url
+					}
+				/>
+			) : (
+				<div
+					style={ {
+						height: `${ frameHeight }px`,
+						overflow: 'hidden',
+					} }
+				>
+					<iframe
+						className="pattern-grid__preview"
+						title={ alt || __( 'Pattern Preview', 'wporg-patterns' ) }
+						tabIndex="-1"
+						style={ {
+							border: 'none',
+							width: `${ frameWidth * 4 }px`,
+							maxWidth: 'none',
+							height: `${ frameHeight * 4 }px`,
+							transform: 'scale(0.25)',
+							transformOrigin: isRTL() ? 'top right' : 'top left',
+							pointerEvents: 'none',
+						} }
+						src={ shouldLoad ? url : '' }
+					/>
+				</div>
+			) }
 		</div>
 	);
 }

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/index.js
@@ -35,6 +35,7 @@ function PatternThumbnail( { pattern, showAvatar, showOptions } ) {
 				<a href={ pattern.link } rel="bookmark">
 					<span className="screen-reader-text">{ decodeEntities( pattern.title.rendered ) }</span>
 					<Canvas
+						useMShot={ 'publish' === pattern.status }
 						url={ addQueryArgs( pattern.link, {
 							view: true,
 							modified: pattern.modified_gmt,


### PR DESCRIPTION
Draft & pending patterns are not accessible by the mshots service, so it screencaps the 404 page (currently a white screen). This brings back the iframe previewer for non-published patterns, leaving the performance benefit of images for the general archive. The draft/pending patterns are visible to the current user via the iframe because it uses the current user's permissions.

Fixes #543

### Screenshots

| Before | After |
|-----|------|
| ![before](https://user-images.githubusercontent.com/541093/224430250-dc7ac0a4-8161-495b-8489-a71cc437d5e7.png) | ![after](https://user-images.githubusercontent.com/541093/224430249-46308c8b-8355-405e-aa70-72e3a878feed.png) |

**To test**

1. Create some draft or pending patterns, or unlist an existing pattern
2. View the "My Patterns" grid
3. There should be a preview of the pattern(s)

(Note that on a local site, the mshots preview will only work if the same pattern exists on production)