### PR TITLE
Update order of the sub navigation items

### DIFF
--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
@@ -300,8 +300,13 @@ function add_site_navigation_menus( $menus ) {
 	$statuses = array();
 
 	$menu[] = array(
+		'label' => __( 'New pattern', 'wporg-patterns' ),
+		'url' => '/new-pattern/',
+	);
+	$menu[] = array(
 		'label' => __( 'My favorites', 'wporg-patterns' ),
 		'url' => '/favorites/',
+		'className' => 'has-separator'
 	);
 	if ( is_user_logged_in() ) {
 		$menu[] = array(
@@ -309,10 +314,7 @@ function add_site_navigation_menus( $menus ) {
 			'url' => '/my-patterns/',
 		);
 	}
-	$menu[] = array(
-		'label' => __( 'New pattern', 'wporg-patterns' ),
-		'url' => '/new-pattern/',
-	);
+
 
 	$current_status = isset( $wp_query->query['status'] ) ? $wp_query->query['status'] : false;
 	$statuses = array(

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
@@ -306,7 +306,7 @@ function add_site_navigation_menus( $menus ) {
 	$menu[] = array(
 		'label' => __( 'My favorites', 'wporg-patterns' ),
 		'url' => '/favorites/',
-		'className' => 'has-separator'
+		'className' => 'has-separator',
 	);
 	if ( is_user_logged_in() ) {
 		$menu[] = array(
@@ -314,7 +314,6 @@ function add_site_navigation_menus( $menus ) {
 			'url' => '/my-patterns/',
 		);
 	}
-
 
 	$current_status = isset( $wp_query->query['status'] ) ? $wp_query->query['status'] : false;
 	$statuses = array(


### PR DESCRIPTION
Following this [commit on learn](https://github.com/WordPress/Learn/commit/9661a4e67d21a73c1848145c0d5fe364f820b3af) and the theme directory, this PR updates the "my" links to occur after the separator.

### Screenshots

| Current | Proposed Logged out | Proposed Logged in  |
|--------|--------|--------|
| <img width="389" alt="Screenshot 2024-07-15 at 2 29 25 PM" src="https://github.com/user-attachments/assets/a677fccd-8016-4387-bfc7-841cf18273df"> | <img width="277" alt="Screenshot 2024-07-15 at 2 27 47 PM" src="https://github.com/user-attachments/assets/95d865fb-b06c-484b-bec9-3749054dfb16"> | <img width="405" alt="Screenshot 2024-07-15 at 2 27 34 PM" src="https://github.com/user-attachments/assets/81ebc4f8-1a51-4b51-8da7-9f30c9743cee"> | 


