### PR TITLE
Block: Pattern Thumbnail: Fix loading and error state

### DIFF
--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/render.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/render.php
@@ -36,6 +36,9 @@ $init_state = [
 	'base64Image' => '',
 	'src' => esc_url( $url ),
 	'alt' => the_title_attribute( array( 'echo' => false ) ),
+	'attempts' => 0,
+	'shouldRetry' => true,
+	'hasError' => false,
 ];
 $encoded_state = wp_json_encode( $init_state );
 

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/render.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/render.php
@@ -72,6 +72,7 @@ if ( $has_link ) {
 		/>
 		<span
 			data-wp-bind--hidden="state.base64Image"
+			data-wp-class--screen-reader-text="!state.base64Image"
 			data-wp-text="context.alt"
 		></span>
 	</div>

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/style.scss
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/style.scss
@@ -41,8 +41,7 @@
 		justify-content: center;
 		height: 100%;
 
-		img,
-		span {
+		img {
 			display: none;
 		}
 
@@ -78,10 +77,12 @@
 			content: "";
 			display: inline-block;
 			box-sizing: border-box;
-			height: 48px;
-			width: 48px;
+			height: 24px;
+			width: 24px;
 			// stylelint-disable-next-line function-url-quotes
-			background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg' width='48' height='48'%3E%3Cpath d='M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM5 4.5h14c.3 0 .5.2.5.5v8.4l-3-2.9c-.3-.3-.8-.3-1 0L11.9 14 9 12c-.3-.2-.6-.2-.8 0l-3.6 2.6V5c-.1-.3.1-.5.4-.5zm14 15H5c-.3 0-.5-.2-.5-.5v-2.4l4.1-3 3 1.9c.3.2.7.2.9-.1L16 12l3.5 3.4V19c0 .3-.2.5-.5.5z'%3E%3C/path%3E%3C/svg%3E");
+			background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h5l-.121-.121 1.379-1.379H5a.5.5 0 0 1-.5-.5v-2.436l4.096-2.987 2.996 1.941a.75.75 0 0 0 .93-.091L16 12.046l1.375 1.337 1.06-1.06-1.912-1.86a.75.75 0 0 0-1.046 0l-3.571 3.471-2.927-1.897a.75.75 0 0 0-.85.024L4.5 14.707V5a.5.5 0 0 1 .5-.5h14a.5.5 0 0 1 .5.5v6.258l1.5-1.5V5a2 2 0 0 0-2-2H5Zm16 11-1.5 1.5V19a.5.5 0 0 1-.5.5h-3.5L14 21h5a2 2 0 0 0 2-2v-5Z' fill='%231E1E1E'/%3E%3C/svg%3E");
+			background-position: center;
+			background-repeat: no-repeat;
 		}
 	}
 }

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/style.scss
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/style.scss
@@ -26,25 +26,24 @@
 		aspect-ratio: 4 / 3;
 		display: flex;
 		align-items: center;
+		justify-content: center;
+		height: 100%;
 	}
 
 	img {
-		display: block;
+		display: none;
 		margin: auto;
 		max-width: 100%;
 		max-height: 100%;
 	}
 
-	.wporg-pattern-thumbnail__loader {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		height: 100%;
-
+	&.has-loaded {
 		img {
-			display: none;
+			display: block;
 		}
+	}
 
+	.wporg-pattern-thumbnail__loader {
 		&::after {
 			content: "";
 			display: inline-block;
@@ -62,16 +61,7 @@
 	}
 
 	.wporg-pattern-thumbnail__error {
-		display: flex;
-		align-items: center;
-		justify-content: center;
 		flex-direction: column;
-		height: 100%;
-		aspect-ratio: 4 / 3;
-
-		img {
-			display: none;
-		}
 
 		&::before {
 			content: "";

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/style.scss
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/style.scss
@@ -66,8 +66,23 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		flex-direction: column;
 		height: 100%;
-		aspect-ratio: 21 / 9;
+		aspect-ratio: 4 / 3;
+
+		img {
+			display: none;
+		}
+
+		&::before {
+			content: "";
+			display: inline-block;
+			box-sizing: border-box;
+			height: 48px;
+			width: 48px;
+			// stylelint-disable-next-line function-url-quotes
+			background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg' width='48' height='48'%3E%3Cpath d='M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM5 4.5h14c.3 0 .5.2.5.5v8.4l-3-2.9c-.3-.3-.8-.3-1 0L11.9 14 9 12c-.3-.2-.6-.2-.8 0l-3.6 2.6V5c-.1-.3.1-.5.4-.5zm14 15H5c-.3 0-.5-.2-.5-.5v-2.4l4.1-3 3 1.9c.3.2.7.2.9-.1L16 12l3.5 3.4V19c0 .3-.2.5-.5.5z'%3E%3C/path%3E%3C/svg%3E");
+		}
 	}
 }
 

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/view.js
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-thumbnail/view.js
@@ -12,9 +12,15 @@ const RETRY_DELAY = 2000;
 
 const { actions, state } = store( 'wporg/patterns/thumbnail', {
 	state: {
-		attempts: 0,
-		shouldRetry: true,
-		hasError: false,
+		get attempts() {
+			return getContext().attempts;
+		},
+		get shouldRetry() {
+			return getContext().shouldRetry;
+		},
+		get hasError() {
+			return getContext().hasError;
+		},
 		get base64Image() {
 			return getContext().base64Image;
 		},
@@ -24,11 +30,13 @@ const { actions, state } = store( 'wporg/patterns/thumbnail', {
 	},
 	actions: {
 		setShouldRetry( value ) {
-			state.shouldRetry = value;
+			const context = getContext();
+			context.shouldRetry = value;
 		},
 
 		setHasError( value ) {
-			state.hasError = value;
+			const context = getContext();
+			context.hasError = value;
 		},
 
 		setBase64Image( value ) {
@@ -38,8 +46,9 @@ const { actions, state } = store( 'wporg/patterns/thumbnail', {
 
 		*fetchImage( fullUrl ) {
 			try {
+				const context = getContext();
 				const res = yield fetch( fullUrl );
-				state.attempts++;
+				context.attempts++;
 
 				if ( res.redirected ) {
 					actions.setShouldRetry( true );


### PR DESCRIPTION
Fixes #652 — This updates the pattern preview block to use context for the initial block state (ex, `attempts`). Previously the state.attempts value was global, so each pattern on the page incremented it. By the time the last patterns on the page are rendered, the `attempts` value would already be >10, so it would only try the initial fetch and if the mshots image did not exist, it would error - no retries.

This updates the `attempts` to behave as expected, 10 attempts per pattern. This should cut down on the number of errors per page.

The error display has also been updated, in the case where there are issues. Happy to tweak this if there are any suggestions @StevenDufresne @WordPress/meta-design (screenshot below)

### Screenshots

<img width="1212" alt="Screenshot 2024-04-02 at 5 01 34 PM" src="https://github.com/WordPress/pattern-directory/assets/541093/3abf6294-9560-4350-a453-526d3bfd3ab0">

### How to test the changes in this Pull Request:

1. View the pattern archives
2. The previews should load successfully
3. If there are any errors, it should not show the broken `<img>` tag

To check that this is loading correctly from scratch, you could update `$cache_key` to something random, which will force mshots to re-take the screenshots, and take longer for loading.

To intentionally trigger an error state, update the `$cache_key` (render.php) and change `MAX_ATTEMPTS` (view.js) to 1 or 2.

Remember to rebuild if you make those changes.
