### PR TITLE
Patterns: Add a curation filter to the UI

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -669,7 +669,7 @@ function filter_patterns_collection_params( $query_params ) {
 	$query_params['curation'] = array(
 		'description' => __( 'Limit result to either curated core, community, or all patterns.', 'wporg-patterns' ),
 		'type'        => 'string',
-		'default'     => 'core',
+		'default'     => 'all',
 		'enum'        => array(
 			'all',
 			'core',

--- a/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_components.scss
@@ -32,12 +32,12 @@
 @import "pattern-menu";
 @import "pattern-navigation-layout";
 @import "pattern-notice";
-@import "pattern-order-select";
 @import "pattern-pagination";
 @import "pattern-preview";
 @import "pattern-report-button";
 @import "pattern-report-modal";
 @import "pattern-search";
+@import "pattern-select-control";
 @import "pattern";
 @import "patterns-favorites";
 @import "site-content";

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-navigation-layout.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-navigation-layout.scss
@@ -1,6 +1,7 @@
 .pattern-navigation-layout {
 	margin: 0 auto $gutter-default;
 	max-width: $size__site-main;
+	gap: $gutter-default;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -11,21 +12,25 @@
 	}
 
 	.pattern-navigation-layout__secondary {
-		margin-top: $gutter-default;
-		width: calc(100% - #{$gutter-default * 2});
+		display: flex;
+		flex-direction: column;
+		gap: #{$gutter-default / 2};
 	}
 
 	@media only screen and ( min-width: #{$breakpoint-medium + 1} ) {
 		margin: $gutter-default;
+		gap: #{$gutter-default / 2};
 		flex-direction: row;
+		flex-wrap: wrap;
 
 		.pattern-navigation-layout__primary {
 			margin-bottom: 0;
+			width: auto;
 		}
 
 		.pattern-navigation-layout__secondary {
-			margin: 0;
 			width: auto;
+			flex-direction: row;
 		}
 	}
 

--- a/public_html/wp-content/themes/pattern-directory/css/components/_pattern-select-control.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_pattern-select-control.scss
@@ -1,4 +1,4 @@
-.pattern-order-select {
+.pattern-select-control {
 	margin: 0 auto;
 	width: max-content;
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/context-bar/index.js
@@ -29,8 +29,8 @@ import { store as patternStore } from '../../store';
  */
 const isHomeQuery = ( query ) => {
 	const allKeys = Object.keys( query || {} );
-	// Filter out "orderby" and "page", which have no affect on what kind of query this is.
-	const keys = allKeys.filter( ( key ) => ! [ 'orderby', 'page' ].includes( key ) );
+	// Filter out "orderby", "page", and "curation", which have no affect on what kind of query this is.
+	const keys = allKeys.filter( ( key ) => ! [ 'orderby', 'page', 'curation' ].includes( key ) );
 	return ! keys.length;
 };
 

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
@@ -59,6 +59,7 @@ const MyFavorites = () => {
 						query={ query }
 						onNavigation={ onNavigation }
 						isEmpty={ isEmpty }
+						hideCuration
 					/>
 				) }
 			</div>

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-favorites/index.js
@@ -42,7 +42,7 @@ const MyFavorites = () => {
 	} );
 	const [ ref, onNavigation ] = useFocusOnNavigation();
 
-	const mostFavoritedQuery = { orderby: 'favorite_count', per_page: 6 };
+	const mostFavoritedQuery = { orderby: 'favorite_count', per_page: 6, curation: 'core' };
 	if ( query[ 'pattern-categories' ] ) {
 		mostFavoritedQuery[ 'pattern-categories' ] = query[ 'pattern-categories' ];
 	}

--- a/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/my-patterns/index.js
@@ -13,8 +13,8 @@ import { useSelect } from '@wordpress/data';
 import Menu from './menu';
 import NavigationLayout from '../navigation-layout';
 import PatternGrid from '../pattern-grid';
+import PatternSelectControl from '../pattern-select-control';
 import PatternThumbnail from '../pattern-thumbnail';
-import PatternOrderSelect from '../pattern-order-select';
 import QueryMonitor from '../query-monitor';
 import { RouteProvider } from '../../hooks';
 
@@ -63,10 +63,13 @@ const MyPatterns = () => {
 			<NavigationLayout
 				primary={ <Menu /> }
 				secondary={
-					<PatternOrderSelect
+					<PatternSelectControl
+						label={ __( 'Order by', 'wporg-patterns' ) }
+						param="orderby"
+						defaultValue="date"
 						options={ [
 							{ label: __( 'Newest', 'wporg-patterns' ), value: 'date' },
-							{ label: __( 'Favorites', 'wporg-patterns' ), value: 'favorite_count' },
+							{ label: __( 'Popular', 'wporg-patterns' ), value: 'favorite_count' },
 						] }
 					/>
 				}

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
@@ -8,7 +8,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import ContextBar from '../context-bar';
-import PatternOrderSelect from '../pattern-order-select';
+import PatternSelectControl from '../pattern-select-control';
 import Menu from '../menu';
 import NavigationLayout from '../navigation-layout';
 import { store as patternStore } from '../../store';
@@ -76,7 +76,10 @@ const PatternGridMenu = ( { basePath = '', onNavigation, ...props } ) => {
 					/>
 				}
 				secondary={
-					<PatternOrderSelect
+					<PatternSelectControl
+						label={ __( 'Order by', 'wporg-patterns' ) }
+						param="orderby"
+						defaultValue="date"
 						options={ [
 							{ label: __( 'Newest', 'wporg-patterns' ), value: 'date' },
 							{ label: __( 'Popular', 'wporg-patterns' ), value: 'favorite_count' },

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
@@ -76,15 +76,26 @@ const PatternGridMenu = ( { basePath = '', onNavigation, ...props } ) => {
 					/>
 				}
 				secondary={
-					<PatternSelectControl
-						label={ __( 'Order by', 'wporg-patterns' ) }
-						param="orderby"
-						defaultValue="date"
-						options={ [
-							{ label: __( 'Newest', 'wporg-patterns' ), value: 'date' },
-							{ label: __( 'Popular', 'wporg-patterns' ), value: 'favorite_count' },
-						] }
-					/>
+					<>
+						<PatternSelectControl
+							label={ __( 'Filter by', 'wporg-patterns' ) }
+							param="curation"
+							defaultValue="core"
+							options={ [
+								{ label: __( 'Curated', 'wporg-patterns' ), value: 'core' },
+								{ label: __( 'Community', 'wporg-patterns' ), value: 'community' },
+							] }
+						/>
+						<PatternSelectControl
+							label={ __( 'Order by', 'wporg-patterns' ) }
+							param="orderby"
+							defaultValue="date"
+							options={ [
+								{ label: __( 'Newest', 'wporg-patterns' ), value: 'date' },
+								{ label: __( 'Popular', 'wporg-patterns' ), value: 'favorite_count' },
+							] }
+						/>
+					</>
 				}
 			/>
 			<ContextBar { ...props } />

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-grid-menu/index.js
@@ -27,7 +27,7 @@ const ALLOWED_CATS = [
 	'wireframe',
 ];
 
-const PatternGridMenu = ( { basePath = '', onNavigation, ...props } ) => {
+const PatternGridMenu = ( { basePath = '', onNavigation, hideCuration = false, ...props } ) => {
 	const { path, update: updatePath } = useRoute();
 	const { categorySlug, isLoading, options } = useSelect( ( select ) => {
 		const { getCategoryById, getCategories, getQueryFromUrl, getUrlFromQuery, isLoadingCategories } =
@@ -77,15 +77,17 @@ const PatternGridMenu = ( { basePath = '', onNavigation, ...props } ) => {
 				}
 				secondary={
 					<>
-						<PatternSelectControl
-							label={ __( 'Filter by', 'wporg-patterns' ) }
-							param="curation"
-							defaultValue="core"
-							options={ [
-								{ label: __( 'Curated', 'wporg-patterns' ), value: 'core' },
-								{ label: __( 'Community', 'wporg-patterns' ), value: 'community' },
-							] }
-						/>
+						{ hideCuration ? null : (
+							<PatternSelectControl
+								label={ __( 'Filter by', 'wporg-patterns' ) }
+								param="curation"
+								defaultValue="core"
+								options={ [
+									{ label: __( 'Curated', 'wporg-patterns' ), value: 'core' },
+									{ label: __( 'Community', 'wporg-patterns' ), value: 'community' },
+								] }
+							/>
+						) }
 						<PatternSelectControl
 							label={ __( 'Order by', 'wporg-patterns' ) }
 							param="orderby"

--- a/public_html/wp-content/themes/pattern-directory/src/components/pattern-select-control/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/pattern-select-control/index.js
@@ -1,7 +1,6 @@
 /**
  * Wordpress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { SelectControl } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -11,28 +10,29 @@ import { useViewportMatch } from '@wordpress/compose';
  */
 import { useRoute } from '../../hooks';
 
-const PatternOrderSelect = ( { options } ) => {
+const PatternSelectControl = ( { defaultValue, label, param, options } ) => {
 	const { path, replace } = useRoute();
 	const hideLabel = useViewportMatch( 'medium', '>=' );
 
 	if ( ! options ) {
 		return null;
 	}
+	const value = getQueryArg( window.location.href, param ) || defaultValue;
 
 	return (
-		<div className="pattern-order-select">
+		<div className="pattern-select-control">
 			<SelectControl
-				label={ __( 'Order by', 'wporg-patterns' ) }
+				label={ label }
 				labelPosition="side"
 				hideLabelFromVision={ hideLabel }
-				value={ getQueryArg( window.location.href, 'orderby' ) }
+				value={ value }
 				options={ options }
-				onChange={ ( value ) => {
-					replace( addQueryArgs( path, { orderby: value } ).replace( /\/page\/[\d]+/, '' ) );
+				onChange={ ( newValue ) => {
+					replace( addQueryArgs( path, { [ param ]: newValue } ).replace( /\/page\/[\d]+/, '' ) );
 				} }
 			/>
 		</div>
 	);
 };
 
-export default PatternOrderSelect;
+export default PatternSelectControl;

--- a/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
@@ -19,16 +19,25 @@ import { store as patternStore } from '../../store';
 import useFocusOnNavigation from '../../hooks/use-focus-on-navigation';
 
 const Patterns = () => {
-	const { isEmpty, isSearch, query } = useSelect( ( select ) => {
+	const { isAuthor, isEmpty, isSearch, query } = useSelect( ( select ) => {
 		const { getCurrentQuery, getPatternsByQuery, isLoadingPatternsByQuery } = select( patternStore );
-		const _query = getCurrentQuery();
-		const isLoading = _query && isLoadingPatternsByQuery( _query );
-		const posts = _query ? getPatternsByQuery( _query ) : [];
+		const _query = getCurrentQuery() || {};
+		const _isSearch = !! _query.search;
+		const _isAuthor = !! _query.author_name;
+
+		const modifiedQuery = { ..._query };
+		if ( ! _isSearch && ! _isAuthor && ! modifiedQuery.curation ) {
+			modifiedQuery.curation = 'core';
+		}
+
+		const isLoading = isLoadingPatternsByQuery( modifiedQuery );
+		const posts = modifiedQuery ? getPatternsByQuery( modifiedQuery ) : [];
 
 		return {
+			isAuthor: _isAuthor,
 			isEmpty: ! isLoading && ! posts.length,
-			isSearch: _query && !! _query.search,
-			query: _query,
+			isSearch: _isSearch,
+			query: modifiedQuery,
 		};
 	} );
 	const [ ref, onNavigation ] = useFocusOnNavigation();
@@ -39,12 +48,16 @@ const Patterns = () => {
 			<QueryMonitor />
 			<BreadcrumbMonitor />
 			<div ref={ ref }>
-				{ isSearch ? <ContextBar query={ query } /> : <PatternGridMenu onNavigation={ onNavigation } /> }
+				{ isSearch ? (
+					<ContextBar query={ query } />
+				) : (
+					<PatternGridMenu onNavigation={ onNavigation } hideCuration={ isAuthor } />
+				) }
 			</div>
 			{ isEmpty ? (
 				<>
 					<EmptyHeader />
-					<PatternGrid query={ { per_page: 6 } } showPagination={ false }>
+					<PatternGrid query={ { per_page: 6, curation: 'core' } } showPagination={ false }>
 						{ ( post ) => <PatternThumbnail key={ post.id } pattern={ post } showAvatar /> }
 					</PatternGrid>
 				</>

--- a/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
+++ b/public_html/wp-content/themes/pattern-directory/src/components/patterns/index.js
@@ -51,7 +51,7 @@ const Patterns = () => {
 				{ isSearch ? (
 					<ContextBar query={ query } />
 				) : (
-					<PatternGridMenu onNavigation={ onNavigation } hideCuration={ isAuthor } />
+					<PatternGridMenu onNavigation={ onNavigation } query={ query } hideCuration={ isAuthor } />
 				) }
 			</div>
 			{ isEmpty ? (


### PR DESCRIPTION
This adds a new filter to the UI for "curation", as described in #580— "curated" patterns are those which have been picked to auto-load into core. The new filter is a dropdown with "curated" and "community", which lets the viewer switch between those  two views. It defaults to curated on home & category archives, and uses curated for the empty state recommendations.

The author archive, favorites, and my patterns don't have this filter, and default to showing "all" patterns.

Fixes #580

Note, this is based off #583, which adds the parameter to the API endpoint.

### Screenshots

I applied this to my sandbox to take screenshots, so this is using production patterns.

|  | Curated | Community |
|---|---|---|
| Home, default sort | ![home-curated](https://github.com/WordPress/pattern-directory/assets/541093/b1ea507a-cd28-47e5-a756-09dcb14deaf5) | ![home-community](https://github.com/WordPress/pattern-directory/assets/541093/f2972806-ac93-4798-8f74-7a0e15f827bb) |
| Home, sorted by popular | ![home-curated-popular](https://github.com/WordPress/pattern-directory/assets/541093/a40e70ac-615b-4997-9db2-e53f9da7c248) | ![home-community-popular](https://github.com/WordPress/pattern-directory/assets/541093/1f8dd00b-1f5c-49de-9db7-ea063e4f1f95) |
| Category, default sort | ![category-curated](https://github.com/WordPress/pattern-directory/assets/541093/c03a09e1-10f6-4cb4-b10e-caebf5324e3f) | ![category-community](https://github.com/WordPress/pattern-directory/assets/541093/4e345615-426c-4f16-9646-359a1584c2bc) |

<details>
<summary>Favorites & My Patterns have no changes, but screenshots for reference</summary>

![favorites](https://github.com/WordPress/pattern-directory/assets/541093/d9cc3b3d-c7ef-4930-a7ce-8c97085bc127)

![my-patterns](https://github.com/WordPress/pattern-directory/assets/541093/cc4c0e0b-551e-4d15-8ffc-d884e957d0a3)

</details>

On medium-smaller screens, the filters wrap, then at 782px the menu collapses.

<img alt="" width="790" src="https://github.com/WordPress/pattern-directory/assets/541093/63fa17e2-31b0-4901-a86e-632f2b268d2d" />

<img alt="" width="600" src="https://github.com/WordPress/pattern-directory/assets/541093/d1772e2c-5a0e-486c-a50b-4bbc0cb16293" />

This new change means that the Call to Action menu item defaults to empty (https://wordpress.org/patterns/categories/call-to-action/), but you can see here the empty state also uses the "curated" patterns.

![home-curated-cta-empty](https://github.com/WordPress/pattern-directory/assets/541093/282a8299-13f4-4ae7-9293-ec71f9599619)

### How to test the changes in this Pull Request:

1. Check out the branch and build the project
2. Make sure you have some patterns with the `core` keyword: `/wp-admin/edit.php?wporg-pattern-keyword=core&post_type=wporg-pattern&post_parent=0&post_status=publish` — if not, you should be able to add some via wp-admin
3. View the homepage, it should default to the core patterns
4. Try using the filters on the UI to switch to community
5. Navigate through categories, it should persist your chosen curation
6. My Patterns, My Favorites, and author archives should still work, without a curation filter

