### PR TITLE
Patterns API: Fix the `category_slugs` format for featured patterns

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -295,6 +295,7 @@ function register_rest_fields() {
 				$slugs = wp_list_pluck( wp_get_object_terms( get_the_ID(), 'wporg-pattern-category' ), 'slug' );
 				$slugs = array_map( 'sanitize_title', $slugs );
 				$slugs = array_diff( $slugs, [ 'featured' ] );
+				$slugs = array_values( $slugs );
 
 				return $slugs;
 			},


### PR DESCRIPTION
This fixes a regression caused via https://github.com/WordPress/pattern-directory/pull/704 that returns `category_slugs` as an object instead of an array for patterns that has the `featured` category.

This is breaking the Patterns tab in the block editor for all WP sites.

The modified array returned by `array_diff()` can have non-consecutive indexes, causing it to be JSON-encoded as an object rather than array which is the expected format. Applying `array_values()` to the response fixes it.

1. View the response for https://api.wordpress.org/patterns/1.0/?page=1&per_page=100&order=desc&orderby=date&locale=en_US&wp-version=6.6.1&pattern-keywords=11
2. Lookup the pattern with `"id": 199` 
3. The value for its `"category_slugs"` attribute must be an array and not an object
