### PR TITLE
Show a status-aware empty state on My Patterns

### DIFF
--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/_grid-mine.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/_grid-mine.php
@@ -6,6 +6,13 @@
  * Inserter: no
  */
 
+global $wp_query;
+
+// When a status filter is applied, an empty result only means the filter
+// matched nothing, not that the user has never created a pattern. This reads
+// the same query var that filters the list in modify_query_loop_block_query_vars().
+$is_status_filtered = ! empty( $wp_query->query['status'] );
+
 ?>
 <!-- wp:query {"align":"wide","queryId":0,"query":{"inherit":false,"postType":"wporg-pattern"},"className":"wporg-my-patterns","layout":{"type":"default"}} -->
 <div class="wp-block-query alignwide wporg-my-patterns">
@@ -68,6 +75,19 @@
 	<!-- /wp:spacer -->
 
 	<!-- wp:query-no-results -->
+		<?php if ( $is_status_filtered ) : ?>
+		<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0"}}}} -->
+		<p style="margin-top:0"><?php esc_html_e( 'You have no patterns with this status.', 'wporg-patterns' ); ?></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:buttons -->
+		<div class="wp-block-buttons">
+			<!-- wp:button -->
+			<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( get_permalink() ); ?>"><?php esc_html_e( 'View all your patterns', 'wporg-patterns' ); ?></a></div>
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
+		<?php else : ?>
 		<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0"}}}} -->
 		<p style="margin-top:0"><?php esc_html_e( 'Anyone can create and share patterns using the familiar block editor. Design helpful starting points for yourself and any WordPress site.', 'wporg-patterns' ); ?></p>
 		<!-- /wp:paragraph -->
@@ -79,6 +99,7 @@
 			<!-- /wp:button -->
 		</div>
 		<!-- /wp:buttons -->
+		<?php endif; ?>
 
 		<!-- wp:spacer {"height":"var:preset|spacing|40","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
 		<div style="margin-top:0;margin-bottom:0;height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
Fixes #745.

## Problem

On the My Patterns page, the empty state always uses first-time-user copy. If you filter by a status and have nothing in that status, the page says "Create your first pattern" even when you already have patterns in other statuses.

This happens because the `wp:query-no-results` block in `_grid-mine.php` fires whenever the current query returns nothing. It has no way to know that the result is empty only because a status filter is applied.

## Solution

Check whether a status filter is active, and show different copy when it is.

The check reads `$wp_query->query['status']`, which is the same query var that `modify_query_loop_block_query_vars()` in `functions.php` uses to filter the list. Reading the same source keeps the message in sync with whatever caused the empty result.

Behaviour after the change:

- No status filter and no patterns: unchanged, still shows "Create your first pattern".
- Status filter applied and nothing matches: shows "You have no patterns with this status." with a button back to the unfiltered view.

The button points to `get_permalink()`, which is where the existing "All" status link already points.

## Testing

Tested locally with wp-env, using a user with 2 published patterns, 1 pending, and 0 drafts.

Before the change, `status=draft` showed "Create your first pattern".
After the change, it shows the new message. With no filter the output is unchanged.

Also checked:

- The block markup parses correctly, and the block tree is identical to before when no filter is applied.
- `status` values of empty, pending, publish, and an array all behave correctly.
- No PHP notice when `$wp_query` is not set up, for example in REST or CLI contexts. It falls back to the original copy.
- `php -l` and `composer run lint` are both clean.

## Notes

I could not load `/my-patterns/` over HTTP locally, because that page and its template come from WordPress.org rather than this repo. So the visual result is not verified. I did confirm the original behaviour on the live site when reporting #745. A visual check during review would be helpful.

Separately, line 51 of the same file has a `wp:button` block that is closed with `<!-- /wp:paragraph -->`. It is pre-existing and I have left it alone to keep this change focused. Happy to open a separate issue for it.
