### PR TITLE
Fix block styles missing in pattern creator editor canvas

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -201,6 +201,33 @@ function inject_editor_template( $template ) {
 add_filter( 'template_include', __NAMESPACE__ . '\inject_editor_template' );
 
 /**
+ * Enqueue block frontend styles for the editor canvas.
+ *
+ * _wp_get_iframed_editor_assets() fires enqueue_block_assets with an isolated WP_Styles
+ * instance, then captures its output into __unstableResolvedAssets. It enqueues
+ * editor_style_handles but not style_handles, so block frontend styles (style.min.css)
+ * are absent from the canvas — breaking blocks like Cover that need them for layout/background.
+ *
+ * Mirroring the fix proposed for WordPress core (_wp_get_iframed_editor_assets should loop
+ * over style_handles too), we enqueue them here so they are captured in the same window.
+ */
+function enqueue_block_frontend_styles_for_canvas() {
+	if ( ! should_load_creator() ) {
+		return;
+	}
+
+	$block_registry = \WP_Block_Type_Registry::get_instance();
+	foreach ( $block_registry->get_all_registered() as $block_type ) {
+		if ( isset( $block_type->style_handles ) && is_array( $block_type->style_handles ) ) {
+			foreach ( $block_type->style_handles as $style_handle ) {
+				wp_enqueue_style( $style_handle );
+			}
+		}
+	}
+}
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\enqueue_block_frontend_styles_for_canvas' );
+
+/**
  * Add a rewrite rule to handle editing a pattern.
  */
 function rewrite_for_pattern_editing() {

--- a/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
@@ -67,11 +67,11 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 				</div>
 				<Iframe
 					style={ resizedCanvasStyles }
-					head={ <EditorStyles styles={ settings.styles } /> }
 					ref={ ref }
 					contentRef={ mergedRefs }
 					name="editor-canvas"
 				>
+					<EditorStyles styles={ settings.styles } />
 					<LayoutStyle
 						selector=".pattern-block-editor__block-list.is-root-container"
 						layout={ { ...layout, type: 'constrained' } }

--- a/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/block-editor/index.js
@@ -65,12 +65,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 				<div className="pattern-visual-editor__post-title-wrapper">
 					<PostTitle />
 				</div>
-				<Iframe
-					style={ resizedCanvasStyles }
-					ref={ ref }
-					contentRef={ mergedRefs }
-					name="editor-canvas"
-				>
+				<Iframe style={ resizedCanvasStyles } ref={ ref } contentRef={ mergedRefs } name="editor-canvas">
 					<EditorStyles styles={ settings.styles } />
 					<LayoutStyle
 						selector=".pattern-block-editor__block-list.is-root-container"


### PR DESCRIPTION
## Summary

- Enqueues block frontend style_handles via enqueue_block_assets so they are captured by _wp_get_iframed_editor_assets, which only picks up editor_style_handles and misses frontend styles needed by blocks like Cover for layout/background rendering.
- Moves EditorStyles from the head prop of Iframe to inside the component as a child, so styles are injected within the canvas iframe.

Fixes #737

## Test plan

- [ ] Open the pattern creator and insert a Cover block — verify background/layout styles render correctly in the editor canvas.
- [ ] Confirm no regressions in other blocks' styles inside the canvas.
- [ ] Verify the editor still loads without JS errors.
<img width="1314" height="905" alt="Screenshot 2026-04-06 at 14 52 37" src="https://github.com/user-attachments/assets/c2773223-eec8-4ffa-8b07-6abb0127d282" />

<img width="1081" height="892" alt="Screenshot 2026-04-06 at 14 52 41" src="https://github.com/user-attachments/assets/5a6868f1-4b88-4bde-9a94-53c2624e0312" />

Generated with [Claude Code](https://claude.com/claude-code)