### PR TITLE
Fix 'core/interface' registration error

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -182,7 +182,6 @@ function pattern_creator_init() {
 		'after'
 	);
 
-	wp_enqueue_script( 'wp-edit-site' );
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-site' );
 	wp_enqueue_style( 'wp-format-library' );

--- a/public_html/wp-content/plugins/pattern-creator/webpack.config.js
+++ b/public_html/wp-content/plugins/pattern-creator/webpack.config.js
@@ -1,4 +1,5 @@
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 
 const config = {
 	...defaultConfig,
@@ -7,6 +8,25 @@ const config = {
 		library: [ 'wp', 'patternCreator' ],
 		libraryTarget: 'window',
 	},
+
+	plugins: [
+		...defaultConfig.plugins.filter(
+			( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
+		),
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternal( request ) {
+				if (
+					request === '@wordpress/editor' ||
+					request === '@wordpress/icons' ||
+					request === '@wordpress/interface' ||
+					request === '@wordpress/fields' ||
+					request === '@wordpress/dataviews'
+				) {
+					return false;
+				}
+			},
+		} ),
+	],
 };
 
 module.exports = config;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->

Fixes #723.

This PR fixes the `core/interface` registration error, but it doesn't fix the other errors mentioned in the issue. 

This error happens because `core/interface` is a package included in the bundle and not available on the document object. 
Currently, on the `/new-pattern/` route are loaded the `site-editor` scripts and the bundle of the pattern creator editor.
Both of them, under the hood, load the `@wordpress/editor` package and this causes that the `core/interface` store is registered twice. 

With this PR, the `@wordpress/editor` is bundled in the pattern creator editor and the `site-editor` scripts aren't loaded. In this way, the `core/interface` store is registered once. 


At the same time, while this PR can be a good temporary solution, I think that we need to explore https://github.com/WordPress/pattern-directory/pull/719. As mentioned in #719, this will reduce the maintenance cost and fix other issues too.


<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Visit `/new-pattern/`
2. Open the dev tools.
3. Ensure that `Store "core/interface" is already registered.` isn't visible.

<!-- If you can, add the appropriate [Component] label(s). -->
