### PR TITLE
Temporarily restore gutenberg_initialize_editor() until reliance removed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
 		"wp-phpunit/wp-phpunit": "^5.4",
 		"phpunit/phpunit": "^7.5.20",
 		"rmccue/requests": "^1.8.1",
-		"yoast/phpunit-polyfills": "^1.0"
+		"yoast/phpunit-polyfills": "^1.1"
 	},
 	"scripts": {
 		"format": "phpcbf -p",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c3a6d8e205ef5b7b9c3ee9055abf808",
+    "content-hash": "54e3c6ca1c005db26a4953ae7b982200",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -2454,16 +2454,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -2510,7 +2510,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],
@@ -2526,5 +2526,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -273,3 +273,61 @@ function set_theme_twentytwentythree() {
 		return 'core/twentytwentythree';
 	}
 }
+
+/**
+ * Temporarily restore gutenberg_initialize_editor() for compat with Gutenberg 16.5.0
+ *
+ * @see https://github.com/WordPress/pattern-directory/issues/601
+ */
+function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $settings ) {
+
+	$defaults = array(
+		'preload_paths'    => array(),
+		'initializer_name' => 'initialize',
+		'editor_settings'  => array(),
+	);
+
+	$settings = wp_parse_args( $settings, $defaults );
+
+	/**
+	 * Preload common data by specifying an array of REST API paths that will be preloaded.
+	 *
+	 * Filters the array of paths that will be preloaded.
+	 *
+	 * @param string[] $preload_paths Array of paths to preload.
+	 */
+	$preload_paths = apply_filters( "{$editor_name}_preload_paths", $settings['preload_paths'] );
+
+	$preload_data = array_reduce(
+		$preload_paths,
+		'rest_preload_api_request',
+		array()
+	);
+
+	wp_add_inline_script(
+		'wp-api-fetch',
+		sprintf(
+			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
+			wp_json_encode( $preload_data )
+		),
+		'after'
+	);
+	wp_add_inline_script(
+		"wp-{$editor_script_handle}",
+		sprintf(
+			'wp.domReady( function() {
+				wp.%s.%s( "%s", %s );
+			} );',
+			lcfirst( str_replace( '-', '', ucwords( $editor_script_handle, '-' ) ) ),
+			$settings['initializer_name'],
+			str_replace( '_', '-', $editor_name ),
+			wp_json_encode( $settings['editor_settings'] )
+		)
+	);
+
+	// Preload server-registered block schemas.
+	wp_add_inline_script(
+		'wp-blocks',
+		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
+	);
+}


### PR DESCRIPTION
See #601

This is not a fix, this is a temporary bandaid to resolve the Pattern creator fataling with Gutenberg 16.5.0.
