### PR TITLE
Change the Translated pattern cron task to run many smaller tasks

### DIFF
--- a/public_html/wp-content/plugins/pattern-translations/includes/cron.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/cron.php
@@ -24,7 +24,7 @@ add_action( 'admin_init', __NAMESPACE__ . '\register_cron_tasks' );
 /**
  * Periodically import all Patterns into GlotPress for translation.
  *
- * This is the equivilient of the following WP-CLI command:
+ * This is the equivalent of the following WP-CLI command:
  * `wp --url=https://wordpress.org/patterns/ patterns glotpress-import --all-posts --save`
  */
 function pattern_import_to_glotpress() {

--- a/public_html/wp-content/plugins/pattern-translations/includes/cron.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/cron.php
@@ -60,7 +60,7 @@ function pattern_import_translations_to_directory( $pattern_ids = array() ) {
 				$timestamp += $delay;
 			}
 
-			printf( "Queued %d cron jobs of %d Patterns each.\n", count( $pattern_ids ) / CHUNK_SIZE, CHUNK_SIZE );
+			printf( "Queued %d cron jobs of %d Patterns each.\n", count( $pattern_ids ) / CHUNK_SIZE, CHUNK_SIZE ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return;
 		}
 	}

--- a/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
@@ -135,12 +135,14 @@ class Pattern {
 
 		$options = wp_parse_args( $args, $defaults );
 
-		$query = new \WP_Query();
-		$posts = $query->query( $options );
+		$query    = new \WP_Query();
+		$patterns = $query->query( $options );
 
 		wp_reset_postdata();
 
-		$patterns = array_map( [ self::class, 'from_post' ], $posts );
+		if ( 'ids' !== $query->get( 'fields' ) ) {
+			$patterns = array_map( [ self::class, 'from_post' ], $patterns );
+		}
 
 		return $patterns;
 	}


### PR DESCRIPTION
Recently the cron task 'pattern_import_translations_to_directory' has been running into memory limits.

While this shouldn't happen, it makes sense to just split this task up into many smaller jobs.