### PR TITLE
Update WordPress Coding Standards to 3.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,11 +76,11 @@
 		"wporg/wporg-mu-plugins": "dev-build"
 	},
 	"require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"phpunit/phpunit": "^9.5",
 		"rmccue/requests": "^1.8.1",
-		"wp-coding-standards/wpcs": "2.*",
+		"wp-coding-standards/wpcs": "^3.4",
 		"wp-phpunit/wp-phpunit": "~6.0",
 		"wporg/wporg-parent-2021": "dev-build",
 		"yoast/phpunit-polyfills": "^1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6cc3f076541e82842035264fae168138",
+    "content-hash": "8cad40afe3793e43455240cd57b61ed4",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -375,35 +375,38 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -413,17 +416,16 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -443,10 +445,29 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-02-04T12:51:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -962,6 +983,181 @@
                 }
             ],
             "time": "2025-05-12T16:38:37+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T11:13:17+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2418,16 +2614,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.2",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
-                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -2444,11 +2640,6 @@
                 "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -2498,7 +2689,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-06-17T22:17:01+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2552,30 +2743,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2592,6 +2791,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -2599,7 +2799,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-07-27T11:53:23+00:00"
         },
         {
             "name": "wp-phpunit/wp-phpunit",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -42,9 +42,6 @@
 		<!-- It's often obvious what the placeholder is, so whether or not to include a comment is a judgement call. -->
 		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
 
-		<!-- I know it's a language construct, but it just looks better using the function call syntax. -->
-		<exclude name="PEAR.Files.IncludingFile.BracketsNotRequired" />
-
 		<!-- This requires passing a whitelist of prefixes in order to work, which is not practical for a large and varied codebase. It's also fixes a problem that we're unlikely to cause. -->
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound" />
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound" />
@@ -79,11 +76,17 @@
 		<!-- print_r() is perfectly accepted in some circumstances, like WP_CLI commands. -->
 		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_print_r" />
 
+		<!-- PSR-12's file-header grammar fixes the order of the docblock, namespace and `use` groups, and
+		     forbids interleaving them. This codebase groups its imports by what they import rather than by
+		     kind, and puts the `use` statements directly after the namespace, which is the same preference
+		     recorded below for PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter. New in WPCS 3.0. -->
+		<exclude name="PSR12.Files.FileHeader" />
+
 		<!-- Allow short ternary pattern. -->
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
+		<exclude name="Universal.Operators.DisallowShortTernary.Found" />
 
 		<!-- Allow short array syntax. -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
 	</rule>
 
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
@@ -93,7 +96,7 @@
 
 	<rule ref="WordPress.NamingConventions.ValidVariableName">
 		<properties>
-			<property name="customPropertiesWhitelist" type="array">
+			<property name="allowed_custom_properties" type="array">
 				<element value="nodeValue"/>
 				<element value="parentNode"/>
 			</property>
@@ -148,7 +151,16 @@
 	     provided as a comma-delimited list. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="wporg-patterns" />
+			<property name="text_domain" type="array">
+				<element value="wporg-patterns" />
+			</property>
 		</properties>
+	</rule>
+
+	<!-- I know it's a language construct, but it just looks better using the function call syntax.
+	     Silenced here rather than excluded from `WordPress-Core`, because `WordPress-Extra` re-includes
+	     `WordPress-Core` and reinstates it; this must stay after the `WordPress-Extra` rule to win. -->
+	<rule ref="PEAR.Files.IncludingFile.BracketsNotRequired">
+		<severity>0</severity>
 	</rule>
 </ruleset>

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -84,7 +84,7 @@ function pattern_creator_init() {
 	wp_deregister_style( 'wporg-parent-2021-style' );
 	wp_deregister_style( 'global-styles' );
 
-	$dir = dirname( __FILE__ );
+	$dir = __DIR__;
 	$script_asset_path = "$dir/build/index.asset.php";
 	if ( ! file_exists( $script_asset_path ) ) {
 		throw new \Error( 'You need to run `npm run start:creator` or `npm run build:creator` for the Pattern Creator.' );

--- a/public_html/wp-content/plugins/pattern-creator/view/editor.php
+++ b/public_html/wp-content/plugins/pattern-creator/view/editor.php
@@ -6,7 +6,7 @@
 namespace WordPressdotorg\Pattern_Creator;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
 
-add_filter( 'body_class', function( $classes ) {
+add_filter( 'body_class', function ( $classes ) {
 	$classes[] = 'admin-color-modern';
 	return $classes;
 } );

--- a/public_html/wp-content/plugins/pattern-directory/bin/check-spam.php
+++ b/public_html/wp-content/plugins/pattern-directory/bin/check-spam.php
@@ -103,10 +103,8 @@ while ( $query->have_posts() ) {
 				);
 			}
 		}
-	} else {
-		if ( $opts['verbose'] ) {
-			echo "{$pattern->ID}: Not spam.\n"; // phpcs:ignore
-		}
+	} elseif ( $opts['verbose'] ) {
+		echo "{$pattern->ID}: Not spam.\n"; // phpcs:ignore
 	}
 }
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-flags.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-flags.php
@@ -303,10 +303,10 @@ function flag_list_table_views( $views ) {
 	if ( $parent_id ) {
 		$views = array_map(
 			// Add a post_parent parameter to each view's URL.
-			function( $item ) use ( $parent_id ) {
+			function ( $item ) use ( $parent_id ) {
 				return preg_replace_callback(
 					'|href=[\'"]+([^\'"]+)[\'"]+|',
-					function( $matches ) use ( $parent_id ) {
+					function ( $matches ) use ( $parent_id ) {
 						$old_url = wp_kses_decode_entities( $matches[1] );
 						$new_url = add_query_arg( array( 'post_parent' => $parent_id ), $old_url );
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
@@ -9,7 +9,7 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE as PATTE
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\TAX_TYPE as FLAG_REASON;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\PENDING_STATUS;
-use const  WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ UNLISTED_STATUS, SPAM_STATUS };
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ UNLISTED_STATUS, SPAM_STATUS };
 
 defined( 'WPINC' ) || die();
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-settings.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-settings.php
@@ -50,7 +50,7 @@ function admin_init() {
 		'wporg-pattern-default_status',
 		array(
 			'type' => 'string',
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				return in_array( $value, array( 'publish', 'pending' ) ) ? $value : 'publish';
 			},
 			'default' => 'publish',
@@ -73,7 +73,7 @@ function admin_init() {
 		'wporg-pattern-flag_threshold',
 		array(
 			'type' => 'integer',
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				$value = absint( $value );
 
 				if ( $value < 1 || $value > 100 ) {

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-stats.php
@@ -95,7 +95,7 @@ function get_snapshot_meta_data() {
  * @return array
  */
 function get_export_form_inputs() {
-	$date_filter = function( $string ) {
+	$date_filter = function ( $string ) {
 		$success = preg_match( '|([0-9]{4}\-[0-9]{2}\-[0-9]{2})|', $string, $match );
 
 		if ( $success ) {
@@ -230,7 +230,7 @@ function handle_csv_export() {
 	}
 
 	$data = array_map(
-		function( $snapshot ) use ( $schema ) {
+		function ( $snapshot ) use ( $schema ) {
 			$date = get_the_date( 'Y-m-d', $snapshot );
 			$row  = array( $date );
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-export-csv.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-export-csv.php
@@ -88,7 +88,7 @@ class Export_CSV {
 			$name_segments = (array) $name_segments;
 		}
 
-		$name_segments = array_map( function( $segment ) {
+		$name_segments = array_map( function ( $segment ) {
 			$segment = strtolower( $segment );
 			$segment = str_replace( '_', '-', $segment );
 			$segment = sanitize_file_name( $segment );

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-favorite-controller.php
@@ -23,7 +23,7 @@ function init() {
 
 	$args = array(
 		'id' => array(
-			'validate_callback' => function( $param, $request, $key ) {
+			'validate_callback' => function ( $param, $request, $key ) {
 				return is_numeric( $param );
 			},
 		),

--- a/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/notifications.php
@@ -142,7 +142,7 @@ function notify_pattern_flagged( $post ) {
 				}
 			}
 			$reasons = array_map(
-				function( \WP_Term $reason ) {
+				function ( \WP_Term $reason ) {
 					return wp_strip_all_tags( $reason->description );
 				},
 				$reasons

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -197,7 +197,7 @@ function register_post_type_data() {
 			'type'              => 'string',
 			'description'       => 'A list of block types this pattern supports for transforms.',
 			'single'            => false,
-			'sanitize_callback' => function( $value, $key, $type ) {
+			'sanitize_callback' => function ( $value, $key, $type ) {
 				return preg_replace( '/[^a-z0-9-\/]/', '', $value );
 			},
 			'auth_callback'     => __NAMESPACE__ . '\can_edit_this_pattern',
@@ -216,7 +216,7 @@ function register_post_type_data() {
 			'type'              => 'string',
 			'description'       => 'The language used when creating this pattern.',
 			'single'            => true,
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				if ( ! in_array( $value, array_keys( get_locales() ), true ) ) {
 					return 'en_US';
 				}
@@ -291,7 +291,7 @@ function register_rest_fields() {
 		POST_TYPE,
 		'category_slugs',
 		array(
-			'get_callback' => function() {
+			'get_callback' => function () {
 				$slugs = wp_list_pluck( wp_get_object_terms( get_the_ID(), 'wporg-pattern-category' ), 'slug' );
 				$slugs = array_map( 'sanitize_title', $slugs );
 				$slugs = array_diff( $slugs, [ 'featured' ] );
@@ -314,7 +314,7 @@ function register_rest_fields() {
 		POST_TYPE,
 		'keyword_slugs',
 		array(
-			'get_callback' => function() {
+			'get_callback' => function () {
 				$slugs = wp_list_pluck( wp_get_object_terms( get_the_ID(), 'wporg-pattern-keyword' ), 'slug' );
 
 				return array_map( 'sanitize_title', $slugs );
@@ -340,7 +340,7 @@ function register_rest_fields() {
 		POST_TYPE,
 		'pattern_content',
 		array(
-			'get_callback' => function( $response_data ) {
+			'get_callback' => function ( $response_data ) {
 				$pattern = get_post( $response_data['id'] );
 				return decode_pattern_content( $pattern->post_content );
 			},
@@ -358,7 +358,7 @@ function register_rest_fields() {
 		POST_TYPE,
 		'favorite_count',
 		array(
-			'get_callback' => function() {
+			'get_callback' => function () {
 				return get_favorite_count( get_the_ID() );
 			},
 
@@ -376,7 +376,7 @@ function register_rest_fields() {
 		POST_TYPE,
 		'author_meta',
 		array(
-			'get_callback' => function( $post ) {
+			'get_callback' => function ( $post ) {
 				return array(
 					'name'   => esc_html( get_the_author_meta( 'display_name', $post['author'] ) ),
 					'url'    => esc_url( home_url( '/author/' . get_the_author_meta( 'user_nicename', $post['author'] ) ) ),
@@ -420,7 +420,7 @@ function register_rest_fields() {
 		POST_TYPE,
 		'unlisted_reason',
 		array(
-			'get_callback' => function() {
+			'get_callback' => function () {
 				$reasons = wp_get_object_terms( get_the_ID(), FLAG_REASON );
 				if ( count( $reasons ) > 0 ) {
 					$reason = array_shift( $reasons );
@@ -560,7 +560,7 @@ function enqueue_editor_assets() {
 		return;
 	}
 
-	$dir = dirname( dirname( __FILE__ ) );
+	$dir = dirname( __DIR__ );
 
 	$script_asset_path = "$dir/build/pattern-post-type.asset.php";
 	if ( ! file_exists( $script_asset_path ) ) {
@@ -570,7 +570,7 @@ function enqueue_editor_assets() {
 	$script_asset = require $script_asset_path;
 	wp_enqueue_script(
 		'wporg-pattern-post-type',
-		plugins_url( 'build/pattern-post-type.js', dirname( __FILE__ ) ),
+		plugins_url( 'build/pattern-post-type.js', __DIR__ ),
 		$script_asset['dependencies'],
 		$script_asset['version'],
 		true
@@ -588,7 +588,7 @@ function enqueue_editor_assets() {
 
 	wp_enqueue_style(
 		'wporg-pattern-post-type',
-		plugins_url( 'build/pattern-post-type.css', dirname( __FILE__ ) ),
+		plugins_url( 'build/pattern-post-type.css', __DIR__ ),
 		array(),
 		$script_asset['version'],
 	);
@@ -665,7 +665,7 @@ function filter_patterns_collection_params( $query_params ) {
 	$query_params['author_name'] = array(
 		'description'       => __( 'Limit result set to patterns by a single author.', 'wporg-patterns' ),
 		'type'              => 'string',
-		'validate_callback' => function( $value ) {
+		'validate_callback' => function ( $value ) {
 			$user = get_user_by( 'slug', $value );
 			return (bool) $user;
 		},
@@ -904,7 +904,7 @@ function setup_preview_theme() {
 	if ( preg_match( '#/view/$#', $request_uri ) || preg_match( '#[?&]view=[1|true]#', $request_uri ) ) {
 		add_filter( 'show_admin_bar', '__return_false', 2000 );
 
-		add_filter( 'template', function() {
+		add_filter( 'template', function () {
 			if ( 'local' === wp_get_environment_type() ) {
 				return 'twentytwentythree';
 			} else {
@@ -912,7 +912,7 @@ function setup_preview_theme() {
 			}
 		} );
 
-		add_filter( 'stylesheet', function() {
+		add_filter( 'stylesheet', function () {
 			if ( 'local' === wp_get_environment_type() ) {
 				return 'twentytwentythree';
 			} else {
@@ -920,7 +920,7 @@ function setup_preview_theme() {
 			}
 		} );
 
-		add_filter( 'wp_enqueue_scripts', function() {
+		add_filter( 'wp_enqueue_scripts', function () {
 			wp_deregister_style( 'wp4-styles' );
 			wp_deregister_style( 'wporg-global-header-footer' );
 		}, 201 );
@@ -992,7 +992,7 @@ function load_pattern_preview( $template ) {
  */
 add_action(
 	'the_post',
-	function( $post ) {
+	function ( $post ) {
 		$post->post_content = decode_pattern_content( $post->post_content );
 	}
 );

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -124,7 +124,7 @@ function validate_content( $prepared_post, $request ) {
 
 	// Check that each block in the list has a blockName and is registered.
 	$registry = \WP_Block_Type_Registry::get_instance();
-	$invalid_blocks = array_filter( $all_blocks, function( $block ) use ( $registry ) {
+	$invalid_blocks = array_filter( $all_blocks, function ( $block ) use ( $registry ) {
 		$block_type = $registry->get_registered( $block['blockName'] );
 		return is_null( $block['blockName'] ) || is_null( $block_type );
 	} );

--- a/public_html/wp-content/plugins/pattern-directory/includes/search.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/search.php
@@ -103,7 +103,7 @@ function modify_es_query_args( $es_query_args, $wp_query ) {
 
 	// Requests for a specific locale will still include `en_US` as a fallback.
 	if ( count( $locales ) > 1 ) {
-		$primary_locale = array_reduce( $locales, function( $carry, $item ) {
+		$primary_locale = array_reduce( $locales, function ( $carry, $item ) {
 			// This assumes there will only be 2 items in $locale.
 			if ( 'en_US' !== $item ) {
 				$carry = $item;

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
@@ -161,4 +161,3 @@ class Pattern_Title_Validation_Test extends WP_UnitTestCase {
 		$this->assertSame( 'rest_pattern_empty_title', $data['code'] );
 	}
 }
-

--- a/public_html/wp-content/plugins/pattern-translations/includes/cli-commands.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/cli-commands.php
@@ -21,7 +21,7 @@ class WP_CLI_Patterns extends WP_CLI_Command {
 		$patterns = $this->get_patterns_or_exit( $args );
 
 		// Flatten parent to just being the slug.
-		array_walk( $patterns, function( $pattern ) {
+		array_walk( $patterns, function ( $pattern ) {
 			$pattern->parent = $pattern->parent->name ?? $pattern->parent;
 		} );
 
@@ -139,5 +139,4 @@ class WP_CLI_Patterns extends WP_CLI_Command {
 
 		return $patterns;
 	}
-
 }

--- a/public_html/wp-content/plugins/pattern-translations/includes/cron.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/cron.php
@@ -17,7 +17,6 @@ function register_cron_tasks() {
 	if ( ! wp_next_scheduled( 'pattern_import_translations_to_directory' ) ) {
 		wp_schedule_event( time(), 'twicedaily', 'pattern_import_translations_to_directory' );
 	}
-
 }
 add_action( 'admin_init', __NAMESPACE__ . '\register_cron_tasks' );
 
@@ -72,7 +71,7 @@ function pattern_import_translations_to_directory( $pattern_ids = array() ) {
 	// Raise the memory limit for this process to at least 512M.
 	add_filter(
 		'cron_memory_limit',
-		function() {
+		function () {
 			return '512M';
 		}
 	);

--- a/public_html/wp-content/plugins/pattern-translations/includes/i18n.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/i18n.php
@@ -7,7 +7,7 @@ namespace WordPressdotorg\Pattern_Translations;
  * @param array $patterns An array of Pattern objects to translate.
  * @return array The translated pattern objects.
  */
-function translate_patterns( array $patterns ) : array {
+function translate_patterns( array $patterns ): array {
 	return translate_patterns_to( $patterns, get_locale() );
 }
 
@@ -18,8 +18,8 @@ function translate_patterns( array $patterns ) : array {
  * @param string $locale   The locale to translate into.
  * @return array The translated pattern objects.
  */
-function translate_patterns_to( array $patterns, string $locale ) : array {
-	return array_map( function( $pattern ) use ( $locale ) {
+function translate_patterns_to( array $patterns, string $locale ): array {
+	return array_map( function ( $pattern ) use ( $locale ) {
 		return $pattern->to_locale( $locale ) ?: $pattern;
 	}, $patterns );
 }

--- a/public_html/wp-content/plugins/pattern-translations/includes/makepot.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/makepot.php
@@ -9,11 +9,11 @@ class PatternMakepot {
 		$this->patterns = $patterns;
 	}
 
-	public function makepot( $revision_time = null ) : string {
+	public function makepot( $revision_time = null ): string {
 		return $this->makepo( $revision_time, $comment )->export();
 	}
 
-	public function makepo( $revision_time = null ) : \PO {
+	public function makepo( $revision_time = null ): \PO {
 		require_once ABSPATH . '/wp-includes/pomo/po.php';
 
 		$po = new \PO();
@@ -31,7 +31,7 @@ class PatternMakepot {
 		return $po;
 	}
 
-	public function entries() : array {
+	public function entries(): array {
 		$entries = [];
 
 		foreach ( $this->patterns as $pattern ) {
@@ -121,7 +121,7 @@ class PatternMakepot {
 		// Let's get all the references that we are importing.
 		$import_references = array();
 		if ( ! empty( $po->entries ) ) {
-			$import_references = array_merge( ... array_column( $po->entries, 'references' ) );
+			$import_references = array_merge( ...array_column( $po->entries, 'references' ) );
 		}
 
 		foreach ( $originals_by_key as $entry_key => $original ) {
@@ -178,7 +178,7 @@ class PatternMakepot {
 
 		// Load any GlotPress plugins as needed.
 		$plugins = get_option( 'active_plugins', [] );
-		array_walk( $plugins, function( $plugin ) {
+		array_walk( $plugins, function ( $plugin ) {
 			include_once trailingslashit( WP_PLUGIN_DIR ) . $plugin;
 		} );
 

--- a/public_html/wp-content/plugins/pattern-translations/includes/parser.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/parser.php
@@ -43,7 +43,7 @@ class PatternParser {
 		$this->fallback = new Parsers\BasicText();
 	}
 
-	public function block_parser_to_strings( array $block ) : array {
+	public function block_parser_to_strings( array $block ): array {
 		$parser = $this->parsers[ $block['blockName'] ] ?? $this->fallback;
 
 		$strings = $parser->to_strings( $block );
@@ -55,7 +55,7 @@ class PatternParser {
 		return $strings;
 	}
 
-	public function block_parser_replace_strings( array &$block, array $replacements ) : array {
+	public function block_parser_replace_strings( array &$block, array $replacements ): array {
 		$parser = $this->parsers[ $block['blockName'] ] ?? $this->fallback;
 		$block = $parser->replace_strings( $block, $replacements );
 
@@ -66,7 +66,7 @@ class PatternParser {
 		return $block;
 	}
 
-	public function to_strings() : array {
+	public function to_strings(): array {
 		$blocks = parse_blocks( $this->pattern->html );
 
 		$strings = [];
@@ -91,7 +91,7 @@ class PatternParser {
 		return array_unique( $strings );
 	}
 
-	public function replace_strings_with_kses( array $replacements ) : Pattern {
+	public function replace_strings_with_kses( array $replacements ): Pattern {
 		// Sanitize replacement strings before injecting them into blocks and block attributes.
 		$sanitized_replacements = $replacements;
 		foreach ( $sanitized_replacements as &$replacement ) {
@@ -100,7 +100,7 @@ class PatternParser {
 		return $this->replace_strings( $sanitized_replacements );
 	}
 
-	public function replace_strings( array $replacements ) : Pattern {
+	public function replace_strings( array $replacements ): Pattern {
 		$translated = clone $this->pattern;
 		$translated->title = $replacements[ $translated->title ] ?? $translated->title;
 		$translated->description = $replacements[ $translated->description ] ?? $translated->description;

--- a/public_html/wp-content/plugins/pattern-translations/includes/parsers/BasicText.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/parsers/BasicText.php
@@ -5,7 +5,7 @@ class BasicText implements BlockParser {
 	use DomUtils;
 	use TextNodesXPath;
 
-	public function to_strings( array $block ) : array {
+	public function to_strings( array $block ): array {
 		$dom   = $this->get_dom( $block['innerHTML'] );
 		$xpath = new \DOMXPath( $dom );
 
@@ -20,7 +20,7 @@ class BasicText implements BlockParser {
 		return $strings;
 	}
 
-	public function replace_strings( array $block, array $replacements ) : array {
+	public function replace_strings( array $block, array $replacements ): array {
 		$dom         = $this->get_dom( $block['innerHTML'] );
 		$xpath       = new \DOMXPath( $dom );
 		$xpath_query = $this->text_nodes_xpath_query();
@@ -54,5 +54,4 @@ class BasicText implements BlockParser {
 
 		return $block;
 	}
-
 }

--- a/public_html/wp-content/plugins/pattern-translations/includes/parsers/BlockParser.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/parsers/BlockParser.php
@@ -15,19 +15,19 @@ namespace WordPressdotorg\Pattern_Translations\Parsers;
 // A block transform is specific to a certain block type and contains
 // the know-how of how to both extract and replace strings
 interface BlockParser {
-	public function to_strings( array $block ) : array;
-	public function replace_strings( array $block, array $replacements ) : array;
+	public function to_strings( array $block ): array;
+	public function replace_strings( array $block, array $replacements ): array;
 }
 
 // DomDocument::loadHTML with LIBXML_HTML_NOIMPLIED causes dom doc settings to format / strip whitespace from our html
 // Add/remove html tags to avoid the need for noimplied html
 trait DomUtils {
 	// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
-	private function addHtml( string $html ) : string {
+	private function addHtml( string $html ): string {
 		return "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"></head><body>$html</body></html>";
 	}
 
-	private function removeHtml( string $html ) : string {
+	private function removeHtml( string $html ): string {
 		return preg_replace(
 			[
 				'/^\s*<html><head><meta http-equiv="Content-Type" content="text\/html; charset=utf-8"><\/head><body>/sm',
@@ -39,7 +39,7 @@ trait DomUtils {
 		);
 	}
 
-	private function get_dom( string $html ) : \DOMDocument {
+	private function get_dom( string $html ): \DOMDocument {
 		$previous = libxml_use_internal_errors( true );
 		$dom      = new \DomDocument();
 		$dom->loadHTML( $this->addHtml( $html ), LIBXML_HTML_NODEFDTD | LIBXML_COMPACT );
@@ -51,7 +51,7 @@ trait DomUtils {
 }
 
 trait GetSetAttribute {
-	private function get_attribute( string $attribute_name, array $block ) : array {
+	private function get_attribute( string $attribute_name, array $block ): array {
 		if ( isset( $block['attrs'][ $attribute_name ] ) && is_string( $block['attrs'][ $attribute_name ] ) ) {
 			return [ $block['attrs'][ $attribute_name ] ];
 		}
@@ -73,7 +73,7 @@ trait SwapTags {
 		'em',
 	];
 
-	private function encode_tags( string $raw_html ) : string {
+	private function encode_tags( string $raw_html ): string {
 		foreach ( $this->safe_tags as $tag ) {
 			$raw_html = preg_replace(
 				'#(<' . $tag . '([^>]*)>)(.*)(</' . $tag . '>)#',
@@ -84,7 +84,7 @@ trait SwapTags {
 		return $raw_html;
 	}
 
-	private function decode_tags( string $encoded_html ) : string {
+	private function decode_tags( string $encoded_html ): string {
 		foreach ( $this->safe_tags as $tag ) {
 			$encoded_html = preg_replace(
 				'#({' . $tag . '([^}]*)})(.*)({/' . $tag . '})#',

--- a/public_html/wp-content/plugins/pattern-translations/includes/parsers/Button.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/parsers/Button.php
@@ -7,7 +7,7 @@ class Button implements BlockParser {
 	use GetSetAttribute;
 	use TextNodesXPath;
 
-	public function to_strings( array $block ) : array {
+	public function to_strings( array $block ): array {
 		$strings = $this->get_attribute( 'placeholder', $block );
 
 		$encoded_html = $this->encode_tags( $block['innerHTML'] );
@@ -24,7 +24,7 @@ class Button implements BlockParser {
 		return $strings;
 	}
 
-	public function replace_strings( array $block, array $replacements ) : array {
+	public function replace_strings( array $block, array $replacements ): array {
 		$this->set_attribute( 'placeholder', $block, $replacements );
 
 		$encoded_html = $this->encode_tags( $block['innerHTML'] );

--- a/public_html/wp-content/plugins/pattern-translations/includes/parsers/Heading.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/parsers/Heading.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/BlockParser.php';
 class Heading implements BlockParser {
 	use GetSetAttribute;
 
-	public function to_strings( array $block ) : array {
+	public function to_strings( array $block ): array {
 		$strings = $this->get_attribute( 'placeholder', $block );
 
 		if ( preg_match( '/<h[1-6][^>]*>(.+)<\/h[1-6]>/is', $block['innerHTML'], $matches ) ) {
@@ -19,7 +19,7 @@ class Heading implements BlockParser {
 	}
 
 	// todo: this needs a fix to properly rebuild innerContent - see ParagraphParserTest
-	public function replace_strings( array $block, array $replacements ) : array {
+	public function replace_strings( array $block, array $replacements ): array {
 		$this->set_attribute( 'placeholder', $block, $replacements );
 
 		$html = $block['innerHTML'];

--- a/public_html/wp-content/plugins/pattern-translations/includes/parsers/Noop.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/parsers/Noop.php
@@ -2,11 +2,11 @@
 namespace WordPressdotorg\Pattern_Translations\Parsers;
 
 class Noop implements BlockParser {
-	public function to_strings( array $block ) : array {
+	public function to_strings( array $block ): array {
 		return [];
 	}
 
-	public function replace_strings( array $block, array $replacements ) : array {
+	public function replace_strings( array $block, array $replacements ): array {
 		return $block;
 	}
 }

--- a/public_html/wp-content/plugins/pattern-translations/includes/parsers/Paragraph.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/parsers/Paragraph.php
@@ -4,7 +4,7 @@ namespace WordPressdotorg\Pattern_Translations\Parsers;
 class Paragraph implements BlockParser {
 	use GetSetAttribute;
 
-	public function to_strings( array $block ) : array {
+	public function to_strings( array $block ): array {
 		$strings = $this->get_attribute( 'placeholder', $block );
 
 		$matches = [];
@@ -19,7 +19,7 @@ class Paragraph implements BlockParser {
 	}
 
 	// todo: this needs a fix to properly rebuild innerContent - see ParagraphParserTest
-	public function replace_strings( array $block, array $replacements ) : array {
+	public function replace_strings( array $block, array $replacements ): array {
 		$this->set_attribute( 'placeholder', $block, $replacements );
 
 		$html = $block['innerHTML'];

--- a/public_html/wp-content/plugins/pattern-translations/includes/parsers/ShortcodeBlock.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/parsers/ShortcodeBlock.php
@@ -16,7 +16,7 @@ class ShortcodeBlock implements BlockParser {
 		$this->attribute_names = $attribute_names;
 	}
 
-	public function to_strings( array $block ) : array {
+	public function to_strings( array $block ): array {
 		$strings = [];
 		foreach ( $this->attribute_names as $attribute_name ) {
 			$strings = array_merge( $strings, $this->get_attribute( $attribute_name, $block ) );
@@ -25,7 +25,7 @@ class ShortcodeBlock implements BlockParser {
 		return $strings;
 	}
 
-	public function replace_strings( array $block, array $replacements ) : array {
+	public function replace_strings( array $block, array $replacements ): array {
 		foreach ( $this->attribute_names as $attribute_name ) {
 			$this->set_attribute( $attribute_name, $block, $replacements );
 
@@ -35,7 +35,7 @@ class ShortcodeBlock implements BlockParser {
 
 					$block['innerContent'][ $i ] = preg_replace_callback(
 						$shortcode_param_regex,
-						function( $matches ) use ( $replacements ) {
+						function ( $matches ) use ( $replacements ) {
 							return $this->preg_replace_gutenberg_attributes_handler( $matches, $replacements );
 						},
 						$inner_content
@@ -47,7 +47,7 @@ class ShortcodeBlock implements BlockParser {
 		$regex              = '/\b(\w*?)="(.*?)(")/';
 		$block['innerHTML'] = preg_replace_callback(
 			$regex,
-			function( $matches ) use ( $replacements ) {
+			function ( $matches ) use ( $replacements ) {
 				return $this->preg_replace_gutenberg_attributes_handler( $matches, $replacements );
 			},
 			$block['innerHTML']
@@ -60,7 +60,7 @@ class ShortcodeBlock implements BlockParser {
 		return ltrim(
 			preg_replace_callback(
 				'/([A-Z]+)/',
-				function( $matches ) {
+				function ( $matches ) {
 					return '_' . strtolower( $matches[1] ); },
 				$camelCaseString
 			),

--- a/public_html/wp-content/plugins/pattern-translations/includes/parsers/TextNode.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/parsers/TextNode.php
@@ -4,7 +4,7 @@ namespace WordPressdotorg\Pattern_Translations\Parsers;
 class TextNode implements BlockParser {
 	use DomUtils;
 
-	public function to_strings( array $block ) : array {
+	public function to_strings( array $block ): array {
 		$dom   = $this->get_dom( serialize_block( $block ) );
 		$xpath = new \DOMXPath( $dom );
 
@@ -19,7 +19,7 @@ class TextNode implements BlockParser {
 		return $strings;
 	}
 
-	public function replace_strings( array $block, array $replacements ) : array {
+	public function replace_strings( array $block, array $replacements ): array {
 		$dom   = $this->get_dom( serialize_block( $block ) );
 		$xpath = new \DOMXPath( $dom );
 

--- a/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
@@ -94,7 +94,7 @@ class Pattern {
 	 * @param \WP_Post $post The post object.
 	 * @return Pattern The Pattern object.
 	 */
-	public static function from_post( \WP_Post $post ) : Pattern {
+	public static function from_post( \WP_Post $post ): Pattern {
 		$pattern              = new Pattern();
 		$pattern->ID          = $post->ID;
 		$pattern->title       = $post->post_title;
@@ -114,7 +114,7 @@ class Pattern {
 	 * @param array $args The WP_Query args.
 	 * @return array An array of Pattern objects.
 	 */
-	public static function get_patterns( array $args = [] ) : array {
+	public static function get_patterns( array $args = [] ): array {
 		$defaults = [
 			'post_type'      => POST_TYPE,
 			// Note: This must be set for cli context, in isolated test context this is defaulted to 'publish'

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
@@ -37,7 +37,7 @@ add_filter( 'frontpage_template_hierarchy', __NAMESPACE__ . '\use_archive_templa
 
 add_action(
 	'init',
-	function() {
+	function () {
 		// Don't swap author link with w.org profile link.
 		remove_all_filters( 'author_link' );
 

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
@@ -36,7 +36,7 @@ function register_block_bindings() {
 		array(
 			'label' => __( 'Edit label', 'wporg-patterns' ),
 			'uses_context' => [ 'postId' ],
-			'get_value_callback' => function( $args, $block ) {
+			'get_value_callback' => function ( $args, $block ) {
 				$post_id = $block->context['postId'];
 				/* translators: %s: Post title. Only visible to screen readers. */
 				return sprintf(
@@ -52,7 +52,7 @@ function register_block_bindings() {
 		array(
 			'label' => __( 'Edit link', 'wporg-patterns' ),
 			'uses_context' => [ 'postId' ],
-			'get_value_callback' => function( $args, $block ) {
+			'get_value_callback' => function ( $args, $block ) {
 				$post_id = $block->context['postId'];
 				return site_url( "pattern/$post_id/edit/" );
 			},
@@ -286,7 +286,7 @@ function get_favorite_settings( $settings, $post_id ) {
 	return array(
 		'count' => get_favorite_count( $post_id ),
 		'is_favorite' => is_favorite( $post_id ),
-		'add_callback' => function( $_post_id ) {
+		'add_callback' => function ( $_post_id ) {
 			$success = add_favorite( $_post_id );
 			if ( $success ) {
 				return get_favorite_count( $_post_id );
@@ -298,7 +298,7 @@ function get_favorite_settings( $settings, $post_id ) {
 				array( 'status' => 500 )
 			);
 		},
-		'delete_callback' => function( $_post_id ) {
+		'delete_callback' => function ( $_post_id ) {
 			$success = remove_favorite( $_post_id );
 			if ( $success ) {
 				return get_favorite_count( $_post_id );

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/shortcodes.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/shortcodes.php
@@ -6,7 +6,7 @@ namespace WordPressdotorg\Theme\Pattern_Directory_2024;
  */
 add_shortcode(
 	'pattern_edit_link',
-	function() {
+	function () {
 		$post_id = get_the_ID();
 		return site_url( "pattern/$post_id/edit/" );
 	}
@@ -17,7 +17,7 @@ add_shortcode(
  */
 add_shortcode(
 	'pattern_draft_link',
-	function() {
+	function () {
 		$post_id = get_the_ID();
 		return add_query_arg(
 			array(


### PR DESCRIPTION
## Why

`wp-coding-standards/wpcs` was pinned to `2.*`, resolving to **2.3.0** — released March 2020 and the last of the 2.x line. PHPCS itself was already current (3.13.2); only the WordPress standard was stale.

On PHP 8.1+ WPCS 2.3.0 emits an implicit-nullable deprecation from `PHPCSHelper::ignore_annotations()`, which PHPCS converts into `An error occurred during processing; checking has been aborted`. Any file hitting that code path was **silently skipped instead of linted** — so the local lint was quietly under-reporting. On this branch, running the `WordPress.Security.*` sniffs over the same four directories goes from 27 findings (with `themes/…-2024/functions.php` never actually scanned) to 34.

## What changed

**Dependencies**

| Package | From | To |
|---|---|---|
| `wp-coding-standards/wpcs` | 2.3.0 | 3.4.1 |
| `dealerdirect/phpcodesniffer-composer-installer` | 0.7.2 | 1.2.1 (required by WPCS 3.x) |
| `squizlabs/php_codesniffer` | 3.13.2 | 3.13.6 |
| `phpcsstandards/phpcsutils` | — | 1.2.3 (new, transitive) |
| `phpcsstandards/phpcsextra` | — | 1.5.1 (new, transitive) |

**`phpcs.xml.dist` reconciliation**

The upgrade is not drop-in — several existing directives had gone stale, two of them *silently*:

- `Generic.Arrays.DisallowShortArraySyntax` → `Universal.Arrays.DisallowShortArraySyntax` (moved to PHPCSExtra). The old exclude no longer matched, so short array syntax was flagged **119** times.
- `WordPress.PHP.DisallowShortTernary` → `Universal.Operators.DisallowShortTernary`. Same story, **13** hits.
- `customPropertiesWhitelist` → `allowed_custom_properties` (renamed in WPCS 3.0). This one is a hard error, not silent.
- `text_domain` was passing an array as a comma-separated string — deprecated since PHPCS 3.3.0, removed in 4.0. Now uses `<element>` nodes.
- `PEAR.Files.IncludingFile.BracketsNotRequired` **cannot** be excluded from inside the `WordPress-Core` block: the later `WordPress-Extra` rule re-includes `WordPress-Core` wholesale and reinstates it. Moved to a `<severity>0</severity>` rule positioned after `WordPress-Extra`.
- `PSR12.Files.FileHeader` **newly excluded** — see the judgement call below.

**Code (auto-fixed with `phpcbf`)**

The remaining 84 violations all came from sniffs new in 3.x, and are formatting-only except where noted:

- `Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction` (39) — `function(` → `function (` in closures
- `PSR12.Functions.ReturnTypeDeclaration.SpaceBeforeColon` (34) — `) : array` → `): array`
- `Modernize.FunctionCalls.Dirname.FileConstant` (4) — `dirname( __FILE__ )` → `__DIR__`; exactly equivalent, verified each call site
- `Universal.ControlStructures.DisallowLonelyIf` (1) — `else { if }` → `elseif` in `bin/check-spam.php`
- plus 6 single-instance whitespace/brace fixes

phpcbf mis-indented the `elseif` it produced in `bin/check-spam.php` and left a stray blank line; corrected by hand.

## Judgement call worth a second opinion

`PSR12.Files.FileHeader` is new in WPCS 3.0 and accounted for the last 9 violations. It imposes a fixed order on the file header — docblock, `declare`, `namespace`, class `use`, function `use`, const `use` — and forbids interleaving them.

This codebase consistently groups imports by *what* they import rather than by *kind*, e.g. `functions.php`:

```php
use function WordPressdotorg\Pattern_Directory\Favorite\{get_favorites, get_favorite_count};
use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG_POST_TYPE;
use function WordPressdotorg\Theme\Pattern_Directory_2024\Block_Config\get_applied_filter_list;
```

It also reads `/** Actions and filters. */` above a block of `add_action()` calls as a misplaced *file* docblock, which it isn't.

Satisfying the sniff means reordering imports across 9 files and fighting a preference the ruleset already records — `PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter` is excluded with the comment *"I think it's better to have all the `use` statements come right after the namespace line"*, which PSR-12 also forbids. Excluding seemed the coherent choice, but happy to reformat the 9 files instead if you'd rather adopt the rule.

## Testing

- `npm run lint:php` exits **0** on PHP 8.5.
- `php -l` clean across all 31 modified files.
- ⚠️ **PHPUnit was not run** — Docker wasn't available locally, so `npm run test:php` couldn't execute. CI will cover it. The code changes are whitespace plus the two equivalence-preserving rewrites noted above.

## Follow-up, not fixed here

`phpcs.xml.dist` nests a `<rule ref="WordPress.Arrays.MultipleStatementAlignment">` *inside* the `<rule ref="WordPress-Core">` block, carrying an `@todo This isn't working` comment. It still doesn't work — PHPCS doesn't process a nested `<rule>` as an include, so those `alignMultilineItems` / `ignoreNewlines` properties have never applied. Moving it to the top level fixes that, but it's a pre-existing issue unrelated to this upgrade and changes alignment enforcement, so I left it alone. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)