### PR TITLE
Pattern directory: Add pattern endpoint test matching schema

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/endpoint-wporg-pattern-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/endpoint-wporg-pattern-test.php
@@ -42,7 +42,12 @@ class Endpoint_Wporg_Pattern_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify the pattern response matches the schema.
+	 * Verify the pattern response matches the schema, plus strict type checking
+	 * for the array values.
+	 *
+	 * `rest_validate_value_from_schema` will check most values, but it also
+	 * "normalizes" array values to associative arrays, which does not happen
+	 * in practice, so we need to manually test those values.
 	 */
 	public function test_pattern_directory_api() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/wporg-pattern/' . self::$pattern_id );
@@ -58,5 +63,12 @@ class Endpoint_Wporg_Pattern_Test extends WP_UnitTestCase {
 
 		$result = rest_validate_value_from_schema( $pattern, $schema );
 		$this->assertTrue( $result );
+
+		// Pattern content should always exist.
+		$this->assertNotEmpty( $pattern['pattern_content'] );
+
+		// Check that these arrays are sequential, not associative arrays.
+		$this->assertTrue( array_is_list( $pattern['category_slugs'] ) );
+		$this->assertTrue( array_is_list( $pattern['meta']['wpop_block_types'] ) );
 	}
 }

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/endpoint-wporg-pattern-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/endpoint-wporg-pattern-test.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Test the Block Pattern API endpoint.
+ */
+
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE };
+
+/**
+ * Test pattern API.
+ *
+ * @group rest-api
+ */
+class Endpoint_Wporg_Pattern_Test extends WP_UnitTestCase {
+	protected static $pattern_id;
+
+	/**
+	 * Setup fixtures that are shared across all tests.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		$term_ids = [];
+		foreach ( [ 'call-to-action', 'banner', 'featured', 'services' ] as $term_name ) {
+			$term_ids[] = $factory->term->create(
+				[
+					'taxonomy' => 'wporg-pattern-category',
+					'name' => $term_name,
+				]
+			);
+		}
+		self::$pattern_id = $factory->post->create(
+			array(
+				'post_title' => 'Services call to action with image on left',
+				'post_type' => POST_TYPE,
+				'post_content' => '<!-- wp:heading --><h2 class="wp-block-heading">Guiding your business through the project</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Experience the fusion of imagination and expertise with Études—the catalyst for architectural transformations that enrich the world around us.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p><a>Our services</a></p><!-- /wp:paragraph -->',
+				'meta_input' => [
+					'wpop_contains_block_types' => 'core/heading,core/paragraph',
+					'wpop_viewport_width' => 1400,
+					'wpop_description' => 'An image, title, paragraph and a CTA button to describe services.',
+				],
+			)
+		);
+		$factory->term->add_post_terms( self::$pattern_id, $term_ids, 'wporg-pattern-category' );
+	}
+
+	/**
+	 * Verify the pattern response matches the schema.
+	 */
+	public function test_pattern_directory_api() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$response = rest_do_request( $request );
+		$this->assertFalse( $response->is_error() );
+		$pattern = $response->get_data();
+
+		// New request to get schema, so that `rest_api_init` is called (to register the custom endpoint fields).
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$response = rest_do_request( $request );
+		$schema = $response->get_data();
+		$schema = $schema['schema'];
+
+		$result = rest_validate_value_from_schema( $pattern, $schema );
+		$this->assertTrue( $result );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/endpoint-wporg-pattern-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/endpoint-wporg-pattern-test.php
@@ -65,10 +65,10 @@ class Endpoint_Wporg_Pattern_Test extends WP_UnitTestCase {
 		$this->assertTrue( $result );
 
 		// Pattern content should always exist.
-		$this->assertNotEmpty( $pattern['pattern_content'] );
+		$this->assertNotEmpty( $pattern['pattern_content'], 'Pattern content is empty.' );
 
 		// Check that these arrays are sequential, not associative arrays.
-		$this->assertTrue( array_is_list( $pattern['category_slugs'] ) );
-		$this->assertTrue( array_is_list( $pattern['meta']['wpop_block_types'] ) );
+		$this->assertTrue( array_is_list( $pattern['category_slugs'] ), 'Category slugs is not a sequential array.' );
+		$this->assertTrue( array_is_list( $pattern['meta']['wpop_block_types'] ), 'Block types is not a sequential array.' );
 	}
 }


### PR DESCRIPTION
We recently had an issue causing errors on client WP sites because the Patterns API returned malformed category data — see #711. We did not have any tests to catch that change. This adds a very simple test to check the pattern API response against its own schema. This is not a perfect check (since the validation normalizes arrays), so I've also added some extra checks to make sure the pattern content is never empty, and the two [array values used in core](https://github.com/WordPress/WordPress/blob/master/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php#L191-L200) (`category_slugs` & `meta.wpop_block_types`) are sequential arrays.

See related tests in https://github.com/WordPress/wordpress.org/pull/393

### How to test the changes in this Pull Request:

1. Start up the wp-env
2. Run `yarn test:php` or `yarn test:php -- --group rest-api` for just this test
3. It should pass ✅ 
4. Comment out the `array_values` fix in [plugins/pattern-directory/includes/pattern-post-type.php](https://github.com/WordPress/pattern-directory/blob/a47c46cbbcc18731da5963bb3f8ccd9f38b6a4be/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php#L298)
5. Run the test again
6. It should fail ❌ 
