### PR TITLE
Run the full WordPress standard in phpcs

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -31,7 +31,57 @@
 
 	<arg name="extensions" value="php" />
 
-	<rule ref="WordPress-Core">
+	<!--
+	 ... Keep this block ABOVE the `WordPress` rule. `WordPress` includes `WordPress-Docs` itself, and whichever
+	 ... reference registers a sniff first is the one whose `<exclude-pattern>` sticks. Declared afterwards, the
+	 ... parser-file exemption below is silently ignored and the block pattern parsers pick up ~36 docblock errors.
+	 -->
+	<rule ref="WordPress-Docs">
+		<!-- If files/variables are given descriptive names like they should be, then an explicit description is usually unnecessary, so leave this as a judgement call. -->
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
+		<exclude name="Squiz.Commenting.ClassComment.Missing" />
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+		<exclude name="Squiz.Commenting.VariableComment.Missing" />
+		<exclude name="Squiz.Commenting.VariableComment.MissingVar" />
+
+		<!-- I don't see how these are useful. -->
+		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
+
+		<!-- We really only use basic exceptions, so this is kind of overkill and tedious. -->
+		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
+
+		<!-- Whitespace makes things more readable. -->
+		<exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen" />
+
+		<!-- There are some valid cases of this, like in identifying a closing tag from another file; e.g., in `themes/campsite-2017/footer.php`. -->
+		<exclude name="Squiz.Commenting.InlineComment.SpacingAfter" />
+
+		<!-- It's not wrong for WordPress plugin file headers. -->
+		<exclude name="Squiz.Commenting.FileComment.WrongStyle" />
+
+		<!-- Class comments are generally not useful, so they're left out, but then PHPCS confuses the plugin headers for a class comment -->
+		<exclude name="Squiz.Commenting.ClassComment.WrongStyle" />
+		<exclude name="Squiz.Commenting.ClassComment.SpacingAfter" />
+
+		<!-- WordPress have translators comment which requires no space after `//` -->
+		<exclude name="Squiz.Commenting.InlineComment.NoSpaceBefore" />
+
+		<!-- Ignore punctuation at the end of comments. -->
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+
+		<!-- Ignore docs issues in block pattern parser files. -->
+		<exclude-pattern>*/pattern-translations/includes/*.php$</exclude-pattern>
+	</rule>
+
+	<!--
+	 ... Reference the full `WordPress` standard rather than composing Core/Docs/Extra by hand. Only the meta
+	 ... standard carries the `namespace="WordPressCS\WordPress"` attribute that auto-includes every WordPressCS
+	 ... sniff; the sub-rulesets ref sniffs individually, which left WordPress.Security.ValidatedSanitizedInput
+	 ... out of the run entirely.
+	 -->
+	<rule ref="WordPress">
 		<!-- I don't see anything wrong with this :) -->
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterOpen" />
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd" />
@@ -79,11 +129,8 @@
 		<!-- print_r() is perfectly accepted in some circumstances, like WP_CLI commands. -->
 		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_print_r" />
 
-		<!-- Allow short ternary pattern. -->
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
-
-		<!-- Allow short array syntax. -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+		<!-- I think it's better to have all the `use` statements come right after the namespace line. -->
+		<exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter" />
 	</rule>
 
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
@@ -100,55 +147,24 @@
 		</properties>
 	</rule>
 
-	<rule ref="WordPress-Docs">
-		<!-- If files/variables are given descriptive names like they should be, then an explicit description is usually unnecessary, so leave this as a judgement call. -->
-		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
-		<exclude name="Squiz.Commenting.FileComment.Missing" />
-		<exclude name="Squiz.Commenting.ClassComment.Missing" />
-		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
-		<exclude name="Generic.Commenting.DocComment.MissingShort" />
-		<exclude name="Squiz.Commenting.VariableComment.Missing" />
-		<exclude name="Squiz.Commenting.VariableComment.MissingVar" />
-
-		<!-- I don't see how these are useful. -->
-		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
-
-		<!-- We really only use basic exceptions, so this is kind of overkill and tedious. -->
-		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
-
-		<!-- Whitespace makes things more readable. -->
-		<exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen" />
-
-		<!-- There are some valid cases of this, like in identifying a closing tag from another file; e.g., in `themes/campsite-2017/footer.php`. -->
-		<exclude name="Squiz.Commenting.InlineComment.SpacingAfter" />
-
-		<!-- It's not wrong for WordPress plugin file headers. -->
-		<exclude name="Squiz.Commenting.FileComment.WrongStyle" />
-
-		<!-- Class comments are generally not useful, so they're left out, but then PHPCS confuses the plugin headers for a class comment -->
-		<exclude name="Squiz.Commenting.ClassComment.WrongStyle" />
-		<exclude name="Squiz.Commenting.ClassComment.SpacingAfter" />
-
-		<!-- WordPress have translators comment which requires no space after `//` -->
-		<exclude name="Squiz.Commenting.InlineComment.NoSpaceBefore" />
-
-		<!-- Ignore punctuation at the end of comments. -->
-		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
-
-		<!-- Ignore docs issues in block pattern parser files. -->
-		<exclude-pattern>*/pattern-translations/includes/*.php$</exclude-pattern>
+	<!--
+	 ... `<arg value="psn"/>` above reports errors only, so a security sniff that emits warnings is invisible
+	 ... in CI. Promote the whole category to errors rather than dropping the `n`, which would also surface
+	 ... ~380 array-alignment warnings that have nothing to do with security.
+	 ...
+	 ... Must stay after the `WordPress` rule above to take effect.
+	 -->
+	<rule ref="WordPress.Security">
+		<type>error</type>
 	</rule>
 
-	<rule ref="WordPress-Extra">
-		<!-- I think it's better to have all the `use` statements come right after the namespace line. -->
-		<exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter" />
-	</rule>
-
-	<!-- Verify that the text_domain is set to the desired text-domain. Multiple valid text domains can be
-	     provided as a comma-delimited list. -->
+	<!-- Verify that the text_domain is set to the desired text-domain. Additional valid text domains can be
+	     added as further `<element>` nodes. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="wporg-patterns" />
+			<property name="text_domain" type="array">
+				<element value="wporg-patterns" />
+			</property>
 		</properties>
 	</rule>
 	<!-- Short ternaries are used deliberately throughout; expanding them is a style call for maintainers. -->

--- a/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
+++ b/public_html/wp-content/plugins/pattern-creator/pattern-creator.php
@@ -337,8 +337,8 @@ function allow_reading_global_styles( $caps, $cap, $user_id, $args ) {
 	) {
 		return $caps;
 	}
-	$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( $_SERVER['REQUEST_METHOD'] ) : '';
-	$request_uri    = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
+	$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) ) : '';
+	$request_uri    = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 	if (
 		( 'GET' !== $request_method && 'HEAD' !== $request_method ) ||
 		false === strpos( $request_uri, '/wp/v2/global-styles' )

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
@@ -391,11 +391,8 @@ function handle_pattern_list_table_views( WP_Query $query ) {
  * @return array
  */
 function display_post_states( $post_states, $post ) {
-	if ( isset( $_REQUEST['post_status'] ) ) {
-		$post_status = $_REQUEST['post_status'];
-	} else {
-		$post_status = '';
-	}
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only list table filter, compared against registered statuses.
+	$post_status = isset( $_REQUEST['post_status'] ) ? sanitize_key( wp_unslash( $_REQUEST['post_status'] ) ) : '';
 
 	if (
 		$post->post_status !== $post_status &&

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/admin-patterns-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/admin-patterns-test.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Test the Patterns list table admin helpers.
+ */
+
+use function WordPressdotorg\Pattern_Directory\Admin\Patterns\display_post_states;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, UNLISTED_STATUS, SPAM_STATUS };
+
+/*
+ * These tests set the request superglobal directly to drive the list table filter, which is the
+ * point of them. The sniff guarding production input handling does not apply.
+ */
+// phpcs:disable WordPress.Security.NonceVerification.Recommended
+
+/**
+ * Test the extra post states shown on the Patterns list table.
+ */
+class Pattern_Admin_Post_States_Test extends WP_UnitTestCase {
+	/**
+	 * An unlisted pattern.
+	 *
+	 * @var int
+	 */
+	protected static $unlisted_pattern_id;
+
+	/**
+	 * A pattern flagged as spam.
+	 *
+	 * @var int
+	 */
+	protected static $spam_pattern_id;
+
+	/**
+	 * A published pattern, which never gets an extra state.
+	 *
+	 * @var int
+	 */
+	protected static $published_pattern_id;
+
+	/**
+	 * The $_REQUEST superglobal as it was before the current test ran.
+	 *
+	 * @var array
+	 */
+	protected $original_request;
+
+	/**
+	 * Set up shared fixtures.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$unlisted_pattern_id  = $factory->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_status' => UNLISTED_STATUS,
+			)
+		);
+		self::$spam_pattern_id      = $factory->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_status' => SPAM_STATUS,
+			)
+		);
+		self::$published_pattern_id = $factory->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * Isolate each test from the real request.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_request = $_REQUEST;
+		$_REQUEST               = array();
+	}
+
+	/**
+	 * Restore the real request.
+	 */
+	public function tear_down() {
+		$_REQUEST = $this->original_request;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Without a status filter, unlisted and spam patterns are labelled so they stand out in the
+	 * "All" view.
+	 *
+	 * @dataProvider data_flagged_statuses
+	 *
+	 * @param string $property Name of the fixture property holding the pattern ID.
+	 * @param string $status   The post status that should be labelled.
+	 */
+	public function test_flagged_status_is_labelled_in_unfiltered_view( $property, $status ) {
+		$post = get_post( self::${$property} );
+
+		$states = display_post_states( array(), $post );
+
+		$this->assertArrayHasKey( $status, $states );
+		$this->assertSame( get_post_status_object( $status )->label, $states[ $status ] );
+	}
+
+	/**
+	 * Statuses that earn an extra label.
+	 *
+	 * @return array[]
+	 */
+	public function data_flagged_statuses() {
+		return array(
+			'unlisted' => array( 'unlisted_pattern_id', UNLISTED_STATUS ),
+			'spam'     => array( 'spam_pattern_id', SPAM_STATUS ),
+		);
+	}
+
+	/**
+	 * When the list table is already filtered to that status, the label is redundant and omitted.
+	 */
+	public function test_label_is_omitted_when_already_filtering_by_that_status() {
+		$_REQUEST['post_status'] = UNLISTED_STATUS;
+		$post                    = get_post( self::$unlisted_pattern_id );
+
+		$this->assertSame( array(), display_post_states( array(), $post ) );
+	}
+
+	/**
+	 * An ordinary published pattern never gets an extra state.
+	 */
+	public function test_published_pattern_gets_no_extra_state() {
+		$post = get_post( self::$published_pattern_id );
+
+		$this->assertSame( array(), display_post_states( array(), $post ) );
+	}
+
+	/**
+	 * Existing states are preserved rather than replaced.
+	 */
+	public function test_existing_states_are_preserved() {
+		$post = get_post( self::$unlisted_pattern_id );
+
+		$states = display_post_states( array( 'sticky' => 'Sticky' ), $post );
+
+		$this->assertArrayHasKey( 'sticky', $states );
+		$this->assertArrayHasKey( UNLISTED_STATUS, $states );
+	}
+
+	/**
+	 * The `post_status` request variable runs through `sanitize_key()`, which lowercases it. A
+	 * differently-cased filter therefore matches the post status and suppresses the label, where
+	 * an unsanitized comparison would not.
+	 */
+	public function test_post_status_request_variable_is_sanitized() {
+		$_REQUEST['post_status'] = strtoupper( UNLISTED_STATUS );
+		$post                    = get_post( self::$unlisted_pattern_id );
+
+		$this->assertSame( array(), display_post_states( array(), $post ) );
+	}
+
+	/**
+	 * Sanitizing strips characters a real status can never contain, so a value carrying markup
+	 * cannot match and the label stays.
+	 */
+	public function test_post_status_carrying_markup_does_not_match() {
+		$_REQUEST['post_status'] = '<script>alert(1)</script>' . UNLISTED_STATUS;
+		$post                    = get_post( self::$unlisted_pattern_id );
+
+		$states = display_post_states( array(), $post );
+
+		$this->assertArrayHasKey( UNLISTED_STATUS, $states );
+		$this->assertStringNotContainsString( '<script>', wp_json_encode( $states ) );
+	}
+
+	/**
+	 * A non-string `post_status` must not raise a type error.
+	 */
+	public function test_array_post_status_is_handled() {
+		$_REQUEST['post_status'] = array( UNLISTED_STATUS );
+		$post                    = get_post( self::$unlisted_pattern_id );
+
+		$states = display_post_states( array(), $post );
+
+		$this->assertArrayHasKey( UNLISTED_STATUS, $states );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/locale-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/locale-test.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Test locale negotiation in the Pattern Translations plugin.
+ */
+
+use function WordPressdotorg\Pattern_Translations\locale;
+
+/*
+ * These tests drive the request superglobals directly and assert on what the filter leaves behind,
+ * which is the point of them. The sniffs guarding production input handling do not apply.
+ */
+// phpcs:disable WordPress.Security.NonceVerification.Recommended
+// phpcs:disable WordPress.Security.ValidatedSanitizedInput
+
+/*
+ * `locale()` only honours the `locale` query variable on api.wordpress.org requests, which are
+ * identified by this constant. It is the only place in the codebase that reads it, so defining it
+ * for the whole run does not affect any other test.
+ */
+if ( ! defined( 'WPORG_IS_API' ) ) {
+	define( 'WPORG_IS_API', true );
+}
+
+/**
+ * Test the `locale` filter callback.
+ */
+class Pattern_Translations_Locale_Test extends WP_UnitTestCase {
+	/**
+	 * The $_GET superglobal as it was before the current test ran.
+	 *
+	 * @var array
+	 */
+	protected $original_get;
+
+	/**
+	 * The $_SERVER superglobal as it was before the current test ran.
+	 *
+	 * @var array
+	 */
+	protected $original_server;
+
+	/**
+	 * Isolate each test from the real request.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_get    = $_GET;
+		$this->original_server = $_SERVER;
+		$_GET                  = array();
+	}
+
+	/**
+	 * Restore the real request.
+	 */
+	public function tear_down() {
+		$_GET    = $this->original_get;
+		$_SERVER = $this->original_server;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * A well-formed locale is honoured.
+	 */
+	public function test_valid_locale_is_returned() {
+		$_GET['locale'] = 'fr_FR';
+
+		$this->assertSame( 'fr_FR', locale( 'en_US' ) );
+	}
+
+	/**
+	 * With no locale requested, the passed-in locale survives untouched.
+	 */
+	public function test_missing_locale_falls_through() {
+		$this->assertSame( 'en_US', locale( 'en_US' ) );
+	}
+
+	/**
+	 * A locale is only honoured when sanitizing leaves it unchanged, so anything containing
+	 * characters `sanitize_locale_name()` strips is rejected outright rather than coerced.
+	 *
+	 * @dataProvider data_malformed_locales
+	 *
+	 * @param string $requested The value of the `locale` query variable.
+	 */
+	public function test_malformed_locale_is_rejected( $requested ) {
+		$_GET['locale'] = $requested;
+
+		$this->assertSame( 'en_US', locale( 'en_US' ) );
+	}
+
+	/**
+	 * Locale values that must never be honoured.
+	 *
+	 * @return array[]
+	 */
+	public function data_malformed_locales() {
+		return array(
+			'dot separator'  => array( 'en.US' ),
+			'path traversal' => array( '../../etc/passwd' ),
+			'markup'         => array( '<script>alert(1)</script>' ),
+			'null byte'      => array( "en_US\0" ),
+			'whitespace'     => array( 'en US' ),
+			'empty string'   => array( '' ),
+			'zero string'    => array( '0' ),
+		);
+	}
+
+	/**
+	 * A non-string `locale` cannot satisfy the string comparison, and must not raise a type error.
+	 */
+	public function test_array_locale_is_rejected() {
+		$_GET['locale'] = array( 'fr_FR' );
+
+		$this->assertSame( 'en_US', locale( 'en_US' ) );
+	}
+
+	/**
+	 * WordPress slashes $_GET, so the value is unslashed before it is compared against its own
+	 * sanitized form. A value that is only valid once unslashed is therefore honoured, and what
+	 * gets returned is the sanitized form rather than the raw input.
+	 */
+	public function test_slashed_locale_is_unslashed_before_comparison() {
+		$_GET['locale'] = 'fr\\_FR';
+
+		$this->assertSame( 'fr_FR', locale( 'en_US' ) );
+	}
+
+	/**
+	 * `?_locale=user` is rewritten on JSON requests, so localised sites don't return untranslated
+	 * details to authenticated users.
+	 */
+	public function test_user_locale_is_rewritten_on_json_requests() {
+		$_SERVER['HTTP_ACCEPT'] = 'application/json';
+		$_GET['_locale']        = 'user';
+
+		locale( 'en_US' );
+
+		$this->assertSame( 'site', $_GET['_locale'] );
+	}
+
+	/**
+	 * Outside a JSON request, `_locale` is left alone.
+	 */
+	public function test_user_locale_is_untouched_on_regular_requests() {
+		unset( $_SERVER['HTTP_ACCEPT'], $_SERVER['CONTENT_TYPE'] );
+		$_GET['_locale'] = 'user';
+
+		locale( 'en_US' );
+
+		$this->assertSame( 'user', $_GET['_locale'] );
+	}
+
+	/**
+	 * A `_locale` other than `user` is left alone even on a JSON request.
+	 */
+	public function test_other_locale_values_are_untouched() {
+		$_SERVER['HTTP_ACCEPT'] = 'application/json';
+		$_GET['_locale']        = 'site';
+
+		locale( 'en_US' );
+
+		$this->assertSame( 'site', $_GET['_locale'] );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
+++ b/public_html/wp-content/plugins/pattern-translations/pattern-translations.php
@@ -124,15 +124,20 @@ add_filter( 'single_post_title', __NAMESPACE__ . '\translate_page_title', 1, 2 )
  * For REST API requests, the `_locale=user` GET parameter is ignored for authenticated requests, causing the rest to default to the Site locale.
  */
 function locale( $locale ) {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- locale negotiation on GET; nothing is persisted, and the only write is to $_GET itself for the current request.
+
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- $raw_locale is the untouched baseline the next line is compared against.
+	$raw_locale  = isset( $_GET['locale'] ) && is_string( $_GET['locale'] ) ? wp_unslash( $_GET['locale'] ) : '';
+	$safe_locale = sanitize_locale_name( $raw_locale );
+
 	// When being requested through api.wordpress.org, respect the query variable.
 	if (
 		defined( 'WPORG_IS_API' ) &&
 		WPORG_IS_API &&
-		! empty( $_GET['locale'] ) &&
-		is_string( $_GET['locale'] ) &&
-		sanitize_locale_name( $_GET['locale'] ) === $_GET['locale']
+		! empty( $raw_locale ) &&
+		$safe_locale === $raw_locale
 	) {
-		return $_GET['locale'];
+		return $safe_locale;
 	}
 
 	// Respect the site locale otherwise for rest api queries.
@@ -144,6 +149,7 @@ function locale( $locale ) {
 	) {
 		$_GET['_locale'] = 'site';
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 	return $locale;
 }

--- a/public_html/wp-content/tests/phpunit/bootstrap.php
+++ b/public_html/wp-content/tests/phpunit/bootstrap.php
@@ -41,6 +41,7 @@ require_once $_tests_dir . '/includes/functions.php';
 function _manually_load_plugins() {
 	require dirname( dirname( __DIR__ ) ) . '/plugins/pattern-directory/bootstrap.php';
 	require dirname( dirname( __DIR__ ) ) . '/plugins/pattern-creator/pattern-creator.php';
+	require dirname( dirname( __DIR__ ) ) . '/plugins/pattern-translations/pattern-translations.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugins' );
 

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
@@ -72,8 +72,8 @@ function do_pattern_actions() {
 		return;
 	}
 
-	$action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : false;
-	$nonce = isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : false;
+	$action  = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : false;
+	$nonce   = isset( $_REQUEST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ) : false;
 	$post_id = get_the_ID();
 
 	if ( 'draft' === $action ) {
@@ -112,14 +112,17 @@ function do_pattern_actions() {
 				return;
 			}
 
+			$report_details = isset( $_POST['report-details'] ) ? sanitize_text_field( wp_unslash( $_POST['report-details'] ) ) : '';
+			$report_reason  = isset( $_POST['report-reason'] ) ? intval( $_POST['report-reason'] ) : 0;
+
 			$success = wp_insert_post(
 				array(
-					'post_type'   => FLAG_POST_TYPE,
-					'post_parent' => $post_id,
-					'post_excerpt'  => sanitize_text_field( $_POST['report-details'] ),
-					'post_status' => PENDING_STATUS,
-					'tax_input'  => array(
-						'wporg-pattern-flag-reason' => intval( $_POST['report-reason'] ),
+					'post_type'    => FLAG_POST_TYPE,
+					'post_parent'  => $post_id,
+					'post_excerpt' => $report_details,
+					'post_status'  => PENDING_STATUS,
+					'tax_input'    => array(
+						'wporg-pattern-flag-reason' => $report_reason,
 					),
 				)
 			);

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/single-my-pattern.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/single-my-pattern.php
@@ -5,9 +5,10 @@
  * Inserter: no
  */
 
-$action_status = isset( $_GET['status'] ) ? $_GET['status'] : false;
-$notice = '';
-$notice_type = 'warning';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only notice flag set by our own redirect; nothing is written here.
+$action_status = isset( $_GET['status'] ) ? sanitize_key( wp_unslash( $_GET['status'] ) ) : false;
+$notice        = '';
+$notice_type   = 'warning';
 if ( 'draft-failed' === $action_status ) {
 	$notice = __( 'Your pattern could not be updated, please try again.', 'wporg-patterns' );
 }

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/single-pattern.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/single-pattern.php
@@ -5,9 +5,10 @@
  * Inserter: no
  */
 
-$action_status = isset( $_GET['status'] ) ? $_GET['status'] : false;
-$notice = '';
-$notice_type = 'warning';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only notice flag set by our own redirect; nothing is written here.
+$action_status = isset( $_GET['status'] ) ? sanitize_key( wp_unslash( $_GET['status'] ) ) : false;
+$notice        = '';
+$notice_type   = 'warning';
 
 if ( 'report-failed' === $action_status ) {
 	$notice = __( 'Your pattern report could not be saved. Please try again.', 'wporg-patterns' );


### PR DESCRIPTION
## What

`phpcs.xml.dist` composed `WordPress-Core`, `WordPress-Docs` and `WordPress-Extra` directly instead of referencing the `WordPress` standard. Only the meta standard carries the `namespace="WordPressCS\WordPress"` attribute that auto-includes every WordPressCS sniff — the sub-rulesets reference sniffs one by one, and `WordPress-Extra` only lists `EscapeOutput`, `SafeRedirect` and `NonceVerification`. So `WordPress.Security.ValidatedSanitizedInput` was never loaded.

Separately, `<arg value="psn"/>` reports errors only, which meant the nonce findings were warnings nobody saw.

Between the two, `npm run lint:php` reported zero security issues on trunk while 34 were present.

## Ruleset changes

- `<rule ref="WordPress-Core">` → `<rule ref="WordPress">`, absorbing the one `WordPress-Extra` exclude.
- `WordPress-Docs` block moved **above** the `WordPress` rule. `WordPress` includes `WordPress-Docs` itself, and whichever reference registers a sniff first is the one whose `<exclude-pattern>` applies. Declared after, the parser-file exemption is silently ignored and the block pattern parsers pick up 36 docblock errors. There's a comment on the block; it's worth keeping in mind if anyone reorders the file.
- `WordPress.Security` promoted to `<type>error</type>`. Dropping the `n` from `psn` instead would surface 490 warnings, ~380 of them array alignment, which is a different piece of work.
- `text_domain` moved off the comma-separated string syntax — deprecated in PHPCS 3.3.0, removed in 4.0. It was printing a `DEPRECATED` notice on every run.
- Dropped `Generic.Arrays.DisallowShortArraySyntax.Found` and `WordPress.PHP.DisallowShortTernary.Found`. Both moved to PHPCSExtra in WPCS 3.0 and no longer matched anything; short ternaries are already covered by the working `Universal.Operators.DisallowShortTernary` rule at the bottom of the file. Confirmed no-ops — `phpcs -e` output is identical with and without them.

Checked with `phpcs -e` that the active sniff set is a superset of trunk: 182 → 186, nothing lost.

## Code changes

One actual bug:

```php
// themes/wporg-pattern-directory-2024/functions.php
'post_excerpt' => sanitize_text_field( $_POST['report-details'] ),
```

No `wp_unslash()`, and `sanitize_text_field()` doesn't unslash, so a report containing `it's` was stored as `it\'s`, compounding on re-save. Both report fields now go through guarded locals with `isset()` defaults.

The rest are unslash/sanitize on read-only request values in the theme patterns, the patterns list table and the pattern creator. `locale()` in pattern-translations was restructured so the value is unslashed once and compared against its own sanitized form, which keeps the existing reject-rather-than-coerce behaviour.

`$_SERVER['REQUEST_URI']` uses `esc_url_raw()`. `sanitize_text_field()` would strip percent-encoded octets; checked against eight real REST URI shapes and `esc_url_raw` is byte-identical to raw on all of them.

Six `phpcs:ignore`/`disable` annotations remain — nonce false positives on read-only GET paths, plus one deliberate raw comparison in `locale()`. Each was checked by deleting it and re-running phpcs; all are load-bearing.

## Tests

New coverage for `locale()` (9 tests) and `display_post_states()` (13). The test bootstrap now loads pattern-translations, which activates its filters for the whole suite — no effect on the existing tests, but worth knowing.

Both fixes were verified by reverting them and confirming a test fails. Worth noting because my first version of the `display_post_states` test passed against the broken code — asserting "no `<script>` in the output" is true either way. Rewrote it around `sanitize_key()` case-folding, which actually discriminates.

76 tests / 244 assertions, up from 54. `phpcs` exits 0.

## Not covered

`allow_reading_global_styles()` early-returns unless `REST_REQUEST` is defined, and defining that constant would leak into every subsequent test, so it's untested.

Two pre-existing things noticed but left alone, both unchanged by this PR:

- `intval( $_POST['report-reason'] )` returns `1` for any non-empty array, so `?report-reason[]=99` assigns term ID 1 rather than rejecting.
- `strpos( $request_uri, '/wp/v2/global-styles' )` misses the `?rest_route=%2Fwp%2Fv2%2F...` encoded form that plain-permalink sites use.