### PR TITLE
Remove import statement of non-existent ToolSelector component

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/header/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/header/index.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { ToolSelector } from '@wordpress/block-editor';
 import { Button, VisuallyHidden } from '@wordpress/components';
 import { Icon, arrowLeft, listView, plus } from '@wordpress/icons';
 import { PinnedItems } from '@wordpress/interface';
@@ -89,7 +88,6 @@ export default function Header() {
 					/>
 					{ isLargeViewport && (
 						<>
-							<ToolSelector />
 							<UndoButton />
 							<RedoButton />
 							<Button


### PR DESCRIPTION
Fixes #729
It was also reported here: https://core.trac.wordpress.org/ticket/64309

Props [amitdholiya](https://profiles.wordpress.org/amitdholiya/), [paulkevan](https://profiles.wordpress.org/paulkevan/), [noruzzaman](https://profiles.wordpress.org/noruzzaman/)

Gutenberg had the `ToolSelector` component like this to switch modes:

<img width="390" height="315" alt="487045269-041bf935-8a55-48ee-a78c-c504cc6360ee" src="https://github.com/user-attachments/assets/7681eaf3-81e9-4ff8-9ac1-2495d9eed06a" />

Later, the concept of design/light mode was abolished, so this component was removed accordingly in https://github.com/WordPress/gutenberg/pull/72193.

The editor should now work correctly without this component.

### How to test the changes in this Pull Request:

1. Launch a local environment
2. Access http://localhost:8888/new-pattern/
3. There shouldn't be any errors.