### PR TITLE
Add results check for URL field

### DIFF
--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
@@ -475,12 +475,18 @@ function add_social_meta_tags() {
 			'og:image'       => esc_url( $default_image ),
 		];
 	} else if ( is_tax() ) {
+		// Make sure URL is going to be a string since `get_term_link` can return wp_error.
+		$og_url_field = get_term_link( get_queried_object_id() );
+		if ( is_wp_error( $og_url_field ) ) {
+			$og_url_field = '';
+		}
+
 		$og_fields = [
 			'og:title'       => sprintf( __( 'Block Patterns: %s', 'wporg-patterns' ), esc_attr( single_term_title( '', false ) ) ),
 			'og:description' => __( 'Add a beautifully designed, ready to go layout to any WordPress site with a simple copy/paste.', 'wporg-patterns' ),
 			'og:site_name'   => $site_title,
 			'og:type'        => 'website',
-			'og:url'         => esc_url( get_term_link( get_queried_object_id() ) ),
+			'og:url'         => esc_url( $og_url_field ),
 			'og:image'       => esc_url( $default_image ),
 		];
 	} else if ( is_singular( POST_TYPE ) ) {


### PR DESCRIPTION
`get_term_link` can return WP_Error if there is no matching term (https://developer.wordpress.org/reference/functions/get_term_link/) - this additional check protects against this and the warnings produced from attempting to escape this.

if we want to produce a standard URL i.e. home_url this could also be possible, although unsure what the implications are for doing so i.e. indexing the URLs etc