### PR TITLE
Single pattern: Use "Has results" block to conditionally display "More from…" title

### DIFF
--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/single-pattern.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/single-pattern.php
@@ -71,24 +71,26 @@ if ( 'report-failed' === $status ) {
 <div class="wp-block-group alignfull" style="margin-top:0;padding-bottom:var(--wp--preset--spacing--50)">
 	<!-- wp:group {"align":"wide"} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
-		<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)">
-			<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"large","fontFamily":"inter"} -->
-			<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600"><?php esc_html_e( 'More from this designer', 'wporg-patterns' ); ?></h2>
-			<!-- /wp:heading -->
-
-			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-			<div class="wp-block-group">
-				<!-- wp:avatar {"size":24,"style":{"border":{"radius":"100%"}}} /-->
-
-				<!-- wp:post-author-name {"isLink":true,"style":{"typography":{"fontStyle":"normal"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}}},"textColor":"charcoal-1","fontSize":"small"} /-->
-			</div>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
-
 		<!-- wp:query {"queryId":1,"query":{"inherit":false,"perPage":3,"postType":"wporg-pattern","_id":"more-by-author"}} -->
 		<div class="wp-block-query">
+			<!-- wp:wporg/query-has-results -->
+				<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
+				<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)">
+					<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"large","fontFamily":"inter"} -->
+					<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600"><?php esc_html_e( 'More from this designer', 'wporg-patterns' ); ?></h2>
+					<!-- /wp:heading -->
+
+					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+					<div class="wp-block-group">
+						<!-- wp:avatar {"size":24,"style":{"border":{"radius":"100%"}}} /-->
+
+						<!-- wp:post-author-name {"isLink":true,"style":{"typography":{"fontStyle":"normal"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}}},"textColor":"charcoal-1","fontSize":"small"} /-->
+					</div>
+					<!-- /wp:group -->
+				</div>
+				<!-- /wp:group -->
+			<!-- /wp:wporg/query-has-results -->
+			
 			<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"grid","columnCount":3}} -->
 				<!-- wp:group {"style":{"spacing":{"blockGap":"5px"}}} -->
 				<div class="wp-block-group">


### PR DESCRIPTION
Fixes #636 — this uses the new block from https://github.com/WordPress/wporg-mu-plugins/pull/599 to conditionally display the "More from this designer" header.

Requires https://github.com/WordPress/wporg-mu-plugins/pull/599 to merge first.

### Screenshots

| Multiple pattern author | Single pattern author |
|---|---|
| ![Screen Shot 2024-04-08 at 18 10 34](https://github.com/WordPress/pattern-directory/assets/541093/fcc85af3-01f0-466c-aef1-a943c1e7e875) | ![Screen Shot 2024-04-08 at 18 11 05](https://github.com/WordPress/pattern-directory/assets/541093/983f0684-0a52-450f-89f1-70d4c29e3dd8) |

### How to test the changes in this Pull Request:

Requires wporg-mu-plugins branch https://github.com/WordPress/wporg-mu-plugins/pull/599

1. Find an author with multiple patterns
2. View a pattern by them
3. You should see more patterns available under the large preview, with a "More from this designer" heading
4. Find an author with only one pattern
5. View that pattern
6. There should be nothing under the large preview section
