### PR TITLE
Pattern creator: stop block styles leaking into the editor's outer page

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -210,9 +210,23 @@ add_filter( 'template_include', __NAMESPACE__ . '\inject_editor_template' );
  *
  * Mirroring the fix proposed for WordPress core (_wp_get_iframed_editor_assets should loop
  * over style_handles too), we enqueue them here so they are captured in the same window.
+ *
+ * enqueue_block_assets also fires on the outer creator page's normal front-end render.
+ * Enqueuing there would print every block's frontend stylesheet into the outer <head>,
+ * where Gutenberg's iframe onLoad clones each one into the canvas and logs a
+ * "<handle> was added to the iframe incorrectly" warning. The outer page renders no
+ * blocks, so those styles are pure leakage. _wp_get_iframed_editor_assets() brackets its
+ * enqueue_block_assets dispatch with a `should_load_block_editor_scripts_and_styles` =>
+ * __return_false filter; its presence is what distinguishes the capture from the outer
+ * render, so we only enqueue when that filter is active.
  */
 function enqueue_block_frontend_styles_for_canvas() {
 	if ( ! should_load_creator() ) {
+		return;
+	}
+
+	// Only run inside the iframed-editor asset capture, not on the outer page.
+	if ( false === has_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Problem

The pattern creator logs a cluster of console warnings in the editor canvas:

```
<handle> was added to the iframe incorrectly. Please use block.json or enqueue_block_assets to add styles to the iframe.
```

…for `wporg-pattern-preview-style`, `wporg-post-status-style`, `wporg-copy-button-style`, `wporg-delete-button-style`, plus dependency block styles surfaced through the same path (`wporg-ratings-*`, `wporg-site-breadcrumbs`, `wporg-link-wrapper`, `wporg-language-suggest`, `jetpack-sharing-buttons`, `wporg-global-header-footer`).

## Root cause

`enqueue_block_frontend_styles_for_canvas()` (added in #740) hooks `enqueue_block_assets` and enqueues **every registered block's** frontend style so they're captured into the iframe canvas — which core's `_wp_get_iframed_editor_assets()` doesn't do for `style_handles`, only `editor_style_handles`.

But `enqueue_block_assets` fires twice on a creator request:

1. **During the iframe-asset capture** — wanted; this is how the styles reach the canvas.
2. **On the outer creator page's normal `wp_head()`** — unwanted. The outer shell renders no blocks, yet every block stylesheet was printed into `<head>`. Gutenberg's iframe `onLoad` → `getCompatibilityStyles()` then clones each head style whose id doesn't start with `wp-` and whose CSS contains `.wp-block` into the canvas, logging one warning per style. (That `wp-` exemption is why only `wporg-*`/`jetpack-*` handles appear, and why dependency block names showed up — our loop is what enqueued them on the outer page.)

## Fix

Gate the enqueue to the capture context only. Core brackets its capture dispatch with `add_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' )`, so its presence distinguishes the capture from the outer render:

```php
if ( false === has_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' ) ) {
    return;
}
```

## Verification (wp-env)

Integration-tested both branches of the gate against a real registered block style:

| Context | Pre-fix | Post-fix |
|---|---|---|
| Outer `<head>` (warning source) | style leaks in → warning | not enqueued → no warning |
| Iframe capture (canvas styles) | enqueued ✓ | still enqueued ✓ |

So the warnings are eliminated without regressing #740's canvas-styles fix.

## Not addressed (not this repo)

The other console messages on the page originate from dependencies, not our code: the JQMIGRATE notice (jQuery Migrate), the `'root','media'` `canUser` deprecation (`@wordpress/core-data`), and the `__unstableUseRichText` deprecation (`@wordpress/block-editor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)