### PR TITLE
Pattern Directory Links Hover Issue #592

### DIFF
--- a/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
+++ b/public_html/wp-content/themes/pattern-directory/css/components/_site-header.scss
@@ -30,7 +30,6 @@
 			margin: $gutter-default $gutter-default / 2 0 0;
 			color: $color-white;
 			font-size: 0.8125rem;
-			text-decoration: underline;
 		}
 	}
 


### PR DESCRIPTION
Favorites, Create a new pattern, My patterns links already apply text-decoration: underline; but I saw pattern-directory all pages when hover effect apply text-decoration and normally text-decoration: none;


[Pattern Directory Links Hover Issue #592](https://github.com/WordPress/pattern-directory/issues/592)

### Screenshots
after excluding text-decoration: underline;

## Normally
<img width="1428" alt="Screenshot 2023-07-20 at 9 13 24 AM" src="https://github.com/huzaifaalmesbah/pattern-directory/assets/63150399/c1997b7e-92f6-4d0d-872e-7cf0de7ba838">

## Hover
<img width="1419" alt="Screenshot 2023-07-20 at 9 13 43 AM" src="https://github.com/huzaifaalmesbah/pattern-directory/assets/63150399/0c618920-b340-4083-b353-501ee70be0f6">
