### PR TITLE
Navigation: Add "Log in" link to local nav

### DIFF
--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
@@ -358,6 +358,13 @@ function add_site_navigation_menus( $menus ) {
 			'label' => __( 'My patterns', 'wporg-patterns' ),
 			'url' => '/my-patterns/',
 		);
+	} else {
+		global $wp;
+		$redirect_url = home_url( $wp->request );
+		$menu[] = array(
+			'label' => __( 'Log in', 'wporg-patterns' ),
+			'url' => wp_login_url( $redirect_url ),
+		);
 	}
 
 	$current_status = isset( $wp_query->query['status'] ) ? $wp_query->query['status'] : false;


### PR DESCRIPTION
This updates the Pattern Directory to include the "Log in" link in the local navigation across the site. The link only appears when you're logged out, once logged in, you can manage your account/login status in the admin bar. Once logged in, the "My patterns" link replaces the "Log in" link.

This site already has no admin bar when logged out.

See https://github.com/WordPress/wporg-mu-plugins/issues/647

### Screenshots

| Logged out | Logged in |
|--------|-------|
| ![Screen Shot 2024-09-10 at 15 44 32](https://github.com/user-attachments/assets/38c0e363-1253-442d-b9ce-e670de4fe4ef) | ![Screen Shot 2024-09-10 at 15 46 22](https://github.com/user-attachments/assets/f8ab3f1f-1c28-42fe-aa2f-ad48aa36f591) |

### How to test the changes in this Pull Request:

1. Be logged out
2. There should be a "log in" link
3. Clicking it and signing in should redirect you back to the page you were just on
4. The "log in" link should not appear
5. You should see the admin bar

cc @WordPress/meta-design 