### PR TITLE
API Middleware: Set the raw post content on /posts requests

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/api-middleware/filter-endpoints.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/api-middleware/filter-endpoints.js
@@ -57,6 +57,14 @@ export default async function ( options, next ) {
 			if ( response[ 'wporg-pattern' ] ) {
 				response[ 'wporg-pattern' ].viewable = false;
 			}
+		} else if ( options.path.includes( '/wp/v2/posts' ) ) {
+			response.forEach( ( post, index ) => {
+				if ( post.content && ! post.content.raw ) {
+					const content = post.content.rendered || '';
+					post.content.raw = content;
+				}
+				response[ index ] = post;
+			} );
 		}
 	}
 


### PR DESCRIPTION
This injects the rendered post content into the `raw` property in the API response, which allows users to show full post content in the Latest Posts block without triggering an `undefined` error.

Fixes #555

### How to test the changes in this Pull Request:

1. Insert a Latest Posts block, show post content, then toggle on "full post"
2. Or use the following:
    ```html
    <!-- wp:latest-posts {"postsToShow":1,"displayPostContent":true,"displayPostContentRadio":"full_post","displayAuthor":true,"displayPostDate":true,"displayFeaturedImage":true} /-->
    ```
3. There should be no block error
4. It should show the post content
