### PR TITLE
Fix the screenshot requesting when it doesn't need to.

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
@@ -31,6 +31,7 @@ const IMAGE_WIDTH = 600;
  * @param {string}  props.alt       The alt text for the screenshot image.
  * @param {string}  props.className Any extra class names for the wrapper div.
  * @param {boolean} props.isReady   Whether we should start try to show the image.
+ * @param {Object}  props.style     Styles for the wrapper div.
  * @param {string}  props.src       The url of the page to screenshot.
  * @return {Object} React component
  */

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { Spinner } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -88,8 +88,8 @@ export default function ( { alt, className, isReady = false, src, style } ) {
 		}
 	};
 
-	useEffect( async () => {
-		await fetchImage();
+	useEffect( () => {
+		( async () => await fetchImage() )();
 	}, [] );
 
 	/**

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-thumbnail/screenshot.js
@@ -17,7 +17,7 @@ import useInterval from '../../hooks/use-interval';
  * Module constants
  */
 const MAX_ATTEMPTS = 10;
-const RETRY_DELAY = 1000;
+const RETRY_DELAY = 2000;
 const VIEWPORT_WIDTH = 1200;
 const IMAGE_WIDTH = 600;
 
@@ -31,7 +31,6 @@ const IMAGE_WIDTH = 600;
  * @param {string}  props.alt       The alt text for the screenshot image.
  * @param {string}  props.className Any extra class names for the wrapper div.
  * @param {boolean} props.isReady   Whether we should start try to show the image.
- * @param {Object}  props.style     Styles for the wrapper div.
  * @param {string}  props.src       The url of the page to screenshot.
  * @return {Object} React component
  */
@@ -46,6 +45,7 @@ export default function ( { alt, className, isReady = false, src, style } ) {
 	const [ hasLoaded, setHasLoaded ] = useState( false );
 	const [ hasError, setHasError ] = useState( false );
 	const [ base64Img, setBase64Img ] = useState( '' );
+	const [ shouldRetry, setShouldRetry ] = useState( false );
 
 	// We don't want to keep trying infinitely.
 	const hasAborted = attempts > MAX_ATTEMPTS;
@@ -68,27 +68,39 @@ export default function ( { alt, className, isReady = false, src, style } ) {
 		reader.readAsDataURL( blob );
 	};
 
+	const fetchImage = async () => {
+		try {
+			const res = await fetch( fullUrl );
+
+			if ( res.redirected ) {
+				setShouldRetry( true );
+			} else if ( res.status === 200 && ! res.redirected ) {
+				await convertResponseToBase64( res );
+
+				setHasLoaded( true );
+				setShouldRetry( false );
+			} else {
+				setAttempts( attempts + 1 );
+			}
+		} catch ( error ) {
+			setHasError( true );
+			setShouldRetry( false );
+		}
+	};
+
+	useEffect( async () => {
+		await fetchImage();
+	}, [] );
+
 	/**
 	 * The Snapshot service will redirect when its generating an image.
 	 * We want to continue requesting the image until it doesn't redirect.
 	 */
 	useInterval(
 		async () => {
-			try {
-				const res = await fetch( fullUrl );
-
-				if ( res.status === 200 && ! res.redirected ) {
-					await convertResponseToBase64( res );
-
-					setHasLoaded( true );
-				} else {
-					setAttempts( attempts + 1 );
-				}
-			} catch ( error ) {
-				setHasError( true );
-			}
+			await fetchImage();
 		},
-		isLoading ? RETRY_DELAY : null
+		shouldRetry ? RETRY_DELAY : null
 	);
 
 	if ( ! isReady ) {


### PR DESCRIPTION
See: https://github.com/WordPress/wporg-mu-plugins/pull/357 and https://github.com/WordPress/wporg-mu-plugins/commit/1e4975600cb0e617e687b624123cbe0b1d391e4d

This is a copy/paste of the code updates made in the `wordpress\wporg-mu-plugins`. It isn't ideal that we have code in both places, it would be nice to address that, hopefully when we redesign this directory.


### How to test the changes in this Pull Request:

See https://github.com/WordPress/wporg-mu-plugins/pull/357 for testing details.
