### PR TITLE
Update string on private APIs

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/lock-unlock.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/lock-unlock.js
@@ -4,6 +4,6 @@
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
 export const { lock, unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 	'@wordpress/edit-post' // Hack to enable APIs by using a core package.
 );


### PR DESCRIPTION
Changed in https://github.com/WordPress/gutenberg/pull/62635

Broke pattern creator, as reported in: https://wordpress.slack.com/archives/C02QB8GMM/p1720180116195859