### PR TITLE
Patterns API: Omit the "featured" category in the REST API

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -293,8 +293,10 @@ function register_rest_fields() {
 		array(
 			'get_callback' => function() {
 				$slugs = wp_list_pluck( wp_get_object_terms( get_the_ID(), 'wporg-pattern-category' ), 'slug' );
+				$slugs = array_map( 'sanitize_title', $slugs );
+				$slugs = array_diff( $slugs, [ 'featured' ] );
 
-				return array_map( 'sanitize_title', $slugs );
+				return $slugs;
 			},
 
 			'schema' => array(


### PR DESCRIPTION
This removes the "featured" category from the API response, so that patterns remotely loaded from the pattern directory will never be included in the "Featured" section of local WordPress sites. This breaks the connection between the [Pattern Directory "Featured" category](https://wordpress.org/patterns/categories/featured/) & the "Featured" section of the pattern inserter. Patterns in the featured category on the Pattern Directory will still be sent to WordPress sites, and they will still appear the other categories they have.

For example, [Simple call to action](https://wordpress.org/patterns/pattern/simple-call-to-action/) has categories "Featured, Buttons", so it will only appear in "Buttons" on local WordPress sites.

Fixes #612.
Props richtabor

### How to test the changes in this Pull Request:

1. View an API response `/wp-json/wp/v2/wporg-pattern/`
2. None of the patterns should have "featured" in `category_slugs`

For easier testing, find the ID for "featured" and use that for the API request, `/wp-json/wp/v2/wporg-pattern/?pattern-categories=CAT_ID` or use slugs for individual patterns, `/wp-json/wp/v2/wporg-pattern/?slug=offset-images-with-descriptions`.

There should be no change for non-featured patterns.
