### PR TITLE
Block theme: Add drag handles to resize pattern preview

### DIFF
--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/render.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/render.php
@@ -23,12 +23,16 @@ $p->remove_attribute( 'data-wp-interactive' );
 $p->remove_attribute( 'data-wp-context' );
 $content = $p->get_updated_html();
 
+$html_id = wp_unique_id( 'pattern-preview-help-' );
+
 ?>
 <div
 	<?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>
 	data-wp-interactive="wporg/patterns/preview"
 	data-wp-context="<?php echo esc_attr( $encoded_state ); ?>"
 	data-wp-class--is-mobile-view="state.isWidthNarrow"
+	data-wp-on-window--mousemove="actions.onDrag"
+	data-wp-on-window--mouseup="actions.onDragEnd"
 >
 	<section class="wporg-pattern-view-control__controls wp-block-buttons" aria-label="<?php esc_attr_e( 'Preview width', 'wporg-patterns' ); ?>">
 		<div class="wp-block-button is-style-toggle is-small">
@@ -66,8 +70,37 @@ $content = $p->get_updated_html();
 		</div>
 	</section>
 
-	<?php
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content from child blocks.
-		echo $content;
-	?>
+	<div class="wporg-pattern-preview__drag-container">
+		<div class="wporg-pattern-preview__drag-handle">
+			<button
+				class="wporg-pattern-view-control__drag-handle is-left"
+				aria-label="<?php esc_attr( 'Drag to resize', 'wporg-patterns' ); ?>"
+				aria-describedby="<?php echo esc_attr( $html_id ); ?>-left"
+				data-direction="left"
+				data-wp-on--keydown="actions.onLeftKeyDown"
+				data-wp-on--mousedown="actions.onDragStart"
+			></button>
+		</div>
+		<?php
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content from child blocks.
+			echo $content;
+		?>
+		<div class="wporg-pattern-preview__drag-handle">
+			<button
+				class="wporg-pattern-view-control__drag-handle is-right"
+				aria-label="<?php esc_attr( 'Drag to resize', 'wporg-patterns' ); ?>"
+				aria-describedby="<?php echo esc_attr( $html_id ); ?>-right"
+				data-direction="right"
+				data-wp-on--keydown="actions.onRightKeyDown"
+				data-wp-on--mousedown="actions.onDragStart"
+			></button>
+		</div>
+	</div>
+
+	<span id="<?php echo esc_attr( $html_id ); ?>-left" class="screen-reader-text">
+		<?php esc_attr_e( 'Drag or use arrow keys to resize the pattern preview. Left to make larger, right to make smaller.', 'wporg-patterns' ); ?>
+	</span>
+	<span id="<?php echo esc_attr( $html_id ); ?>-right" class="screen-reader-text">
+		<?php esc_attr_e( 'Drag or use arrow keys to resize the pattern preview. Right to make larger, left to make smaller.', 'wporg-patterns' ); ?>
+	</span>
 </div>

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/render.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/render.php
@@ -31,6 +31,7 @@ $html_id = wp_unique_id( 'pattern-preview-help-' );
 	data-wp-interactive="wporg/patterns/preview"
 	data-wp-context="<?php echo esc_attr( $encoded_state ); ?>"
 	data-wp-class--is-mobile-view="state.isWidthNarrow"
+	data-wp-class--is-dragging="state.isDrag"
 	data-wp-on-window--mousemove="actions.onDrag"
 	data-wp-on-window--mouseup="actions.onDragEnd"
 >

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/render.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/render.php
@@ -98,10 +98,10 @@ $html_id = wp_unique_id( 'pattern-preview-help-' );
 		</div>
 	</div>
 
-	<span id="<?php echo esc_attr( $html_id ); ?>-left" class="screen-reader-text">
+	<span id="<?php echo esc_attr( $html_id ); ?>-left" hidden>
 		<?php esc_attr_e( 'Drag or use arrow keys to resize the pattern preview. Left to make larger, right to make smaller.', 'wporg-patterns' ); ?>
 	</span>
-	<span id="<?php echo esc_attr( $html_id ); ?>-right" class="screen-reader-text">
+	<span id="<?php echo esc_attr( $html_id ); ?>-right" hidden>
 		<?php esc_attr_e( 'Drag or use arrow keys to resize the pattern preview. Right to make larger, left to make smaller.', 'wporg-patterns' ); ?>
 	</span>
 </div>

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/style.scss
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/style.scss
@@ -106,4 +106,8 @@
 	&.is-left {
 		padding-right: 10px;
 	}
+
+	@media (max-width: 782px) {
+		display: none;
+	}
 }

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/style.scss
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/style.scss
@@ -60,36 +60,50 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	gap: 4px;
 }
 
 .wporg-pattern-view-control__drag-handle {
 	$height: 52px;
-	$width: 8px;
+	$width: 4px;
 	height: $height;
 	width: $width;
+	box-sizing: content-box;
 	padding: 0;
-	border-radius: math.div($width, 2);
 	z-index: 2;
 	border: none;
-	background: var(--wp--preset--color--charcoal-5);
+	background-color: transparent;
+	cursor: col-resize;
 
-	&:hover {
+	&::before {
+		content: "";
+		display: block;
+		height: $height;
+		width: $width;
+		border-radius: math.div($width, 2);
+		background: var(--wp--preset--color--charcoal-5);
+	}
+
+	&:hover::before {
 		background: var(--wp--preset--color--charcoal-4);
 	}
 
 	&:focus {
-		border-radius: math.div($width, 2);
 		box-shadow: none;
-		background: var(--wp--preset--color--charcoal-4);
+
+		&::before {
+			background: var(--wp--preset--color--charcoal-4);
+		}
 	}
 
-	&:focus-visible {
+	&:focus-visible::before {
 		box-shadow: 0 0 0 1.5px var(--wp--custom--link--color--text);
 	}
 
 	&.is-right {
-		left: auto;
-		right: -20px;
+		padding-left: 10px;
+	}
+
+	&.is-left {
+		padding-right: 10px;
 	}
 }

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/style.scss
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/style.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .wp-block-wporg-pattern-view-control {
 	position: relative;
 	width: 100%;
@@ -7,7 +9,7 @@
 	.wp-block-wporg-pattern-preview {
 		box-sizing: content-box;
 		border: none;
-		width: calc(100% - var(--wp--custom--wporg-pattern-preview--border--width) * 2);
+		width: auto;
 		padding: var(--wp--custom--wporg-pattern-preview--border--width);
 		display: flex;
 		justify-content: center;
@@ -24,12 +26,9 @@
 			margin: 0;
 			display: block;
 			border-radius: var(--wp--custom--wporg-pattern-preview--border--radius);
+			// @todo This breaks scrolling.
 			pointer-events: none;
 		}
-	}
-
-	&.is-mobile-view .wp-block-wporg-pattern-preview__container > iframe {
-		pointer-events: auto;
 	}
 }
 
@@ -52,5 +51,43 @@
 		svg {
 			fill: currentColor !important;
 		}
+	}
+}
+
+.wporg-pattern-preview__drag-container {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+}
+
+.wporg-pattern-view-control__drag-handle {
+	$height: 52px;
+	$width: 8px;
+	height: $height;
+	width: $width;
+	padding: 0;
+	border-radius: math.div($width, 2);
+	z-index: 2;
+	border: none;
+	background: var(--wp--preset--color--charcoal-5);
+
+	&:hover {
+		background: var(--wp--preset--color--charcoal-4);
+	}
+
+	&:focus {
+		border-radius: math.div($width, 2);
+		box-shadow: none;
+		background: var(--wp--preset--color--charcoal-4);
+	}
+
+	&:focus-visible {
+		box-shadow: 0 0 0 1.5px var(--wp--custom--link--color--text);
+	}
+
+	&.is-right {
+		left: auto;
+		right: -20px;
 	}
 }

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/style.scss
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/style.scss
@@ -26,9 +26,11 @@
 			margin: 0;
 			display: block;
 			border-radius: var(--wp--custom--wporg-pattern-preview--border--radius);
-			// @todo This breaks scrolling.
-			pointer-events: none;
 		}
+	}
+
+	&.is-dragging .wp-block-wporg-pattern-preview__container > iframe {
+		pointer-events: none;
 	}
 }
 

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/view.js
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/view.js
@@ -3,11 +3,6 @@
  */
 import { getContext, getElement, store } from '@wordpress/interactivity';
 
-/**
- * Module constants
- */
-const THROTTLE_DELAY = 10;
-
 const { actions, state } = store( 'wporg/patterns/preview', {
 	state: {
 		get scale() {
@@ -36,6 +31,7 @@ const { actions, state } = store( 'wporg/patterns/preview', {
 		get isWidthNarrow() {
 			return getContext().previewWidth < 800;
 		},
+		dragPos: 0,
 		isDrag: false,
 		throttleTimeout: 0,
 		prevX: 0,
@@ -74,22 +70,23 @@ const { actions, state } = store( 'wporg/patterns/preview', {
 			state.isDrag = true;
 			state.prevX = event.x;
 			state.direction = ref.dataset.direction;
+			state.dragPos = getContext().previewWidth;
 		},
 		onDrag( event ) {
-			if ( ! state.isDrag || state.throttleTimeout > Date.now() ) {
+			if ( ! state.isDrag ) {
 				return;
 			}
 
-			const context = getContext();
 			const delta = event.x - state.prevX;
 			if ( ( delta < 0 && 'left' === state.direction ) || ( delta > 0 && 'right' === state.direction ) ) {
-				actions.updatePreviewWidth( context.previewWidth + 2 * Math.abs( delta ) );
+				state.dragPos += 2 * Math.abs( delta );
+				actions.updatePreviewWidth( state.dragPos );
 			} else {
-				actions.updatePreviewWidth( context.previewWidth - 2 * Math.abs( delta ) );
+				state.dragPos -= 2 * Math.abs( delta );
+				actions.updatePreviewWidth( state.dragPos );
 			}
 
 			state.prevX = event.x;
-			state.throttleTimeout = Date.now() + THROTTLE_DELAY;
 		},
 		onDragEnd() {
 			state.throttleTimeout = 0;

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/view.js
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/view.js
@@ -40,7 +40,7 @@ const { actions, state } = store( 'wporg/patterns/preview', {
 	actions: {
 		updatePreviewWidth( newWidth ) {
 			const context = getContext();
-			if ( newWidth > 320 && newWidth < 2400 ) {
+			if ( newWidth > 320 && newWidth < 1400 ) {
 				context.previewWidth = newWidth;
 			}
 		},

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/view.js
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/view.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { getContext, getElement, store } from '@wordpress/interactivity';
+import { getContext, getElement, store, withScope } from '@wordpress/interactivity';
 
 const { actions, state } = store( 'wporg/patterns/preview', {
 	state: {
@@ -48,6 +48,10 @@ const { actions, state } = store( 'wporg/patterns/preview', {
 			const { ref } = getElement();
 			const context = getContext();
 			context.previewWidth = parseInt( ref.dataset.width, 10 );
+			setTimeout(
+				withScope( () => actions.handleOnResize() ),
+				0
+			);
 		},
 		onLeftKeyDown( event ) {
 			const context = getContext();
@@ -111,7 +115,14 @@ const { actions, state } = store( 'wporg/patterns/preview', {
 		handleOnResize() {
 			const context = getContext();
 			const { ref } = getElement();
-			context.pageWidth = ref.querySelector( '.wp-block-wporg-pattern-preview__container' )?.clientWidth;
+
+			// Back up to the block container, so that this works regardless
+			// of which element interaction triggered it.
+			const container = ref.closest( '.wp-block-wporg-pattern-view-control' );
+			if ( container ) {
+				const preview = container.querySelector( '.wp-block-wporg-pattern-preview__container' );
+				context.pageWidth = preview?.clientWidth;
+			}
 		},
 	},
 } );

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/view.js
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/view.js
@@ -3,6 +3,11 @@
  */
 import { getContext, getElement, store } from '@wordpress/interactivity';
 
+/**
+ * Module constants
+ */
+const THROTTLE_DELAY = 10;
+
 const { actions, state } = store( 'wporg/patterns/preview', {
 	state: {
 		get scale() {
@@ -23,20 +28,73 @@ const { actions, state } = store( 'wporg/patterns/preview', {
 			return `scale(${ state.scale })`;
 		},
 		get isWidthWide() {
-			return 1200 === getContext().previewWidth;
+			return getContext().previewWidth >= 1200;
 		},
 		get isWidthMedium() {
-			return 800 === getContext().previewWidth;
+			return getContext().previewWidth >= 800 && getContext().previewWidth < 1200;
 		},
 		get isWidthNarrow() {
-			return 400 === getContext().previewWidth;
+			return getContext().previewWidth < 800;
 		},
+		isDrag: false,
+		throttleTimeout: 0,
+		prevX: 0,
+		direction: '',
 	},
 	actions: {
+		updatePreviewWidth( newWidth ) {
+			const context = getContext();
+			if ( newWidth > 320 && newWidth < 2400 ) {
+				context.previewWidth = newWidth;
+			}
+		},
 		onWidthChange() {
 			const { ref } = getElement();
 			const context = getContext();
 			context.previewWidth = parseInt( ref.dataset.width, 10 );
+		},
+		onLeftKeyDown( event ) {
+			const context = getContext();
+			if ( 'ArrowLeft' === event.code ) {
+				actions.updatePreviewWidth( context.previewWidth + 20 );
+			} else if ( 'ArrowRight' === event.code ) {
+				actions.updatePreviewWidth( context.previewWidth - 20 );
+			}
+		},
+		onRightKeyDown( event ) {
+			const context = getContext();
+			if ( 'ArrowRight' === event.code ) {
+				actions.updatePreviewWidth( context.previewWidth + 20 );
+			} else if ( 'ArrowLeft' === event.code ) {
+				actions.updatePreviewWidth( context.previewWidth - 20 );
+			}
+		},
+		onDragStart( event ) {
+			const { ref } = getElement();
+			state.isDrag = true;
+			state.prevX = event.x;
+			state.direction = ref.dataset.direction;
+		},
+		onDrag( event ) {
+			if ( ! state.isDrag || state.throttleTimeout > Date.now() ) {
+				return;
+			}
+
+			const context = getContext();
+			const delta = event.x - state.prevX;
+			if ( ( delta < 0 && 'left' === state.direction ) || ( delta > 0 && 'right' === state.direction ) ) {
+				actions.updatePreviewWidth( context.previewWidth + 2 * Math.abs( delta ) );
+			} else {
+				actions.updatePreviewWidth( context.previewWidth - 2 * Math.abs( delta ) );
+			}
+
+			state.prevX = event.x;
+			state.throttleTimeout = Date.now() + THROTTLE_DELAY;
+		},
+		onDragEnd() {
+			state.throttleTimeout = 0;
+			state.isDrag = false;
+			state.direction = '';
 		},
 		*onLoad() {
 			const { ref } = getElement();
@@ -50,22 +108,7 @@ const { actions, state } = store( 'wporg/patterns/preview', {
 		},
 		updatePreviewHeight() {
 			const context = getContext();
-			const { ref } = getElement();
-
-			// If this is the "narrow" (mobile) view, it should use a fixed height.
-			if ( state.isWidthNarrow ) {
-				context.previewHeight = 600;
-				return;
-			}
-
-			// Need to "use" previewWidth so that `data-wp-watch` will re-run this action when it changes.
-			context.previewWidth; // eslint-disable-line no-unused-expressions
-
-			const iframeDoc = ref.contentDocument;
-			const height = iframeDoc.querySelector( '.entry-content' )?.clientHeight;
-			if ( height ) {
-				context.previewHeight = height * state.scale;
-			}
+			context.previewHeight = 600;
 		},
 		handleOnResize() {
 			const context = getContext();

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/view.js
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/controls/view.js
@@ -85,6 +85,7 @@ const { actions, state } = store( 'wporg/patterns/preview', {
 				state.dragPos -= 2 * Math.abs( delta );
 				actions.updatePreviewWidth( state.dragPos );
 			}
+			actions.handleOnResize();
 
 			state.prevX = event.x;
 		},
@@ -110,7 +111,7 @@ const { actions, state } = store( 'wporg/patterns/preview', {
 		handleOnResize() {
 			const context = getContext();
 			const { ref } = getElement();
-			context.pageWidth = ref.querySelector( 'div' )?.clientWidth;
+			context.pageWidth = ref.querySelector( '.wp-block-wporg-pattern-preview__container' )?.clientWidth;
 		},
 	},
 } );


### PR DESCRIPTION
See #642. This updates the `wporg/pattern-view-control` block to include drag handles for resizing the preview. Since the new version of the block uses the Interactivity API, not React components, we can't "just port over" the old functionality, and we can't use the gesture library. I've made it work fairly well with vanilla JS + interactivity directives, but it still seems janky to me.

- When the drag handle is clicked (mousedown), it triggers the "dragging" state, and tracks the current x-position & which handle was clicked
- On any mousemove, if we're in dragging state, check the difference in x-position to see which way we should resize and update the previewWidth accordingly
    - On large screens, the iframe width doesn't update correctly, so the preview is pushed to the side
    - There's a throttle timeout, but it's just 10ms — any higher and the resizing was jumpy
- On any mouseup, it resets the dragging state back to the initial values

For keyboard users, they can focus on the drag handles, and use the left/right arrow keys to change the preview width. This matches the current behavior.

I did not use the HTML `draggable` API because it created a ghost-button while dragging, and it seemed to not work on the `button` element.

In the design, the toggles are only 4px wide. When testing, I had a lot of trouble targeting that size, so I've changed them to 8px.

⚠️  **Known issues, would appreciate opinions:**

- I had to give the whole preview a fixed height, otherwise the middle-aligned drag buttons jump around, so now the patterns are cut off on the wide/medium sizes (or have extra whitespace, if the pattern is short).
- The mousemove event over iframe only works when `pointer-events: none` or there's an overlay, but then we can't scroll inside the window.
- The aforementioned width issue on large screens (shown in the video below)

### Screenshots

![Screen Shot 2024-04-01 at 16 28 13](https://github.com/WordPress/pattern-directory/assets/541093/df7664a7-b3e7-4efd-b07c-4df7e3191e56)

On a large screen, resize up and then back down.

https://github.com/WordPress/pattern-directory/assets/541093/245961d7-4f9f-4b42-9048-18dbc6d5a4f3

On small screen, resize from the "mobile toggle" up to large screen, which scales down the preview (but not the frame height).

https://github.com/WordPress/pattern-directory/assets/541093/169c3af9-f570-4956-a6b9-468418b89903

### How to test the changes in this Pull Request:

1. Check out the branch and built the project
2. View any pattern
3. You should see drag handles, and be able to drag them to change the preview size
4. Clicking the set buttons should still work
5. Try again with a pattern you own
