### PR TITLE
Use core default value for viewport width

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -178,7 +178,7 @@ function register_post_type_data() {
 			'type'              => 'number',
 			'description'       => 'The width of the pattern in the block inserter.',
 			'single'            => true,
-			'default'           => 800,
+			'default'           => 1200,
 			'sanitize_callback' => 'absint',
 			'auth_callback'     => __NAMESPACE__ . '\can_edit_this_pattern',
 			'show_in_rest'      => array(


### PR DESCRIPTION
Fixes #683 by adjusting the previous `800` value for the default viewport width to `1200`, which matches [the default value in core](https://github.com/WordPress/gutenberg/blob/006107338d284b9d88f3ecf901dad4e41eca86dc/packages/block-editor/src/components/block-preview/index.js#L27). This way patterns render the same, regardless of source. 

props @ryelle 

