### PR TITLE
Fix block crash in pattern creator

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/index.js
@@ -4,6 +4,7 @@
 import { dispatch } from '@wordpress/data';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { render, unmountComponentAtNode } from '@wordpress/element';
+import { removeFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -45,3 +46,8 @@ export function initialize( id, settings ) {
 	registerCoreBlocks();
 	reinitializeEditor( target, settings );
 }
+
+// The hook for the pattern editor somehow triggers a critical error.
+// The pattern editor cannot use the pattern directory in the first place,
+// so disables the filter itself.
+removeFilter( 'editor.BlockEdit', 'core/editor/with-pattern-override-controls' );


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/64309#comment:3

Props [@amitdholiya](https://profiles.wordpress.org/amitdholiya/)

I'm not sure how long this issue has been occurring, but it seems to cause blocks to crash when adding or selecting them in the pattern creator.

After investigating, I found that [the hook for pattern overrides](https://github.com/WordPress/gutenberg/blob/8f13b56c3219435467d32aa3a33bc9cd0fddaef9/packages/editor/src/hooks/pattern-overrides.js#L118-L122) is affecting this. The underlying issue is likely on the Gutenberg side, but since the pattern editor isn't available in the pattern creator in the first place, let's disable the hook itself for now.

### Screenshots

<img width="1118" height="631" alt="image" src="https://github.com/user-attachments/assets/ed7eeae8-e5dc-45dc-8dd5-0f8164108f79" />

### How to test the changes in this Pull Request:

- Set up and launch this repo locally.
- Open the pattern creator.
- Click the empty Paragraph block.
- Confirm that no errors should occur.
