### PR TITLE
Update search.php

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/search.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/search.php
@@ -148,10 +148,15 @@ function modify_es_query_args( $es_query_args, $wp_query ) {
 			if ( ! in_array( $taxonomy, array( 'wporg-pattern-category', 'wporg-pattern-keyword' ) ) ) {
 				continue;
 			}
-
-			$filter['bool']['must'][] = [
-				'term' => [ "$taxonomy.slug" => $term['terms'] ],
-			];
+			if ( is_string( $term['terms'] ) ) {
+				$filter['bool']['must'][] = [
+					'term' => [ "taxonomy.$taxonomy.slug" => $term['terms'] ],
+				];
+			} else if ( is_int( $term['terms'] ) ) {
+				$filter['bool']['must'][] = [
+					'term' => [ "taxonomy.$taxonomy.term_id" => $term['terms'] ],
+				];
+			}
 		}
 	}
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/search.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/search.php
@@ -150,7 +150,7 @@ function modify_es_query_args( $es_query_args, $wp_query ) {
 			}
 
 			$filter['bool']['must'][] = [
-				'terms' => [ "taxonomy.$taxonomy.term_id" => $term['terms'] ],
+				'term' => [ "$taxonomy.slug" => $term['terms'] ],
 			];
 		}
 	}


### PR DESCRIPTION
Changes to query via slug, rather than term_id, since the new taxonomy `wporg-pattern-keyword` is used with slug.

Fixes #688.
