### PR TITLE
Fix unlist button and add reasons to email

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -9,10 +9,43 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\{ POST_TYPE a
 defined( 'WPINC' ) || die();
 
 /**
+ * The post meta key holding the moderator's message to the author, which is
+ * included in the "pattern unlisted" email.
+ */
+const UNLISTED_DETAIL_META = '_wporg_unlist_reason_detail';
+
+/**
  * Actions and filters.
  */
 add_action( 'wp_after_insert_post', __NAMESPACE__ . '\trigger_notifications', 20, 4 );
 add_action( 'wporg_unlist_pattern', __NAMESPACE__ . '\notify_pattern_flagged' );
+add_action( 'init', __NAMESPACE__ . '\register_unlisted_meta' );
+
+/**
+ * Register the post meta used to store the moderator's message to the author.
+ *
+ * Editable by anyone who can edit the pattern (i.e. moderators), so it can be
+ * set from the Unlist modal in the block editor and read back when sending the
+ * "pattern unlisted" email.
+ *
+ * @return void
+ */
+function register_unlisted_meta() {
+	register_post_meta(
+		PATTERN,
+		UNLISTED_DETAIL_META,
+		array(
+			'type'              => 'string',
+			'description'       => 'A message from the moderator, included in the email sent to the author when a pattern is unlisted.',
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'sanitize_textarea_field',
+			'auth_callback'     => function( $allowed, $meta_key, $object_id ) {
+				return current_user_can( 'edit_post', $object_id );
+			},
+		)
+	);
+}
 
 /**
  * Fire off relevant notification when a post is finished updating.
@@ -209,6 +242,12 @@ function notify_pattern_unlisted( $post ) {
 
 	if ( ! $reason ) {
 		$reason = get_default_reason_description();
+	}
+
+	// Append the moderator's message to the author, if one was provided.
+	$detail = get_post_meta( $post->ID, UNLISTED_DETAIL_META, true );
+	if ( $detail ) {
+		$reason .= "\n\n" . $detail;
 	}
 
 	$subject = esc_html__( 'Pattern unlisted', 'wporg-patterns' );

--- a/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/details.js
+++ b/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/details.js
@@ -2,15 +2,17 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-// `PluginDocumentSettingPanel` moved from `@wordpress/edit-post` to `@wordpress/editor`.
-// Import from both and use whichever the running WordPress version provides.
-import { PluginDocumentSettingPanel as PluginDocumentSettingPanelFromEditor } from '@wordpress/editor';
-import { PluginDocumentSettingPanel as PluginDocumentSettingPanelFromEditPost } from '@wordpress/edit-post';
-const PluginDocumentSettingPanel =
-	PluginDocumentSettingPanelFromEditor || PluginDocumentSettingPanelFromEditPost;
 import { ComboboxControl, FormTokenField, TextControl, TextareaControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
+// `PluginDocumentSettingPanel` moved from `@wordpress/edit-post` to `@wordpress/editor`.
+// Import from both and use whichever the running WordPress version provides.
+import {
+	PluginDocumentSettingPanel as PluginDocumentSettingPanelFromEditor,
+	store as editorStore,
+} from '@wordpress/editor';
+import { PluginDocumentSettingPanel as PluginDocumentSettingPanelFromEditPost } from '@wordpress/edit-post';
+
+const PluginDocumentSettingPanel = PluginDocumentSettingPanelFromEditor || PluginDocumentSettingPanelFromEditPost;
 
 const KEYWORD_SLUG = 'wpop_keywords';
 const DESCRIPTION_SLUG = 'wpop_description';

--- a/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/details.js
+++ b/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/details.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+// `PluginDocumentSettingPanel` moved from `@wordpress/edit-post` to `@wordpress/editor`.
+// Import from both and use whichever the running WordPress version provides.
+import { PluginDocumentSettingPanel as PluginDocumentSettingPanelFromEditor } from '@wordpress/editor';
+import { PluginDocumentSettingPanel as PluginDocumentSettingPanelFromEditPost } from '@wordpress/edit-post';
+const PluginDocumentSettingPanel =
+	PluginDocumentSettingPanelFromEditor || PluginDocumentSettingPanelFromEditPost;
 import { ComboboxControl, FormTokenField, TextControl, TextareaControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';

--- a/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/index.js
+++ b/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/index.js
@@ -2,13 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 // `PluginPostStatusInfo` moved from `@wordpress/edit-post` to `@wordpress/editor`.
 // Import from both and use whichever the running WordPress version provides.
-import { PluginPostStatusInfo as PluginPostStatusInfoFromEditor } from '@wordpress/editor';
+import { PluginPostStatusInfo as PluginPostStatusInfoFromEditor, store as editorStore } from '@wordpress/editor';
 import { PluginPostStatusInfo as PluginPostStatusInfoFromEditPost } from '@wordpress/edit-post';
-const PluginPostStatusInfo = PluginPostStatusInfoFromEditor || PluginPostStatusInfoFromEditPost;
-import { Button } from '@wordpress/components';
-import { store as editorStore } from '@wordpress/editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
@@ -18,6 +16,8 @@ import { useState } from '@wordpress/element';
 import { UNLISTED_STATUS } from '../settings';
 import UnlistModal from './modal';
 import './unlist.scss';
+
+const PluginPostStatusInfo = PluginPostStatusInfoFromEditor || PluginPostStatusInfoFromEditPost;
 
 export const UnlistButton = () => {
 	const status = useSelect( ( select ) => {

--- a/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/index.js
+++ b/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/index.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PluginPostStatusInfo } from '@wordpress/edit-post';
+// `PluginPostStatusInfo` moved from `@wordpress/edit-post` to `@wordpress/editor`.
+// Import from both and use whichever the running WordPress version provides.
+import { PluginPostStatusInfo as PluginPostStatusInfoFromEditor } from '@wordpress/editor';
+import { PluginPostStatusInfo as PluginPostStatusInfoFromEditPost } from '@wordpress/edit-post';
+const PluginPostStatusInfo = PluginPostStatusInfoFromEditor || PluginPostStatusInfoFromEditPost;
 import { Button } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -23,10 +27,11 @@ export const UnlistButton = () => {
 	const { editPost, savePost } = useDispatch( editorStore );
 	const [ showModal, setShowModal ] = useState( false );
 
-	const onSubmit = ( reasonId ) => {
+	const onSubmit = ( reasonId, details = '' ) => {
 		editPost( {
 			status: UNLISTED_STATUS,
 			'wporg-pattern-flag-reason': [ reasonId ],
+			meta: { _wporg_unlist_reason_detail: details },
 		} );
 		savePost();
 	};

--- a/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/modal.js
+++ b/public_html/wp-content/plugins/pattern-directory/src/pattern-post-type/unlist-button/modal.js
@@ -74,7 +74,7 @@ const UnlistModal = ( { onClose, onSubmit } ) => {
 	}, [] );
 
 	const submittedText = __(
-		'The pattern has been unlisted, and your internal note has been saved.',
+		'The pattern has been unlisted, and the author has been notified by email.',
 		'wporg-patterns'
 	);
 
@@ -101,7 +101,7 @@ const UnlistModal = ( { onClose, onSubmit } ) => {
 			note: details ? `UNLISTED: ${ reason.label } — ${ details }` : `UNLISTED: ${ reason.label }`,
 			onSuccess: () => {
 				if ( 'function' === typeof onSubmit ) {
-					onSubmit( selectedOption );
+					onSubmit( selectedOption, details );
 				}
 				dispatch( { status: 'NOTE_RECIEVED' } );
 				speak( submittedText );
@@ -155,9 +155,9 @@ const UnlistModal = ( { onClose, onSubmit } ) => {
 							<Spinner />
 						) }
 						<TextareaControl
-							label={ __( 'Please provide internal details', 'wporg-patterns' ) }
+							label={ __( 'Message to the pattern author', 'wporg-patterns' ) }
 							help={ __(
-								'This note will only be seen by other admins and moderators.',
+								'This message will be emailed to the pattern author, along with the reason selected above.',
 								'wporg-patterns'
 							) }
 							value={ details }


### PR DESCRIPTION
## Summary

The Unlist button and its modal were not showing up on production. The editor plugin imports `PluginPostStatusInfo` and `PluginDocumentSettingPanel` from `@wordpress/edit-post`, but those were moved to `@wordpress/editor` in newer WordPress. On versions where the old location no longer provides them, the import is empty and the whole pattern editor plugin fails to render, so the button, the modal, and the Pattern Details panel all disappear at once. We now import from both packages and use whichever the running version provides, so it works on old and new WordPress.

While fixing this, we also made the modal's textarea actually useful to the author. Before, that field was saved as an internal note that only moderators could see, even though moderators often want to tell the author what is wrong so they can fix it and resubmit. Now the text is included in the unlisted email that goes to the author. We renamed the field to "Message to the pattern author" so it is clear the content will be sent to them.


## How to test

1. Open a pattern in the editor and confirm the Unlist button appears in the Status and visibility panel.
2. Click Unlist, pick a reason, and write a message in the textarea.
3. Submit and confirm the pattern is unlisted and the author receives an email containing both the reason and your message.


<img width="1512" height="982" alt="Screenshot 2026-06-04 at 15 43 54" src="https://github.com/user-attachments/assets/040e42e3-0a94-44b5-bce1-6797a51d80e8" />


This was working locally before my fix, and I don't know if I can reproduce the failure locally with the environment from this repo, so this fix is done a bit in the dark.