### PR TITLE
Increase submission modal title contrast

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/style.scss
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/submission-modal/style.scss
@@ -72,7 +72,7 @@ $modal-height: 375px;
 	line-height: normal;
 }
 
-.submission-modal__title-sidebar {
+h3.submission-modal__title-sidebar {
 	margin: $grid-unit-10 0 0 0;
 	color: $white;
 	font-size: 1.5rem;


### PR DESCRIPTION
Fixes #752.

Props bor0, akeda

### How to test the changes in this Pull Request:

1. Go to https://wordpress.org/patterns/new-pattern/
2. Add at least one block
3. Click Submit to get the modal show

Before:

<img width="629" height="412" alt="Screenshot 2026-07-02 at 11 10 18" src="https://github.com/user-attachments/assets/599fc772-0296-4538-a4ca-248fb34388d0" />

After:

<img width="976" height="1195" alt="Screenshot 2026-07-02 at 11 55 54" src="https://github.com/user-attachments/assets/eb64f9a2-62a7-4add-9a68-bc16f028e7e7" />