### PR TITLE
Avoid warning with invalid tax queries

### DIFF
--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
@@ -474,7 +474,7 @@ function add_social_meta_tags() {
 			'og:url'         => home_url(),
 			'og:image'       => esc_url( $default_image ),
 		];
-	} else if ( is_tax() ) {
+	} else if ( is_tax() && get_queried_object() ) {
 		$og_fields = [
 			'og:title'       => sprintf( __( 'Block Patterns: %s', 'wporg-patterns' ), esc_attr( single_term_title( '', false ) ) ),
 			'og:description' => __( 'Add a beautifully designed, ready to go layout to any WordPress site with a simple copy/paste.', 'wporg-patterns' ),


### PR DESCRIPTION
```
E_WARNING: ltrim() expects parameter 1 to be string, object given in wp-includes/formatting.php:4494

Source: GET https://example.org/?pattern-categories=1&s=the
```

get_term_link() can return a WP_Error when the input is invalid, this is then passed to `esc_url()`.

This is a slightly hacky workaround by checking that `get_queried_object()` returns something before venturing into the taxonomy branch.
Technically, it would probably be better to validate that `get_term_link()` return s a term, and that `get_queried_object()` return a WP_Term though.. so perhaps this could be `&& ( get_queried_object() instanceof \WP_Term )`?
