### PR TITLE
Block theme: Update pattern workaround to use template filters.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
 	],
 	"require": {
 		"composer/installers": "~1.0",
-		"wpackagist-plugin/gutenberg": "17.8.1",
+		"wpackagist-plugin/gutenberg": "*",
 		"wpackagist-plugin/stream": "*",
 		"wpackagist-plugin/wordpress-importer": "*",
 		"wordpress-meta/wporg": "1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9e893473fca2901ccf72d2d3c29e7a9",
+    "content-hash": "74ea5900c960f7fe6903d62deaf576ae",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -236,15 +236,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "17.8.1",
+            "version": "18.2.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/17.8.1"
+                "reference": "tags/18.2.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.17.8.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.18.2.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -319,12 +319,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "2ef6485db0cfeb1411e8e24bf60832bd8147ea6c"
+                "reference": "1c01971a816aba069a1c9e5d9c200ac2e20c8dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/2ef6485db0cfeb1411e8e24bf60832bd8147ea6c",
-                "reference": "2ef6485db0cfeb1411e8e24bf60832bd8147ea6c",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/1c01971a816aba069a1c9e5d9c200ac2e20c8dc6",
+                "reference": "1c01971a816aba069a1c9e5d9c200ac2e20c8dc6",
                 "shasum": ""
             },
             "require": {
@@ -365,7 +365,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/build",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2024-04-09T17:31:18+00:00"
+            "time": "2024-04-30T16:50:57+00:00"
         }
     ],
     "packages-dev": [
@@ -813,28 +813,28 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
-                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "paragonie/random_compat": "dev-master",
                 "paragonie/sodium_compat": "dev-master"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -864,22 +864,37 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2022-10-25T01:46:02+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-24T21:30:46+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.4",
+            "version": "2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
+                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
-                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
+                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
                 "shasum": ""
             },
             "require": {
@@ -887,10 +902,10 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -919,9 +934,24 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2022-10-24T09:00:36+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-24T21:37:59+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2370,16 +2400,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.9.1",
+            "version": "3.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909"
+                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/267a4405fff1d9c847134db3a3c92f1ab7f77909",
-                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/aac1f6f347a5c5ac6bc98ad395007df00990f480",
+                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480",
                 "shasum": ""
             },
             "require": {
@@ -2446,7 +2476,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-03-31T21:03:09+00:00"
+            "time": "2024-04-23T20:25:34+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/_logged-out-favorites.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/_logged-out-favorites.php
@@ -12,8 +12,8 @@ $login_url = wp_login_url();
 $register_url = wp_registration_url();
 
 ?>
-<!-- wp:group {"layout":{"type":"constrained","contentSize":"30rem","justifyContent":"left"}} -->
-<div class="wp-block-group">
+<!-- wp:group {"layout":{"type":"constrained","contentSize":"30rem","justifyContent":"left"},"align":"wide"} -->
+<div class="wp-block-group alignwide">
 	<!-- wp:paragraph -->
 	<p><?php esc_html_e( 'Log in to your WordPress.org account and you&#8217;ll be able to see all your favorite patterns in one place.', 'wporg-patterns' ); ?></p>
 	<!-- /wp:paragraph -->

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/_logged-out-patterns.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/_logged-out-patterns.php
@@ -12,8 +12,8 @@ $login_url = wp_login_url();
 $register_url = wp_registration_url();
 
 ?>
-<!-- wp:group {"layout":{"type":"constrained","contentSize":"30rem","justifyContent":"left"}} -->
-<div class="wp-block-group">
+<!-- wp:group {"layout":{"type":"constrained","contentSize":"30rem","justifyContent":"left"},"align":"wide"} -->
+<div class="wp-block-group alignwide">
 	<!-- wp:paragraph -->
 	<p><?php esc_html_e( 'Anyone can create and share patterns using the familiar block editor. Design helpful starting points for yourself and any WordPress site.', 'wporg-patterns' ); ?></p>
 	<!-- /wp:paragraph -->

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/templates/page-favorites-anon.html
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/templates/page-favorites-anon.html
@@ -1,0 +1,16 @@
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
+
+<!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
+<main class="wp-block-group alignfull">
+
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+		<!-- wp:post-title {"align":"wide","level":1,"fontSize":"heading-3","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} /-->
+
+		<!-- wp:pattern {"slug":"wporg-pattern-directory-2024/logged-out-favorites"} /-->
+	</div>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/templates/page-my-patterns-anon.html
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/templates/page-my-patterns-anon.html
@@ -1,0 +1,16 @@
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
+
+<!-- wp:group {"tagName":"main","align":"full","layout":{"type":"constrained"}} -->
+<main class="wp-block-group alignfull">
+
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+		<!-- wp:post-title {"align":"wide","level":1,"fontSize":"heading-3","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} /-->
+
+		<!-- wp:pattern {"slug":"wporg-pattern-directory-2024/logged-out-patterns"} /-->
+	</div>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/templates/single-mine.html
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/templates/single-mine.html
@@ -1,0 +1,9 @@
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"align":"full","layout":{"type":"constrained"}} -->
+<main class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:pattern {"slug":"wporg-pattern-directory-2024/single-my-pattern"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
Fixes #662 — This removes the pattern slug filtering in favor of adding extra custom templates, and filtering to inject those into the hierarchy. This is a more core-native way to handle template overrides, so it will be less likely to break in the future. With this change, we can unpin Gutenberg.

Additionally, this fixes the alignment of the "logged out" error messages.

### Screenshots

"Before" here is with GB <18, just to show the alignment change.

| Before | After |
|---|---|
| ![gb18-before](https://github.com/WordPress/pattern-directory/assets/541093/3ace2306-414f-4949-b5c5-24b6e47b07ba) | ![gb18-after](https://github.com/WordPress/pattern-directory/assets/541093/6a049624-9d88-4016-9683-34465f3c7086) |

### How to test the changes in this Pull Request:

1. Update locally to Gutenberg 18+
2. Be logged out
3. View the "My patterns" page
4. It should give you a "please log in" message
5. Repeat with Favorites, it should also show a "please log in" message
6. View a pattern you own
7. There should be a status message above the pattern name and pattern actions (edit, etc) under the preview.
