### PR TITLE
Tests: Use the polyfill teardown methods, to ensure unit tests can run in all versions of PHP

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/capabilities-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/capabilities-test.php
@@ -108,7 +108,7 @@ class Capabilities_Test extends WP_UnitTestCase {
 	/**
 	 * Clean up shared fixtures.
 	 */
-	public static function wpTearDownAfterClass() {
+	public static function tear_down_after_class() {
 		wp_delete_post( self::$pattern_id_1, true );
 		wp_delete_post( self::$pattern_id_2, true );
 		wp_delete_post( self::$post_id, true );
@@ -124,7 +124,7 @@ class Capabilities_Test extends WP_UnitTestCase {
 	/**
 	 * Reset state between tests.
 	 */
-	public function tearDown() {
+	public function tear_down() {
 		unset( $GLOBALS['current_screen'] );
 		wp_set_current_user( 0 );
 	}


### PR DESCRIPTION
PHP Unit tests are currently failing with this:
```
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.

Fatal error: Declaration of WordPressdotorg\Pattern_Directory\Tests\Capabilities_Test::tearDown() must be compatible with Yoast\PHPUnitPolyfills\TestCases\TestCase::tearDown(): void in /var/www/html/wp-content/plugins/pattern-directory/tests/phpunit/capabilities-test.php on line 1[27](https://github.com/WordPress/pattern-directory/actions/runs/7737062016/job/21095422620#step:9:28)
255
✖ Command failed with exit code 255
```

This is an attempt to fix it.