### PR TITLE
Block theme: Update filters with new single-select behavior

### DIFF
--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
@@ -132,6 +132,9 @@ function get_curation_options( $options ) {
 		case 'core':
 			$label = __( 'Curated', 'wporg' );
 			break;
+		default:
+			$label = __( 'All', 'wporg' );
+			break;
 	}
 
 	// Show the correct filters on the front page.
@@ -146,6 +149,7 @@ function get_curation_options( $options ) {
 		'key' => 'curation',
 		'action' => get_filter_action_url(),
 		'options' => array(
+			'' => __( 'All', 'wporg' ),
 			'community' => __( 'Community', 'wporg' ),
 			'core' => __( 'Curated', 'wporg' ),
 		),

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
@@ -127,17 +127,17 @@ function get_curation_options( $options ) {
 	$label = __( 'Filter by', 'wporg' );
 	switch ( $current ) {
 		case 'community':
-			$label = __( 'Filter by: Community', 'wporg' );
+			$label = __( 'Community', 'wporg' );
 			break;
 		case 'core':
-			$label = __( 'Filter by: Curated', 'wporg' );
+			$label = __( 'Curated', 'wporg' );
 			break;
 	}
 
 	// Show the correct filters on the front page.
 	if ( is_front_page() ) {
 		$current = 'core';
-		$label = __( 'Filter by: Curated', 'wporg' );
+		$label = __( 'Curated', 'wporg' );
 	}
 
 	return array(
@@ -168,22 +168,22 @@ function get_sort_options( $options ) {
 	$label = __( 'Sort', 'wporg' );
 	switch ( $sort ) {
 		case 'date_desc':
-			$label = __( 'Sort: Newest', 'wporg' );
+			$label = __( 'Newest', 'wporg' );
 			break;
 		case 'date_asc':
-			$label = __( 'Sort: Oldest', 'wporg' );
+			$label = __( 'Oldest', 'wporg' );
 			break;
 	}
 
 	// Popular is a special case since it's not a true "order" value.
 	if ( 'meta_value_num' === $orderby && 'wporg-pattern-favorites' === $wp_query->get( 'meta_key' ) ) {
-		$label = __( 'Sort: Popular', 'wporg' );
+		$label = __( 'Popular', 'wporg' );
 	}
 
 	// Show the correct filters on the front page.
 	if ( is_front_page() ) {
 		$sort = 'favorite_count_desc';
-		$label = __( 'Sort: Popular', 'wporg' );
+		$label = __( 'Popular', 'wporg' );
 	}
 
 	$options = array(

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
@@ -169,6 +169,11 @@ function get_sort_options( $options ) {
 	$order = strtolower( $wp_query->get( 'order', 'desc' ) );
 	$sort = $orderby . '_' . $order;
 
+	// Popular is a special case since it's not a true "order" value.
+	if ( 'meta_value_num' === $orderby && 'wporg-pattern-favorites' === $wp_query->get( 'meta_key' ) ) {
+		$sort = 'favorite_count_desc';
+	}
+
 	$label = __( 'Sort', 'wporg' );
 	switch ( $sort ) {
 		case 'date_desc':
@@ -177,11 +182,9 @@ function get_sort_options( $options ) {
 		case 'date_asc':
 			$label = __( 'Oldest', 'wporg' );
 			break;
-	}
-
-	// Popular is a special case since it's not a true "order" value.
-	if ( 'meta_value_num' === $orderby && 'wporg-pattern-favorites' === $wp_query->get( 'meta_key' ) ) {
-		$label = __( 'Popular', 'wporg' );
+		case 'favorite_count_desc':
+			$label = __( 'Popular', 'wporg' );
+			break;
 	}
 
 	// Show the correct filters on the front page.

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
@@ -161,8 +161,8 @@ function get_curation_options( $options ) {
  */
 function get_sort_options( $options ) {
 	global $wp_query;
-	$orderby = strtolower( $wp_query->get( 'orderby' ) );
-	$order = strtolower( $wp_query->get( 'order' ) );
+	$orderby = strtolower( $wp_query->get( 'orderby', 'date' ) );
+	$order = strtolower( $wp_query->get( 'order', 'desc' ) );
 	$sort = $orderby . '_' . $order;
 
 	$label = __( 'Sort', 'wporg' );


### PR DESCRIPTION
Fixes #648, along with https://github.com/WordPress/wporg-mu-plugins/pull/596.

The Query Filter block was updated in https://github.com/WordPress/wporg-mu-plugins/pull/596, and this PR updates the configuration to work with the new expected behavior.

- The label prefix ("Sort"/"Filter") is removed from the buttons, and is now visible in the dropdown
- Sort now has a visible default value, so "Newest" is selected when no filters are applied (this is the WP_Query default)
- Filter now has an "All" option so that something can be selected on the "All patterns" page

### Screenshots

|  | Screenshot | 
|---|---|
| Home | ![home-default](https://github.com/WordPress/wporg-mu-plugins/assets/541093/26cd0c83-1174-41a1-84d5-046539f27a9c) |
| "Filter" open | ![home-filter-open](https://github.com/WordPress/wporg-mu-plugins/assets/541093/dfc7af5d-a22b-4ed1-9684-11a2f14dacf5) |
| "Sort" open | ![home-sort-open](https://github.com/WordPress/wporg-mu-plugins/assets/541093/d697ca26-ffe4-4743-93a0-a1cc8d9add9a) |
| All patterns | ![all-patterns-default](https://github.com/WordPress/wporg-mu-plugins/assets/541093/aaae25be-bcf5-41a2-b87a-370eff3330ff) |
| All patterns, with filters applied | ![all-patterns-filtered](https://github.com/WordPress/wporg-mu-plugins/assets/541093/e3cdeb3f-7c03-4d31-b7ce-00ae1342556f) |

### How to test the changes in this Pull Request:

1. Apply https://github.com/WordPress/wporg-mu-plugins/pull/596 to wporg-mu-plugins
2. View various grid pages, the filters should show up and work as expected
3. You can no longer clear a filter, so something should always appear selected
