### PR TITLE
Pattern directory: align REST permission checks and status handling

### DIFF
--- a/public_html/wp-content/plugins/pattern-creator/src/components/save-button/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/save-button/index.js
@@ -29,6 +29,7 @@ export function SaveButton() {
 		isAutoSaving,
 		isSaveable,
 		isPublished,
+		isUnlisted,
 		isPublishedOrPending,
 		publishStatus,
 	} = useSelect( ( select ) => {
@@ -48,7 +49,8 @@ export function SaveButton() {
 			isAutoSaving: _isAutoSaving,
 			isSaveable: isPatternSaveable( getCurrentPostId() ),
 			isPublished: 'publish' === _post.status,
-			isPublishedOrPending: [ 'pending', 'publish' ].includes( _post.status ),
+			isUnlisted: 'unlisted' === _post.status,
+			isPublishedOrPending: [ 'pending', 'publish', 'unlisted' ].includes( _post.status ),
 			publishStatus: hasPublishAction ? settings.defaultStatus : 'pending',
 		};
 	} );
@@ -63,7 +65,7 @@ export function SaveButton() {
 		if ( isDisabled ) {
 			return;
 		}
-		if ( isPublished ) {
+		if ( isPublished || isUnlisted ) {
 			onSuccess();
 		} else {
 			setShowModal( true );
@@ -71,7 +73,10 @@ export function SaveButton() {
 	};
 
 	const onSuccess = () => {
-		editPost( { status: publishStatus }, { undoIgnore: true } );
+		// An unlisted pattern's status is the moderators' to change, so only save the content.
+		if ( ! isUnlisted ) {
+			editPost( { status: publishStatus }, { undoIgnore: true } );
+		}
 		savePost();
 	};
 
@@ -92,7 +97,7 @@ export function SaveButton() {
 				isBusy={ ! isAutoSaving && isSaving && isPublishedOrPending }
 				onClick={ isDisabled ? undefined : onClick }
 			>
-				{ isPublished ? __( 'Update', 'wporg-patterns' ) : __( 'Submit', 'wporg-patterns' ) }
+				{ isPublished || isUnlisted ? __( 'Update', 'wporg-patterns' ) : __( 'Submit', 'wporg-patterns' ) }
 			</Button>
 		</>
 	);

--- a/public_html/wp-content/plugins/pattern-creator/src/components/save-button/index.js
+++ b/public_html/wp-content/plugins/pattern-creator/src/components/save-button/index.js
@@ -29,7 +29,6 @@ export function SaveButton() {
 		isAutoSaving,
 		isSaveable,
 		isPublished,
-		isUnlisted,
 		isPublishedOrPending,
 		publishStatus,
 	} = useSelect( ( select ) => {
@@ -49,8 +48,7 @@ export function SaveButton() {
 			isAutoSaving: _isAutoSaving,
 			isSaveable: isPatternSaveable( getCurrentPostId() ),
 			isPublished: 'publish' === _post.status,
-			isUnlisted: 'unlisted' === _post.status,
-			isPublishedOrPending: [ 'pending', 'publish', 'unlisted' ].includes( _post.status ),
+			isPublishedOrPending: [ 'pending', 'publish' ].includes( _post.status ),
 			publishStatus: hasPublishAction ? settings.defaultStatus : 'pending',
 		};
 	} );
@@ -65,7 +63,7 @@ export function SaveButton() {
 		if ( isDisabled ) {
 			return;
 		}
-		if ( isPublished || isUnlisted ) {
+		if ( isPublished ) {
 			onSuccess();
 		} else {
 			setShowModal( true );
@@ -73,10 +71,7 @@ export function SaveButton() {
 	};
 
 	const onSuccess = () => {
-		// An unlisted pattern's status is the moderators' to change, so only save the content.
-		if ( ! isUnlisted ) {
-			editPost( { status: publishStatus }, { undoIgnore: true } );
-		}
+		editPost( { status: publishStatus }, { undoIgnore: true } );
 		savePost();
 	};
 
@@ -97,7 +92,7 @@ export function SaveButton() {
 				isBusy={ ! isAutoSaving && isSaving && isPublishedOrPending }
 				onClick={ isDisabled ? undefined : onClick }
 			>
-				{ isPublished || isUnlisted ? __( 'Update', 'wporg-patterns' ) : __( 'Submit', 'wporg-patterns' ) }
+				{ isPublished ? __( 'Update', 'wporg-patterns' ) : __( 'Submit', 'wporg-patterns' ) }
 			</Button>
 		</>
 	);

--- a/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/class-rest-flags-controller.php
@@ -78,7 +78,8 @@ class REST_Flags_Controller extends WP_REST_Posts_Controller {
 	public function get_items_permissions_check( $request ) {
 		$parent_post_type = get_post_type_object( PATTERN );
 
-		if ( ! current_user_can( $parent_post_type->cap->edit_posts ) ) {
+		// Flags name their reporter, so only moderators may list them.
+		if ( ! current_user_can( $parent_post_type->cap->edit_others_posts ) ) {
 			return new WP_Error(
 				'rest_forbidden_context',
 				__( 'Sorry, you are not allowed to view pattern flags.', 'wporg-patterns' ),
@@ -107,7 +108,10 @@ class REST_Flags_Controller extends WP_REST_Posts_Controller {
 			return $parent;
 		}
 
-		if ( ! current_user_can( 'edit_post', $parent->ID ) ) {
+		$parent_post_type = get_post_type_object( PATTERN );
+
+		// Flags name their reporter, so only moderators may read them.
+		if ( ! current_user_can( $parent_post_type->cap->edit_others_posts ) ) {
 			return new WP_Error(
 				'rest_cannot_read',
 				__( 'Sorry, you are not allowed to view flags for this pattern.', 'wporg-patterns' ),

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -103,9 +103,10 @@ function register_post_type_data() {
 			'rewrite'           => array(
 				'slug' => 'pattern-keywords',
 			),
+			// Keywords are moderator-only (the `core` term feeds Core's pattern distribution), unlike categories.
 			'capabilities' => array(
-				'assign_terms' => 'edit_patterns',
-				'edit_terms'   => 'edit_patterns',
+				'assign_terms' => 'edit_others_patterns',
+				'edit_terms'   => 'edit_others_patterns',
 			),
 
 			'labels' => array(

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -353,6 +353,15 @@ function validate_against_spam( $prepared_post, $request ) {
 		return $prepared_post;
 	}
 
+	/*
+	 * An autosave that names no status can't make anything public: the controller either files it as a
+	 * revision, throwing the verdict away, or updates the author's own draft while leaving its status alone.
+	 * One that does name a status can publish a draft in place, so it still gets checked.
+	 */
+	if ( ! isset( $request['status'] ) && '/autosaves' === substr( (string) $request->get_route(), -10 ) ) {
+		return $prepared_post;
+	}
+
 	// Moderators are trusted, the same way `validate_status()` trusts them.
 	if ( current_user_can( get_post_type_object( POST_TYPE )->cap->edit_others_posts ) ) {
 		return $prepared_post;
@@ -373,28 +382,42 @@ function validate_against_spam( $prepared_post, $request ) {
 	// If it's been detected as spam, flag it as pending-review.
 	if ( $is_spam ) {
 		$prepared_post->post_status = SPAM_STATUS;
-		spam_reason( $spam_reason );
+		spam_reason( $prepared_post->ID ?? 0, $spam_reason );
 	}
 
 	return $prepared_post;
 }
 
 /**
- * Hold the reason the pattern in this request was flagged as spam.
+ * Hold the reason a pattern was flagged as spam, until its status is actually saved.
  *
- * `validate_against_spam()` decides before anything is written, and the autosave route discards that decision
- * into a revision, so the note has to wait until a status is actually saved.
+ * `validate_against_spam()` decides before anything is written, and that decision can be discarded, so the
+ * note has to wait. Keyed by pattern because a single request can write more than one -- a `batch/v1`
+ * envelope, a WP-CLI import loop -- and one pattern's reason must not be noted against another. Reading
+ * consumes, so an unconsumed reason can't leak into a later write.
  *
- * @param string|null $reason Reason to store, or null to read back the stored one.
+ * @param int         $pattern_id The pattern the reason belongs to, 0 while it is still being created.
+ * @param string|null $reason     Reason to store, or null to read and consume the stored one.
  *
- * @return string The stored reason.
+ * @return string The stored reason, or '' if there isn't one for this pattern.
  */
-function spam_reason( $reason = null ) {
-	static $stored = '';
+function spam_reason( $pattern_id, $reason = null ) {
+	static $reasons = array();
+
+	$key = (int) $pattern_id;
 
 	if ( null !== $reason ) {
-		$stored = $reason;
+		$reasons[ $key ] = $reason;
+
+		return $reason;
 	}
+
+	if ( ! isset( $reasons[ $key ] ) ) {
+		return '';
+	}
+
+	$stored = $reasons[ $key ];
+	unset( $reasons[ $key ] );
 
 	return $stored;
 }
@@ -413,13 +436,16 @@ function note_spam_status( $new_status, $old_status, $post ) {
 		return;
 	}
 
-	$reason = spam_reason();
+	$reason = spam_reason( $post->ID );
+
+	// A pattern flagged as it was created had no ID to record against.
+	if ( ! $reason && in_array( $old_status, array( 'new', 'auto-draft' ), true ) ) {
+		$reason = spam_reason( 0 );
+	}
+
 	if ( ! $reason ) {
 		return;
 	}
-
-	// One note per decision, however many times the status is written.
-	spam_reason( '' );
 
 	if ( function_exists( '\WordPressdotorg\InternalNotes\create_note' ) ) {
 		\WordPressdotorg\InternalNotes\create_note(

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -379,8 +379,17 @@ function validate_against_spam( $prepared_post, $request ) {
 
 	list( $is_spam, $spam_reason ) = check_for_spam( $pattern );
 
-	// If it's been detected as spam, flag it as pending-review.
 	if ( $is_spam ) {
+		// Demoting a live pattern on a heuristic is unrecoverable for its author, so refuse the edit instead.
+		if ( 'publish' === $current_status ) {
+			return new \WP_Error(
+				'rest_pattern_spam_detected',
+				__( 'These changes were caught by the spam filter, so they have not been saved. The published version of this pattern is unchanged.', 'wporg-patterns' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Anything not yet public goes to the moderation queue as before.
 		$prepared_post->post_status = SPAM_STATUS;
 		spam_reason( $prepared_post->ID ?? 0, $spam_reason );
 	}

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -350,12 +350,7 @@ function validate_against_spam( $prepared_post, $request ) {
 		return $prepared_post;
 	}
 
-	/*
-	 * Autosaves reach this filter too, because the autosave controller builds its revision through the parent
-	 * controller's `prepare_item_for_database()`. They write a revision rather than the live pattern, and the
-	 * creator fires them continuously, so checking them costs an Akismet round trip per keystroke batch and
-	 * can attach a note to the published post for content that was never published.
-	 */
+	// Autosaves write a revision rather than the live pattern, and the creator fires them continuously.
 	if ( '/autosaves' === substr( (string) $request->get_route(), -10 ) ) {
 		return $prepared_post;
 	}

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -380,11 +380,11 @@ function validate_against_spam( $prepared_post, $request ) {
 	list( $is_spam, $spam_reason ) = check_for_spam( $pattern );
 
 	if ( $is_spam ) {
-		// Demoting a live pattern on a heuristic is unrecoverable for its author, so refuse the edit instead.
-		if ( 'publish' === $current_status ) {
+		// Demoting an existing pattern on a heuristic is unrecoverable for its author, so refuse the edit.
+		if ( in_array( $current_status, array( 'publish', 'pending' ), true ) ) {
 			return new \WP_Error(
 				'rest_pattern_spam_detected',
-				__( 'These changes were caught by the spam filter, so they have not been saved. The published version of this pattern is unchanged.', 'wporg-patterns' ),
+				__( 'These changes were caught by the spam filter, so they have not been saved. Your pattern is unchanged.', 'wporg-patterns' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -222,7 +222,7 @@ function validate_status( $prepared_post, $request ) {
 
 	$post_type      = get_post_type_object( POST_TYPE );
 	$target_status  = isset( $request['status'] ) ? $request['status'] : '';
-	$current_status = get_post_status( $prepared_post->ID ?? 0 );
+	$current_status = isset( $prepared_post->ID ) ? get_post_status( $prepared_post->ID ) : '';
 
 	// `unlisted` and spam are moderator-set; authors can't leave them. Must stay above the early returns below.
 	if (
@@ -347,6 +347,16 @@ function validate_against_spam( $prepared_post, $request ) {
 
 	// Only patterns that are, or are becoming, publicly visible are worth the check.
 	if ( 'publish' !== $target_status && 'pending' !== $target_status ) {
+		return $prepared_post;
+	}
+
+	/*
+	 * Autosaves reach this filter too, because the autosave controller builds its revision through the parent
+	 * controller's `prepare_item_for_database()`. They write a revision rather than the live pattern, and the
+	 * creator fires them continuously, so checking them costs an Akismet round trip per keystroke batch and
+	 * can attach a note to the published post for content that was never published.
+	 */
+	if ( '/autosaves' === substr( (string) $request->get_route(), -10 ) ) {
 		return $prepared_post;
 	}
 

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -11,6 +11,7 @@ add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_title', 1
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_status', 11, 2 );
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_parent', 11, 2 );
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_against_spam', 20, 2 );
+add_action( 'transition_post_status', __NAMESPACE__ . '\note_spam_status', 10, 3 );
 
 /**
  * Strip out basic HTML to get at the manually-entered content in block content.
@@ -372,20 +373,63 @@ function validate_against_spam( $prepared_post, $request ) {
 	// If it's been detected as spam, flag it as pending-review.
 	if ( $is_spam ) {
 		$prepared_post->post_status = SPAM_STATUS;
-
-		// Add a note explaining the spam flag; a create has no post to attach it to yet.
-		if ( isset( $prepared_post->ID ) && function_exists( '\WordPressdotorg\InternalNotes\create_note' ) ) {
-			\WordPressdotorg\InternalNotes\create_note(
-				$prepared_post->ID,
-				array(
-					'post_author'  => get_user_by( 'login', 'wordpressdotorg' )->ID ?? 0,
-					'post_excerpt' => $spam_reason,
-				)
-			);
-		}
+		spam_reason( $spam_reason );
 	}
 
 	return $prepared_post;
+}
+
+/**
+ * Hold the reason the pattern in this request was flagged as spam.
+ *
+ * `validate_against_spam()` decides before anything is written, and the autosave route discards that decision
+ * into a revision, so the note has to wait until a status is actually saved.
+ *
+ * @param string|null $reason Reason to store, or null to read back the stored one.
+ *
+ * @return string The stored reason.
+ */
+function spam_reason( $reason = null ) {
+	static $stored = '';
+
+	if ( null !== $reason ) {
+		$stored = $reason;
+	}
+
+	return $stored;
+}
+
+/**
+ * Record why a pattern was quarantined, once that status has actually been saved.
+ *
+ * @param string   $new_status The status the pattern moved to.
+ * @param string   $old_status The status it moved from.
+ * @param \WP_Post $post       The pattern.
+ *
+ * @return void
+ */
+function note_spam_status( $new_status, $old_status, $post ) {
+	if ( POST_TYPE !== $post->post_type || SPAM_STATUS !== $new_status || $new_status === $old_status ) {
+		return;
+	}
+
+	$reason = spam_reason();
+	if ( ! $reason ) {
+		return;
+	}
+
+	// One note per decision, however many times the status is written.
+	spam_reason( '' );
+
+	if ( function_exists( '\WordPressdotorg\InternalNotes\create_note' ) ) {
+		\WordPressdotorg\InternalNotes\create_note(
+			$post->ID,
+			array(
+				'post_author'  => get_user_by( 'login', 'wordpressdotorg' )->ID ?? 0,
+				'post_excerpt' => $reason,
+			)
+		);
+	}
 }
 
 /**

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -9,6 +9,7 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, UNLIS
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_content', 10, 2 );
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_title', 11, 2 );
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_status', 11, 2 );
+add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_parent', 11, 2 );
 add_filter( 'rest_pre_insert_' . POST_TYPE, __NAMESPACE__ . '\validate_against_spam', 20, 2 );
 
 /**
@@ -209,8 +210,10 @@ function validate_title( $prepared_post, $request ) {
 /**
  * Validate the pattern status.
  *
- * Ensures patterns created via the API have either a non-public status (draft, unlisted),
- * or they use the chosen status set in /wp-admin/options-general.php?page=wporg-pattern-creator.
+ * Ensures patterns created via the API are either drafts, or use the chosen status set in
+ * /wp-admin/options-general.php?page=wporg-pattern-creator. The `unlisted` and spam statuses
+ * are moderator-only, both as a target and as a source, so an author can neither self-unlist
+ * nor undo a moderator's removal.
  */
 function validate_status( $prepared_post, $request ) {
 	if ( is_wp_error( $prepared_post ) ) {
@@ -219,10 +222,24 @@ function validate_status( $prepared_post, $request ) {
 
 	$post_type      = get_post_type_object( POST_TYPE );
 	$target_status  = isset( $request['status'] ) ? $request['status'] : '';
-	$current_status = get_post_status( $prepared_post->ID );
+	$current_status = get_post_status( $prepared_post->ID ?? 0 );
 
-	// Drafts or unlisted patterns are OK.
-	if ( in_array( $target_status, array( 'draft', 'auto-draft', UNLISTED_STATUS ) ) ) {
+	// `unlisted` and spam are moderator-set; authors can't leave them. Must stay above the early returns below.
+	if (
+		in_array( $current_status, array( SPAM_STATUS, UNLISTED_STATUS ), true ) &&
+		'' !== $target_status &&
+		$current_status !== $target_status &&
+		! current_user_can( $post_type->cap->edit_others_posts )
+	) {
+		return new \WP_Error(
+			'rest_pattern_cannot_change_status',
+			__( 'Only a directory moderator can change the status of this pattern.', 'wporg-patterns' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	// Drafts are OK.
+	if ( in_array( $target_status, array( 'draft', 'auto-draft' ), true ) ) {
 		return $prepared_post;
 	}
 
@@ -251,14 +268,54 @@ function validate_status( $prepared_post, $request ) {
 		);
 	}
 
-	// Do not allow for non-privledged users to move a spam post to another status.
-	if ( SPAM_STATUS === $current_status && SPAM_STATUS !== $target_status ) {
+	return $prepared_post;
+}
+
+/**
+ * Validate the pattern's parent.
+ *
+ * `parent` links a translated pattern to its English original and is written only by the translation cron,
+ * never by a submitter. Core accepts it over REST because the field is in the schema, and validates only that
+ * the id names an existing post — not its type, and not the caller's relationship to it. Left open, an author
+ * can point their own submission at any published pattern and have the translation job adopt it.
+ *
+ * @param object           $prepared_post The post object about to be inserted.
+ * @param \WP_REST_Request $request       The request.
+ *
+ * @return object|\WP_Error The post object, or an error if the parent is not the caller's to set.
+ */
+function validate_parent( $prepared_post, $request ) {
+	if ( is_wp_error( $prepared_post ) ) {
+		return $prepared_post;
+	}
+
+	if ( ! isset( $request['parent'] ) ) {
+		return $prepared_post;
+	}
+
+	$existing       = isset( $prepared_post->ID ) ? get_post( $prepared_post->ID ) : null;
+	$current_parent = $existing ? (int) $existing->post_parent : 0;
+	$target_parent  = (int) $request['parent'];
+
+	// Re-sending the stored value isn't a write.
+	if ( $target_parent === $current_parent ) {
+		return $prepared_post;
+	}
+
+	$post_type = get_post_type_object( POST_TYPE );
+	if ( ! current_user_can( $post_type->cap->edit_others_posts ) ) {
 		return new \WP_Error(
-			'rest_pattern_invalid_status',
-			sprintf(
-				__( 'Invalid post status. Status must be %s.', 'wporg-patterns' ),
-				SPAM_STATUS
-			),
+			'rest_pattern_cannot_set_parent',
+			__( 'Only a directory moderator can set the parent of a pattern.', 'wporg-patterns' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	// A moderator's value still has to name another pattern.
+	if ( $target_parent && POST_TYPE !== get_post_type( $target_parent ) ) {
+		return new \WP_Error(
+			'rest_pattern_invalid_parent',
+			__( 'The parent of a pattern must be another pattern.', 'wporg-patterns' ),
 			array( 'status' => 400 )
 		);
 	}
@@ -274,23 +331,33 @@ function validate_against_spam( $prepared_post, $request ) {
 		return $prepared_post;
 	}
 
-	$target_status = isset( $request['status'] ) ? $request['status'] : '';
+	/*
+	 * `ID` is only set on an update: `WP_REST_Posts_Controller::prepare_item_for_database()` adds it when the
+	 * request names an existing post, so on a create there is no stored post to read a status from.
+	 */
+	$post           = isset( $prepared_post->ID ) ? get_post( $prepared_post->ID ) : null;
+	$current_status = $post ? $post->post_status : '';
 
-	// Run spam checks for publish & pending patterns.
+	/*
+	 * An update that omits `status` leaves the pattern at the status it already has, so resolve to that
+	 * rather than to nothing. Reading it as "no status" is what let an author publish clean content and then
+	 * swap in the real payload with a status-less edit that never reached Akismet.
+	 */
+	$target_status = isset( $request['status'] ) ? $request['status'] : $current_status;
+
+	// Only patterns that are, or are becoming, publicly visible are worth the check.
 	if ( 'publish' !== $target_status && 'pending' !== $target_status ) {
 		return $prepared_post;
 	}
 
-	$post = get_post( $prepared_post->ID );
-
 	$pattern = array(
-		'ID'          => $post->ID,
-		'post_name'   => $post->post_name,
-		'post_author' => $post->post_author,
-		'title'       => $prepared_post->post_title ?? $post->post_title,
-		'content'     => $prepared_post->post_content ?? $post->post_content,
-		'description' => $request['meta']['wpop_description'] ?? ( $post->wpop_description ?: '' ),
-		'keywords'    => $request['meta']['wpop_keywords'] ?? ( $post->wpop_keywords ?: '' ),
+		'ID'          => $post->ID ?? 0,
+		'post_name'   => $post->post_name ?? '',
+		'post_author' => $post->post_author ?? get_current_user_id(),
+		'title'       => $prepared_post->post_title ?? ( $post->post_title ?? '' ),
+		'content'     => $prepared_post->post_content ?? ( $post->post_content ?? '' ),
+		'description' => $request['meta']['wpop_description'] ?? ( $post ? ( $post->wpop_description ?: '' ) : '' ),
+		'keywords'    => $request['meta']['wpop_keywords'] ?? ( $post ? ( $post->wpop_keywords ?: '' ) : '' ),
 	);
 
 	list( $is_spam, $spam_reason ) = check_for_spam( $pattern );
@@ -299,8 +366,8 @@ function validate_against_spam( $prepared_post, $request ) {
 	if ( $is_spam ) {
 		$prepared_post->post_status = SPAM_STATUS;
 
-		// Add a note explaining why this post is in pending, if it's due to spam.
-		if ( function_exists( '\WordPressdotorg\InternalNotes\create_note' ) ) {
+		// Add a note explaining the spam flag; a create has no post to attach it to yet.
+		if ( isset( $prepared_post->ID ) && function_exists( '\WordPressdotorg\InternalNotes\create_note' ) ) {
 			\WordPressdotorg\InternalNotes\create_note(
 				$prepared_post->ID,
 				array(

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -179,13 +179,15 @@ function validate_title( $prepared_post, $request ) {
 		return $prepared_post;
 	}
 
-	$status = isset( $request['status'] ) ? $request['status'] : get_post_status( $prepared_post->ID );
+	$post   = isset( $prepared_post->ID ) ? get_post( $prepared_post->ID ) : null;
+	$status = isset( $request['status'] ) ? $request['status'] : ( $post ? $post->post_status : '' );
+
 	// Bypass this validation for drafts.
 	if ( 'draft' === $status || 'auto-draft' === $status ) {
 		return $prepared_post;
 	}
 
-	$title = isset( $request['title'] ) ? $request['title'] : get_the_title( $prepared_post->ID );
+	$title = isset( $request['title'] ) ? $request['title'] : ( $post ? $post->post_title : '' );
 
 	// A title exists, but is empty -- invalid.
 	if ( isset( $title ) && empty( trim( $title ) ) ) {
@@ -350,8 +352,8 @@ function validate_against_spam( $prepared_post, $request ) {
 		return $prepared_post;
 	}
 
-	// Autosaves write a revision rather than the live pattern, and the creator fires them continuously.
-	if ( '/autosaves' === substr( (string) $request->get_route(), -10 ) ) {
+	// Moderators are trusted, the same way `validate_status()` trusts them.
+	if ( current_user_can( get_post_type_object( POST_TYPE )->cap->edit_others_posts ) ) {
 		return $prepared_post;
 	}
 

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/flag-permissions-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/flag-permissions-test.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Test access control on the pattern-flag REST routes.
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\Pattern_Directory\Tests;
+
+use WP_REST_Request;
+use WP_UnitTestCase;
+use WP_UnitTest_Factory;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG_POST_TYPE;
+
+/**
+ * Pattern flags are abuse reports, carrying who reported a pattern and why; only moderators may read them.
+ * `edit_patterns` is granted to every logged-in user by `set_pattern_caps()` and `edit_post` on the parent is
+ * true for the pattern's own author, so both routes must gate on `edit_others_patterns` instead.
+ *
+ * @group pattern-flags
+ */
+class Flag_Permissions_Test extends WP_UnitTestCase {
+	/**
+	 * A moderator: holds `edit_others_patterns`.
+	 *
+	 * @var int
+	 */
+	protected static $moderator;
+
+	/**
+	 * A directory member: gets `edit_patterns` via `set_pattern_caps()`, but not `edit_others_patterns`.
+	 *
+	 * @var int
+	 */
+	protected static $member;
+
+	/**
+	 * A published pattern that the flag is filed against.
+	 *
+	 * @var int
+	 */
+	protected static $pattern_id;
+
+	/**
+	 * A pending abuse report filed against the pattern.
+	 *
+	 * @var int
+	 */
+	protected static $flag_id;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		self::$moderator = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$member    = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		self::$pattern_id = $factory->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_author' => self::$member,
+				'post_status' => 'publish',
+			)
+		);
+
+		self::$flag_id = $factory->post->create(
+			array(
+				'post_type'    => FLAG_POST_TYPE,
+				'post_status'  => 'pending',
+				'post_parent'  => self::$pattern_id,
+				'post_excerpt' => 'PRIVATE-REPORT-CANARY',
+			)
+		);
+	}
+
+	/**
+	 * Clean up shared fixtures.
+	 */
+	public static function tear_down_after_class(): void {
+		wp_delete_post( self::$flag_id, true );
+		wp_delete_post( self::$pattern_id, true );
+		wp_delete_user( self::$moderator );
+		wp_delete_user( self::$member );
+
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Reset the current user between tests.
+	 */
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Dispatch a GET against the flag collection with the given query string.
+	 *
+	 * @param string $query Optional query string, without the leading `?`.
+	 * @return \WP_REST_Response
+	 */
+	protected function list_flags( string $query = '' ): \WP_REST_Response {
+		$route   = '/wp/v2/' . FLAG_POST_TYPE;
+		$request = new WP_REST_Request( 'GET', $route );
+		if ( $query ) {
+			$request->set_query_params( wp_parse_args( $query ) );
+		}
+
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * A member without `edit_others_patterns` cannot list flags.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\REST_Flags_Controller::get_items_permissions_check
+	 */
+	public function test_member_cannot_list_flags(): void {
+		wp_set_current_user( self::$member );
+
+		$response = $this->list_flags();
+
+		$this->assertTrue( $response->is_error(), 'A member should not be able to list flags.' );
+		$this->assertSame( 'rest_forbidden_context', $response->get_data()['code'] );
+	}
+
+	/**
+	 * A logged-out request cannot list flags.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\REST_Flags_Controller::get_items_permissions_check
+	 */
+	public function test_logged_out_cannot_list_flags(): void {
+		$response = $this->list_flags();
+
+		$this->assertTrue( $response->is_error(), 'A logged-out request should not be able to list flags.' );
+		$this->assertSame( 'rest_forbidden_context', $response->get_data()['code'] );
+	}
+
+	/**
+	 * The count header is not leaked to a member: the request is refused before any total is computed.
+	 *
+	 * This closes the `X-WP-Total` oracle that let a member probe the hidden moderation queue with
+	 * `?parent=`, `?author=`, `?search=`, etc.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\REST_Flags_Controller::get_items_permissions_check
+	 */
+	public function test_member_cannot_probe_flag_count(): void {
+		wp_set_current_user( self::$member );
+
+		$response = $this->list_flags( 'parent[]=' . self::$pattern_id );
+
+		$this->assertTrue( $response->is_error(), 'A member should not be able to probe the flag count.' );
+		$this->assertArrayNotHasKey( 'X-WP-Total', $response->get_headers() );
+	}
+
+	/**
+	 * A moderator can list flags.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\REST_Flags_Controller::get_items_permissions_check
+	 */
+	public function test_moderator_can_list_flags(): void {
+		wp_set_current_user( self::$moderator );
+
+		$response = $this->list_flags();
+
+		$this->assertFalse( $response->is_error(), 'A moderator should be able to list flags.' );
+		$this->assertSame( array( self::$flag_id ), wp_list_pluck( $response->get_data(), 'id' ) );
+	}
+
+	/**
+	 * Dispatch a GET for the single flag.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function read_flag(): \WP_REST_Response {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/' . FLAG_POST_TYPE . '/' . self::$flag_id );
+
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * The reported pattern's own author cannot read the report filed against it.
+	 *
+	 * `edit_post` on the parent is true for its author, so the single-item route used to admit them; core's
+	 * `check_read_permission()` denied the row only because the flag post type falls back to the generic
+	 * `post` caps, which is incidental rather than intentional.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\REST_Flags_Controller::get_item_permissions_check
+	 */
+	public function test_pattern_author_cannot_read_flag_on_own_pattern(): void {
+		wp_set_current_user( self::$member );
+
+		$response = $this->read_flag();
+
+		$this->assertTrue( $response->is_error(), 'A pattern author should not be able to read its flags.' );
+		$this->assertSame( 'rest_cannot_read', $response->get_data()['code'] );
+		$this->assertStringNotContainsString( 'PRIVATE-REPORT-CANARY', wp_json_encode( $response->get_data() ) );
+	}
+
+	/**
+	 * A logged-out request cannot read a flag.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\REST_Flags_Controller::get_item_permissions_check
+	 */
+	public function test_logged_out_cannot_read_flag(): void {
+		$response = $this->read_flag();
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertSame( 'rest_cannot_read', $response->get_data()['code'] );
+	}
+
+	/**
+	 * A moderator can read the flag, including the reporter's free text.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\REST_Flags_Controller::get_item_permissions_check
+	 */
+	public function test_moderator_can_read_flag(): void {
+		wp_set_current_user( self::$moderator );
+
+		$response = $this->read_flag();
+
+		$this->assertFalse( $response->is_error(), 'A moderator should be able to read a flag.' );
+		$this->assertSame( self::$flag_id, $response->get_data()['id'] );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/keyword-assignment-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/keyword-assignment-test.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Test access control on assigning the internal pattern-keyword taxonomy.
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\Pattern_Directory\Tests;
+
+use WP_REST_Request;
+use WP_UnitTestCase;
+use WP_UnitTest_Factory;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+
+/**
+ * The `wporg-pattern-keyword` taxonomy is internal: its `core` term feeds WordPress Core's remote pattern
+ * distribution, so only moderators may assign it. Categories stay author-assignable.
+ *
+ * @group pattern-keywords
+ */
+class Keyword_Assignment_Test extends WP_UnitTestCase {
+	/**
+	 * A moderator: holds `edit_others_patterns`.
+	 *
+	 * @var int
+	 */
+	protected static $moderator;
+
+	/**
+	 * The pattern's author: a directory member with no moderator capability.
+	 *
+	 * @var int
+	 */
+	protected static $member;
+
+	/**
+	 * The member's own pattern.
+	 *
+	 * @var int
+	 */
+	protected static $pattern_id;
+
+	/**
+	 * The privileged `core` keyword term.
+	 *
+	 * @var int
+	 */
+	protected static $core_term_id;
+
+	/**
+	 * An ordinary, author-assignable category term.
+	 *
+	 * @var int
+	 */
+	protected static $category_term_id;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		self::$moderator = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$member    = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		self::$pattern_id = $factory->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_author' => self::$member,
+				'post_status' => 'draft',
+			)
+		);
+
+		self::$core_term_id = $factory->term->create(
+			array(
+				'taxonomy' => 'wporg-pattern-keyword',
+				'name'     => 'core',
+				'slug'     => 'core',
+			)
+		);
+		self::$category_term_id = $factory->term->create(
+			array(
+				'taxonomy' => 'wporg-pattern-category',
+				'name'     => 'Headers',
+			)
+		);
+	}
+
+	/**
+	 * Clean up shared fixtures.
+	 */
+	public static function tear_down_after_class(): void {
+		wp_delete_post( self::$pattern_id, true );
+		wp_delete_term( self::$core_term_id, 'wporg-pattern-keyword' );
+		wp_delete_term( self::$category_term_id, 'wporg-pattern-category' );
+		wp_delete_user( self::$moderator );
+		wp_delete_user( self::$member );
+
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Detach any assigned terms and reset the current user between tests.
+	 */
+	public function tear_down(): void {
+		wp_delete_object_term_relationships(
+			self::$pattern_id,
+			array( 'wporg-pattern-keyword', 'wporg-pattern-category' )
+		);
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Dispatch a pattern update with the given body.
+	 *
+	 * @param array $body Request body.
+	 * @return \WP_REST_Response
+	 */
+	protected function update_pattern( array $body ): \WP_REST_Response {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE . '/' . self::$pattern_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $body ) );
+
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * Whether the pattern currently carries the given term.
+	 *
+	 * @param int    $term_id  Term ID.
+	 * @param string $taxonomy Taxonomy.
+	 * @return bool
+	 */
+	protected function pattern_has_term( int $term_id, string $taxonomy ): bool {
+		$term_ids = wp_get_object_terms( self::$pattern_id, $taxonomy, array( 'fields' => 'ids' ) );
+
+		return in_array( $term_id, $term_ids, true );
+	}
+
+	/**
+	 * A member cannot assign the `core` keyword to their own pattern.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\register_post_type_data
+	 */
+	public function test_member_cannot_assign_core_keyword(): void {
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'pattern-keywords' => array( self::$core_term_id ) ) );
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertSame( 'rest_cannot_assign_term', $response->get_data()['code'] );
+		$this->assertFalse( $this->pattern_has_term( self::$core_term_id, 'wporg-pattern-keyword' ) );
+	}
+
+	/**
+	 * A moderator can assign the `core` keyword.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\register_post_type_data
+	 */
+	public function test_moderator_can_assign_core_keyword(): void {
+		wp_set_current_user( self::$moderator );
+
+		$response = $this->update_pattern( array( 'pattern-keywords' => array( self::$core_term_id ) ) );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertTrue( $this->pattern_has_term( self::$core_term_id, 'wporg-pattern-keyword' ) );
+	}
+
+	/**
+	 * A member can still assign an ordinary category to their own pattern.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Post_Type\register_post_type_data
+	 */
+	public function test_member_can_assign_category(): void {
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'pattern-categories' => array( self::$category_term_id ) ) );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertTrue( $this->pattern_has_term( self::$category_term_id, 'wporg-pattern-category' ) );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/keyword-assignment-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/keyword-assignment-test.php
@@ -71,7 +71,7 @@ class Keyword_Assignment_Test extends WP_UnitTestCase {
 			)
 		);
 
-		self::$core_term_id = $factory->term->create(
+		self::$core_term_id     = $factory->term->create(
 			array(
 				'taxonomy' => 'wporg-pattern-keyword',
 				'name'     => 'core',

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -13,8 +13,6 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, SPAM_
 class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	protected static $pattern_id;
 	protected static $user;
-	protected static $member;
-	protected static $member_pattern;
 
 	/**
 	 * Setup fixtures that are shared across all tests.
@@ -29,16 +27,6 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 		self::$user = $factory->user->create(
 			array(
 				'role' => 'administrator',
-			)
-		);
-
-		// Spam checks exempt moderators, so exercise them as a member acting on their own pattern.
-		self::$member         = $factory->user->create( array( 'role' => 'subscriber' ) );
-		self::$member_pattern = $factory->post->create(
-			array(
-				'post_title'  => 'Member pattern',
-				'post_type'   => POST_TYPE,
-				'post_author' => self::$member,
 			)
 		);
 	}
@@ -152,9 +140,18 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	 * Test a block that's detected as spam should be pending.
 	 */
 	public function test_spam_should_be_pending() {
-		wp_set_current_user( self::$member );
+		// Spam checks exempt moderators, so act as a member on their own pattern.
+		$member         = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$member_pattern = self::factory()->post->create(
+			array(
+				'post_title'  => 'Member pattern',
+				'post_type'   => POST_TYPE,
+				'post_author' => $member,
+			)
+		);
+		wp_set_current_user( $member );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$member_pattern );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . $member_pattern );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( array(
 			'title'   => 'Spam Check',
@@ -173,9 +170,18 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	 * Test that paragraph-only posts should be detected as spam.
 	 */
 	public function test_only_paragraphs_are_spam() {
-		wp_set_current_user( self::$member );
+		// Spam checks exempt moderators, so act as a member on their own pattern.
+		$member         = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$member_pattern = self::factory()->post->create(
+			array(
+				'post_title'  => 'Member pattern',
+				'post_type'   => POST_TYPE,
+				'post_author' => $member,
+			)
+		);
+		wp_set_current_user( $member );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$member_pattern );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . $member_pattern );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( array(
 			'title'   => 'Spam Check',

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -13,6 +13,8 @@ use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, SPAM_
 class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	protected static $pattern_id;
 	protected static $user;
+	protected static $member;
+	protected static $member_pattern;
 
 	/**
 	 * Setup fixtures that are shared across all tests.
@@ -27,6 +29,16 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 		self::$user = $factory->user->create(
 			array(
 				'role' => 'administrator',
+			)
+		);
+
+		// Spam checks exempt moderators, so exercise them as a member acting on their own pattern.
+		self::$member         = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$member_pattern = $factory->post->create(
+			array(
+				'post_title'  => 'Member pattern',
+				'post_type'   => POST_TYPE,
+				'post_author' => self::$member,
 			)
 		);
 	}
@@ -140,9 +152,9 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	 * Test a block that's detected as spam should be pending.
 	 */
 	public function test_spam_should_be_pending() {
-		wp_set_current_user( self::$user );
+		wp_set_current_user( self::$member );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$member_pattern );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( array(
 			'title'   => 'Spam Check',
@@ -161,9 +173,9 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 	 * Test that paragraph-only posts should be detected as spam.
 	 */
 	public function test_only_paragraphs_are_spam() {
-		wp_set_current_user( self::$user );
+		wp_set_current_user( self::$member );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$pattern_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/wporg-pattern/' . self::$member_pattern );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( array(
 			'title'   => 'Spam Check',

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-content-validation-test.php
@@ -147,6 +147,7 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 				'post_title'  => 'Member pattern',
 				'post_type'   => POST_TYPE,
 				'post_author' => $member,
+				'post_status' => 'draft',
 			)
 		);
 		wp_set_current_user( $member );
@@ -177,6 +178,7 @@ class Pattern_Content_Validation_Test extends WP_UnitTestCase {
 				'post_title'  => 'Member pattern',
 				'post_type'   => POST_TYPE,
 				'post_author' => $member,
+				'post_status' => 'draft',
 			)
 		);
 		wp_set_current_user( $member );

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-parent-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-parent-validation-test.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Test that a pattern's parent can only be set by a moderator.
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\Pattern_Directory\Tests;
+
+use WP_REST_Request;
+use WP_UnitTestCase;
+use WP_UnitTest_Factory;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+
+/**
+ * `parent` links a translated pattern to its English original. Core accepts it over REST because the field is
+ * in the schema and validates only that the id names an existing post, which let an author point their own
+ * submission at any published pattern for the translation job to adopt.
+ *
+ * @group pattern-parent-validation
+ */
+class Pattern_Parent_Validation_Test extends WP_UnitTestCase {
+	/**
+	 * A moderator: holds `edit_others_patterns`.
+	 *
+	 * @var int
+	 */
+	protected static $moderator;
+
+	/**
+	 * The attacking pattern's author: a directory member with no moderator capability.
+	 *
+	 * @var int
+	 */
+	protected static $member;
+
+	/**
+	 * The member's own pattern, the one whose `parent` each test tries to set.
+	 *
+	 * @var int
+	 */
+	protected static $pattern_id;
+
+	/**
+	 * An unrelated published pattern by another author -- the adoption target.
+	 *
+	 * @var int
+	 */
+	protected static $victim_pattern_id;
+
+	/**
+	 * An ordinary post, to check a moderator's value is still type-checked.
+	 *
+	 * @var int
+	 */
+	protected static $unrelated_post_id;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		self::$moderator = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$member    = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		self::$pattern_id = $factory->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_author' => self::$member,
+				'post_title'  => 'A members own pattern',
+				'post_status' => 'draft',
+			)
+		);
+
+		self::$victim_pattern_id = $factory->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_author' => self::$moderator,
+				'post_title'  => 'A published pattern by someone else',
+				'post_status' => 'publish',
+			)
+		);
+
+		self::$unrelated_post_id = $factory->post->create( array( 'post_type' => 'post' ) );
+	}
+
+	/**
+	 * Clean up shared fixtures.
+	 */
+	public static function tear_down_after_class(): void {
+		wp_delete_post( self::$pattern_id, true );
+		wp_delete_post( self::$victim_pattern_id, true );
+		wp_delete_post( self::$unrelated_post_id, true );
+		wp_delete_user( self::$moderator );
+		wp_delete_user( self::$member );
+
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Detach any parent set by a test, and reset the current user.
+	 */
+	public function tear_down(): void {
+		wp_update_post(
+			array(
+				'ID'          => self::$pattern_id,
+				'post_parent' => 0,
+			)
+		);
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Dispatch a pattern update with the given body.
+	 *
+	 * @param array $body Request body.
+	 * @return \WP_REST_Response
+	 */
+	protected function update_pattern( array $body ): \WP_REST_Response {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE . '/' . self::$pattern_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $body ) );
+
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * A member cannot point their own pattern at someone else's published pattern.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_parent
+	 */
+	public function test_member_cannot_set_parent(): void {
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'parent' => self::$victim_pattern_id ) );
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertSame( 'rest_pattern_cannot_set_parent', $response->get_data()['code'] );
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 0, get_post( self::$pattern_id )->post_parent );
+	}
+
+	/**
+	 * A moderator can set the parent, which is how a genuine translation is linked.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_parent
+	 */
+	public function test_moderator_can_set_parent(): void {
+		wp_set_current_user( self::$moderator );
+
+		$response = $this->update_pattern( array( 'parent' => self::$victim_pattern_id ) );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertSame( self::$victim_pattern_id, get_post( self::$pattern_id )->post_parent );
+	}
+
+	/**
+	 * Even a moderator's value has to name another pattern, not an arbitrary post.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_parent
+	 */
+	public function test_moderator_cannot_set_a_non_pattern_parent(): void {
+		wp_set_current_user( self::$moderator );
+
+		$response = $this->update_pattern( array( 'parent' => self::$unrelated_post_id ) );
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertSame( 'rest_pattern_invalid_parent', $response->get_data()['code'] );
+		$this->assertSame( 0, get_post( self::$pattern_id )->post_parent );
+	}
+
+	/**
+	 * Echoing back the stored value is not a write, so an ordinary round-trip edit still succeeds.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_parent
+	 */
+	public function test_member_can_resend_the_unchanged_parent(): void {
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'parent' => 0 ) );
+
+		$this->assertFalse( $response->is_error() );
+	}
+
+	/**
+	 * An update that doesn't mention `parent` is untouched by the check.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_parent
+	 */
+	public function test_update_without_parent_is_unaffected(): void {
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'title' => 'A renamed pattern' ) );
+
+		$this->assertFalse( $response->is_error() );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
@@ -248,36 +248,40 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Autosaves reach this filter through the autosave controller, but write a revision rather than the live
-	 * pattern. Checking them would cost an Akismet round trip per autosave cycle.
+	 * The autosave route is not a way around the spam check. For a draft the author owns, the autosave
+	 * controller writes the live post rather than a revision, and it accepts `status`.
 	 *
 	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
 	 */
-	public function test_autosave_is_not_spam_checked(): void {
-		$this->seed_pattern( 'publish' );
+	public function test_autosave_cannot_bypass_spam_check(): void {
+		$this->seed_pattern( 'draft' );
 		wp_set_current_user( self::$member );
-
-		/*
-		 * An autosave writes a revision, so the live pattern's status is unchanged either way. Watch what
-		 * `validate_against_spam()` did to the prepared post instead, by running straight after it.
-		 */
-		$prepared_status = null;
-		$spy             = function ( $prepared_post ) use ( &$prepared_status ) {
-			$prepared_status = $prepared_post->post_status ?? '';
-			return $prepared_post;
-		};
-		add_filter( 'rest_pre_insert_' . POST_TYPE, $spy, 21 );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE . '/' . self::$pattern_id . '/autosaves' );
 		$request->set_header( 'content-type', 'application/json' );
-		$request->set_body( wp_json_encode( array( 'content' => self::$spam_content ) ) );
+		$request->set_body( wp_json_encode( array(
+			'status' => 'publish', 'content' => self::$spam_content,
+		) ) );
 		$response = rest_do_request( $request );
 
-		remove_filter( 'rest_pre_insert_' . POST_TYPE, $spy, 21 );
+		$this->assertFalse( $response->is_error() );
+		$this->assertSame( SPAM_STATUS, get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * A moderator's edit is not spam-checked, so a false positive can't silently unpublish an approved
+	 * pattern they were in the middle of correcting.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
+	 */
+	public function test_moderator_edit_does_not_restatus_a_live_pattern(): void {
+		$this->seed_pattern( 'publish', self::$spam_content );
+		wp_set_current_user( self::$moderator );
+
+		$response = $this->update_pattern( array( 'title' => 'A corrected title' ) );
 
 		$this->assertFalse( $response->is_error() );
-		$this->assertNotNull( $prepared_status, 'The autosave must reach the filter for this to prove anything.' );
-		$this->assertNotSame( SPAM_STATUS, $prepared_status, 'The autosave must not be run through the spam check.' );
+		$this->assertSame( 'publish', get_post_status( self::$pattern_id ) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
@@ -283,6 +283,23 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The same holds for a pattern still awaiting review: a false positive must not strand it in the spam
+	 * queue, which its author can't get it out of.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
+	 */
+	public function test_pending_pattern_is_not_demoted_by_an_edit(): void {
+		$this->seed_pattern( 'pending' );
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'content' => self::$spam_content ) );
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertSame( 'rest_pattern_spam_detected', $response->get_data()['code'] );
+		$this->assertSame( 'pending', get_post_status( self::$pattern_id ) );
+	}
+
+	/**
 	 * A status-less edit with clean content leaves a published pattern published.
 	 *
 	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
@@ -350,7 +367,16 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\note_spam_status
 	 */
 	public function test_discarded_spam_verdict_is_not_noted(): void {
-		$this->seed_pattern( 'pending' );
+		$this->seed_pattern( 'draft' );
+
+		/*
+		 * A lock held by someone else -- a moderator with the draft open -- makes the controller file the
+		 * write as a revision instead of updating the post, so the verdict it reaches is thrown away.
+		 */
+		wp_set_current_user( self::$moderator );
+		require_once ABSPATH . 'wp-admin/includes/post.php';
+		wp_set_post_lock( self::$pattern_id );
+
 		wp_set_current_user( self::$member );
 
 		$flagged     = null;
@@ -380,7 +406,7 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 
 		$this->assertSame( SPAM_STATUS, $flagged, 'This case must reach the spam check, or it proves nothing.' );
 		$this->assertSame( 0, $transitions, 'A discarded verdict must not be noted against the pattern.' );
-		$this->assertSame( 'pending', get_post_status( self::$pattern_id ) );
+		$this->assertSame( 'draft', get_post_status( self::$pattern_id ) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
@@ -248,6 +248,39 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Autosaves reach this filter through the autosave controller, but write a revision rather than the live
+	 * pattern. Checking them would cost an Akismet round trip per autosave cycle.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
+	 */
+	public function test_autosave_is_not_spam_checked(): void {
+		$this->seed_pattern( 'publish' );
+		wp_set_current_user( self::$member );
+
+		/*
+		 * An autosave writes a revision, so the live pattern's status is unchanged either way. Watch what
+		 * `validate_against_spam()` did to the prepared post instead, by running straight after it.
+		 */
+		$prepared_status = null;
+		$spy             = function ( $prepared_post ) use ( &$prepared_status ) {
+			$prepared_status = $prepared_post->post_status ?? '';
+			return $prepared_post;
+		};
+		add_filter( 'rest_pre_insert_' . POST_TYPE, $spy, 21 );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE . '/' . self::$pattern_id . '/autosaves' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'content' => self::$spam_content ) ) );
+		$response = rest_do_request( $request );
+
+		remove_filter( 'rest_pre_insert_' . POST_TYPE, $spy, 21 );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertNotNull( $prepared_status, 'The autosave must reach the filter for this to prove anything.' );
+		$this->assertNotSame( SPAM_STATUS, $prepared_status, 'The autosave must not be run through the spam check.' );
+	}
+
+	/**
 	 * A draft is not spam-checked, so the creator's autosaves don't each cost an Akismet round trip and a
 	 * work-in-progress draft can't be moved into the moderator-only quarantine while it's being written.
 	 *

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
@@ -252,8 +252,34 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 
 		$response = $this->update_pattern( array( 'content' => self::$spam_content ) );
 
+		$this->assertTrue( $response->is_error(), 'The swapped-in content must not be saved.' );
+		$this->assertSame( 'rest_pattern_spam_detected', $response->get_data()['code'] );
+		$this->assertSame( 'publish', get_post_status( self::$pattern_id ) );
+		$this->assertStringNotContainsString(
+			'PatternDirectorySpamTest',
+			get_post( self::$pattern_id )->post_content,
+			'The swapped-in content must not reach the published pattern.'
+		);
+	}
+
+	/**
+	 * A false positive on a live pattern doesn't strand its author: the edit is refused, the pattern stays
+	 * published, and they can still take it to draft and work on it.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
+	 */
+	public function test_refused_edit_leaves_the_author_in_control(): void {
+		$this->seed_pattern( 'publish' );
+		wp_set_current_user( self::$member );
+
+		$this->update_pattern( array( 'content' => self::$spam_content ) );
+		$this->assertSame( 'publish', get_post_status( self::$pattern_id ) );
+
+		// The author can still unpublish it themselves, which a demotion to the spam status would prevent.
+		$response = $this->update_pattern( array( 'status' => 'draft' ) );
+
 		$this->assertFalse( $response->is_error() );
-		$this->assertSame( SPAM_STATUS, get_post_status( self::$pattern_id ) );
+		$this->assertSame( 'draft', get_post_status( self::$pattern_id ) );
 	}
 
 	/**
@@ -324,7 +350,7 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\note_spam_status
 	 */
 	public function test_discarded_spam_verdict_is_not_noted(): void {
-		$this->seed_pattern( 'publish' );
+		$this->seed_pattern( 'pending' );
 		wp_set_current_user( self::$member );
 
 		$flagged     = null;
@@ -354,7 +380,7 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 
 		$this->assertSame( SPAM_STATUS, $flagged, 'This case must reach the spam check, or it proves nothing.' );
 		$this->assertSame( 0, $transitions, 'A discarded verdict must not be noted against the pattern.' );
-		$this->assertSame( 'publish', get_post_status( self::$pattern_id ) );
+		$this->assertSame( 'pending', get_post_status( self::$pattern_id ) );
 	}
 
 	/**
@@ -363,12 +389,12 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\note_spam_status
 	 */
 	public function test_persisted_spam_status_is_noted(): void {
-		$this->seed_pattern( 'publish' );
+		$this->seed_pattern( 'draft', self::$spam_content );
 		wp_set_current_user( self::$member );
 
 		$transitions = $this->count_spam_transitions(
 			function () {
-				$this->update_pattern( array( 'content' => self::$spam_content ) );
+				$this->update_pattern( array( 'status' => 'publish' ) );
 			}
 		);
 

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Test moderation-related pattern status validation.
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\Pattern_Directory\Tests;
+
+use WP_REST_Request;
+use WP_UnitTestCase;
+use WP_UnitTest_Factory;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, UNLISTED_STATUS, SPAM_STATUS };
+
+/**
+ * A member cannot move their own pattern out of a moderator-set status (`unlisted`, spam), directly or by
+ * hopping through another status, and a status-less content edit is still re-checked for spam.
+ *
+ * @group pattern-status-validation
+ */
+class Pattern_Status_Validation_Test extends WP_UnitTestCase {
+	/**
+	 * A moderator: holds `edit_others_patterns`.
+	 *
+	 * @var int
+	 */
+	protected static $moderator;
+
+	/**
+	 * The pattern's author: a directory member with no moderator capability.
+	 *
+	 * @var int
+	 */
+	protected static $member;
+
+	/**
+	 * The member's pattern, whose status each test drives.
+	 *
+	 * @var int
+	 */
+	protected static $pattern_id;
+
+	/**
+	 * Three non-empty, non-paragraph-only blocks: passes content validation and reads as clean.
+	 *
+	 * @var string
+	 */
+	protected static $clean_content;
+
+	/**
+	 * The same shape, carrying the deterministic spam trigger word.
+	 *
+	 * @var string
+	 */
+	protected static $spam_content;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		self::$moderator = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$member    = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		// Blocks are separated by "\n\n" because `validate_content()` strips that sequence; a single "\n"
+		// would survive as an invalid freeform block.
+		self::$clean_content =
+			"<!-- wp:heading --><h2>A curated layout</h2><!-- /wp:heading -->\n\n" .
+			"<!-- wp:paragraph --><p>Some descriptive copy for the pattern.</p><!-- /wp:paragraph -->\n\n" .
+			'<!-- wp:separator --><hr class="wp-block-separator"/><!-- /wp:separator -->';
+
+		self::$spam_content =
+			"<!-- wp:heading --><h2>A curated layout</h2><!-- /wp:heading -->\n\n" .
+			"<!-- wp:paragraph --><p>PatternDirectorySpamTest buy cheap pills.</p><!-- /wp:paragraph -->\n\n" .
+			'<!-- wp:separator --><hr class="wp-block-separator"/><!-- /wp:separator -->';
+
+		self::$pattern_id = $factory->post->create(
+			array(
+				'post_type'    => POST_TYPE,
+				'post_author'  => self::$member,
+				'post_title'   => 'Stylized Quote and Citation',
+				'post_content' => self::$clean_content,
+				'post_status'  => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * Clean up shared fixtures.
+	 */
+	public static function tear_down_after_class(): void {
+		wp_delete_post( self::$pattern_id, true );
+		wp_delete_user( self::$moderator );
+		wp_delete_user( self::$member );
+
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Reset the current user between tests.
+	 */
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Put the shared pattern into a known state before a test drives it.
+	 *
+	 * @param string $status  Status to set.
+	 * @param string $content Optional content to set.
+	 */
+	protected function seed_pattern( string $status, string $content = '' ): void {
+		wp_update_post(
+			array(
+				'ID'           => self::$pattern_id,
+				'post_status'  => $status,
+				'post_content' => $content ?: self::$clean_content,
+			)
+		);
+	}
+
+	/**
+	 * Dispatch a pattern update with the given body.
+	 *
+	 * @param array $body Request body.
+	 * @return \WP_REST_Response
+	 */
+	protected function update_pattern( array $body ): \WP_REST_Response {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE . '/' . self::$pattern_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $body ) );
+
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * A member cannot relist a pattern a moderator unlisted.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_status
+	 */
+	public function test_member_cannot_relist_unlisted_pattern(): void {
+		$this->seed_pattern( UNLISTED_STATUS );
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'status' => 'publish' ) );
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertSame( 'rest_pattern_cannot_change_status', $response->get_data()['code'] );
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( UNLISTED_STATUS, get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * A member cannot walk a spam pattern out of quarantine via `unlisted` (the two-hop bypass).
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_status
+	 */
+	public function test_member_cannot_move_spam_pattern_to_unlisted(): void {
+		$this->seed_pattern( SPAM_STATUS );
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'status' => UNLISTED_STATUS ) );
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertSame( 'rest_pattern_cannot_change_status', $response->get_data()['code'] );
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( SPAM_STATUS, get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * A member cannot publish a spam pattern directly (the guard that already worked).
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_status
+	 */
+	public function test_member_cannot_publish_spam_pattern(): void {
+		$this->seed_pattern( SPAM_STATUS );
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'status' => 'publish' ) );
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertSame( 'rest_pattern_cannot_change_status', $response->get_data()['code'] );
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( SPAM_STATUS, get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * A moderator can relist an unlisted pattern.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_status
+	 */
+	public function test_moderator_can_relist_unlisted_pattern(): void {
+		$this->seed_pattern( UNLISTED_STATUS );
+		wp_set_current_user( self::$moderator );
+
+		$response = $this->update_pattern( array( 'status' => 'publish' ) );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertSame( 'publish', get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * A member can still publish their own draft, the ordinary submission flow.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_status
+	 */
+	public function test_member_can_publish_own_draft(): void {
+		$this->seed_pattern( 'draft' );
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'status' => 'publish' ) );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertSame( 'publish', get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * A status-less content edit is re-checked for spam, so fresh content cannot be swapped in after publish.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
+	 */
+	public function test_status_less_content_edit_is_spam_checked(): void {
+		$this->seed_pattern( 'publish' );
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'content' => self::$spam_content ) );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertSame( SPAM_STATUS, get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * A status-less edit with clean content leaves a published pattern published.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
+	 */
+	public function test_status_less_clean_content_edit_stays_published(): void {
+		$this->seed_pattern( 'publish' );
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'content' => self::$clean_content ) );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertSame( 'publish', get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * A draft is not spam-checked, so the creator's autosaves don't each cost an Akismet round trip and a
+	 * work-in-progress draft can't be moved into the moderator-only quarantine while it's being written.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
+	 */
+	public function test_draft_content_edit_is_not_spam_checked(): void {
+		$this->seed_pattern( 'draft' );
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'content' => self::$spam_content ) );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertSame( 'draft', get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * Publishing that same draft does run the check, so skipping drafts doesn't open a way in.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
+	 */
+	public function test_publishing_a_spam_draft_is_caught(): void {
+		$this->seed_pattern( 'draft', self::$spam_content );
+		wp_set_current_user( self::$member );
+
+		$response = $this->update_pattern( array( 'status' => 'publish' ) );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertSame( SPAM_STATUS, get_post_status( self::$pattern_id ) );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
@@ -259,9 +259,14 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE . '/' . self::$pattern_id . '/autosaves' );
 		$request->set_header( 'content-type', 'application/json' );
-		$request->set_body( wp_json_encode( array(
-			'status' => 'publish', 'content' => self::$spam_content,
-		) ) );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'status'  => 'publish',
+					'content' => self::$spam_content,
+				)
+			)
+		);
 		$response = rest_do_request( $request );
 
 		$this->assertFalse( $response->is_error() );

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
@@ -314,30 +314,46 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An autosave that is discarded into a revision must not record a spam note against the live pattern.
+	 * A spam verdict the autosave controller throws away must not be noted against the live pattern.
 	 *
-	 * `note_spam_status()` hangs off `transition_post_status`, so a pattern never transitioning to the spam
-	 * status is what proves no note was written. The internal-notes plugin isn't installed under test, and
-	 * standing in for it switches on the logging module that gates on it, so this is the observable.
+	 * A published pattern can't be updated in place, so the controller files the write as a revision -- but
+	 * naming a status still sends the request through the spam check, so the verdict is reached and then
+	 * discarded. `note_spam_status()` hangs off `transition_post_status` precisely so nothing is recorded
+	 * unless the status was actually saved.
 	 *
 	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\note_spam_status
 	 */
-	public function test_autosave_does_not_note_an_unsaved_spam_status(): void {
+	public function test_discarded_spam_verdict_is_not_noted(): void {
 		$this->seed_pattern( 'publish' );
 		wp_set_current_user( self::$member );
 
+		$flagged     = null;
+		$spy         = function ( $prepared_post ) use ( &$flagged ) {
+			$flagged = $prepared_post->post_status ?? '';
+			return $prepared_post;
+		};
+		add_filter( 'rest_pre_insert_' . POST_TYPE, $spy, 21 );
+
 		$transitions = $this->count_spam_transitions(
 			function () {
-				foreach ( array( 1, 2, 3 ) as $round ) {
-					$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE . '/' . self::$pattern_id . '/autosaves' );
-					$request->set_header( 'content-type', 'application/json' );
-					$request->set_body( wp_json_encode( array( 'content' => self::$spam_content ) ) );
-					rest_do_request( $request );
-				}
+				$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE . '/' . self::$pattern_id . '/autosaves' );
+				$request->set_header( 'content-type', 'application/json' );
+				$request->set_body(
+					wp_json_encode(
+						array(
+							'status'  => 'publish',
+							'content' => self::$spam_content,
+						)
+					)
+				);
+				rest_do_request( $request );
 			}
 		);
 
-		$this->assertSame( 0, $transitions, 'A discarded spam status must not be recorded against the pattern.' );
+		remove_filter( 'rest_pre_insert_' . POST_TYPE, $spy, 21 );
+
+		$this->assertSame( SPAM_STATUS, $flagged, 'This case must reach the spam check, or it proves nothing.' );
+		$this->assertSame( 0, $transitions, 'A discarded verdict must not be noted against the pattern.' );
 		$this->assertSame( 'publish', get_post_status( self::$pattern_id ) );
 	}
 

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
@@ -10,6 +10,7 @@ namespace WordPressdotorg\Pattern_Directory\Tests;
 use WP_REST_Request;
 use WP_UnitTestCase;
 use WP_UnitTest_Factory;
+use function WordPressdotorg\Pattern_Directory\Pattern_Validation\spam_reason;
 use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, UNLISTED_STATUS, SPAM_STATUS };
 
 /**
@@ -357,6 +358,78 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 1, $transitions );
 		$this->assertSame( SPAM_STATUS, get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * A status-less autosave doesn't reach the spam check at all, so it costs no Akismet call for a verdict
+	 * that would be thrown away. Watch the prepared post: an unchecked request never carries the spam status.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\validate_against_spam
+	 */
+	public function test_status_less_autosave_is_not_spam_checked(): void {
+		$this->seed_pattern( 'publish' );
+		wp_set_current_user( self::$member );
+
+		$prepared_status = null;
+		$spy             = function ( $prepared_post ) use ( &$prepared_status ) {
+			$prepared_status = $prepared_post->post_status ?? '';
+			return $prepared_post;
+		};
+		add_filter( 'rest_pre_insert_' . POST_TYPE, $spy, 21 );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE . '/' . self::$pattern_id . '/autosaves' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'content' => self::$spam_content ) ) );
+		rest_do_request( $request );
+
+		remove_filter( 'rest_pre_insert_' . POST_TYPE, $spy, 21 );
+
+		$this->assertNotNull( $prepared_status, 'The autosave must reach the filter for this to prove anything.' );
+		$this->assertNotSame( SPAM_STATUS, $prepared_status, 'A status-less autosave must not be spam-checked.' );
+	}
+
+	/**
+	 * One pattern's spam reason is never noted against another, which a batch request or an import loop
+	 * would otherwise do.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\spam_reason
+	 */
+	public function test_spam_reason_is_kept_per_pattern(): void {
+		$first  = self::$pattern_id;
+		$second = self::$pattern_id + 1;
+
+		spam_reason( $first, 'Reason for the first pattern.' );
+
+		$this->assertSame( '', spam_reason( $second ), "Another pattern must not pick up the first's reason." );
+		$this->assertSame( 'Reason for the first pattern.', spam_reason( $first ) );
+		$this->assertSame( '', spam_reason( $first ), 'Reading must consume, so it cannot be noted twice.' );
+	}
+
+	/**
+	 * A pattern flagged as it is created still gets its reason recorded, even though there was no ID to
+	 * record it against when the check ran.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\note_spam_status
+	 */
+	public function test_spam_on_create_is_noted(): void {
+		wp_set_current_user( self::$member );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'title'   => 'A new pattern',
+					'content' => self::$spam_content,
+					'status'  => 'publish',
+				)
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertSame( SPAM_STATUS, get_post_status( $response->get_data()['id'] ) );
+		$this->assertSame( '', spam_reason( 0 ), 'The reason must have been consumed by the note.' );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-status-validation-test.php
@@ -123,6 +123,29 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Count the times a pattern actually transitions into the spam status while $action runs.
+	 *
+	 * This is the same condition `note_spam_status()` fires on, so it stands in for "a note was written".
+	 *
+	 * @param callable $action The work to measure.
+	 * @return int The number of transitions.
+	 */
+	protected function count_spam_transitions( callable $action ): int {
+		$count = 0;
+		$spy   = function ( $new_status, $old_status, $post ) use ( &$count ) {
+			if ( POST_TYPE === $post->post_type && SPAM_STATUS === $new_status && $new_status !== $old_status ) {
+				$count++;
+			}
+		};
+
+		add_action( 'transition_post_status', $spy, 10, 3 );
+		$action();
+		remove_action( 'transition_post_status', $spy, 10 );
+
+		return $count;
+	}
+
+	/**
 	 * Dispatch a pattern update with the given body.
 	 *
 	 * @param array $body Request body.
@@ -287,6 +310,53 @@ class Pattern_Status_Validation_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $response->is_error() );
 		$this->assertSame( 'publish', get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * An autosave that is discarded into a revision must not record a spam note against the live pattern.
+	 *
+	 * `note_spam_status()` hangs off `transition_post_status`, so a pattern never transitioning to the spam
+	 * status is what proves no note was written. The internal-notes plugin isn't installed under test, and
+	 * standing in for it switches on the logging module that gates on it, so this is the observable.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\note_spam_status
+	 */
+	public function test_autosave_does_not_note_an_unsaved_spam_status(): void {
+		$this->seed_pattern( 'publish' );
+		wp_set_current_user( self::$member );
+
+		$transitions = $this->count_spam_transitions(
+			function () {
+				foreach ( array( 1, 2, 3 ) as $round ) {
+					$request = new WP_REST_Request( 'POST', '/wp/v2/' . POST_TYPE . '/' . self::$pattern_id . '/autosaves' );
+					$request->set_header( 'content-type', 'application/json' );
+					$request->set_body( wp_json_encode( array( 'content' => self::$spam_content ) ) );
+					rest_do_request( $request );
+				}
+			}
+		);
+
+		$this->assertSame( 0, $transitions, 'A discarded spam status must not be recorded against the pattern.' );
+		$this->assertSame( 'publish', get_post_status( self::$pattern_id ) );
+	}
+
+	/**
+	 * A real update that does persist the spam status still reaches the note, once.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Directory\Pattern_Validation\note_spam_status
+	 */
+	public function test_persisted_spam_status_is_noted(): void {
+		$this->seed_pattern( 'publish' );
+		wp_set_current_user( self::$member );
+
+		$transitions = $this->count_spam_transitions(
+			function () {
+				$this->update_pattern( array( 'content' => self::$spam_content ) );
+			}
+		);
+
+		$this->assertSame( 1, $transitions );
+		$this->assertSame( SPAM_STATUS, get_post_status( self::$pattern_id ) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-translation-lookup-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-translation-lookup-test.php
@@ -188,6 +188,28 @@ class Pattern_Translation_Lookup_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A missing parent id drops the lookup instead of becoming a `post_parent => 0` constraint, which would
+	 * match an unrelated top-level pattern.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Translations\Pattern::find_existing_translation
+	 */
+	public function test_absent_parent_id_matches_nothing(): void {
+		$toplevel = self::factory()->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'wpop_locale'         => self::LOCALE,
+					'wpop_is_translation' => true,
+				),
+			)
+		);
+
+		$this->assertSame( 0, get_post( $toplevel )->post_parent, 'Fixture must be top-level.' );
+		$this->assertNull( Translations_Pattern::find_existing_translation( 0, self::LOCALE ) );
+	}
+
+	/**
 	 * With nothing to adopt the job gets null, which is what makes it insert a fresh translation.
 	 *
 	 * @covers \WordPressdotorg\Pattern_Translations\Pattern::find_existing_translation

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-translation-lookup-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-translation-lookup-test.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Test that the translation job only adopts patterns it created itself.
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\Pattern_Directory\Tests;
+
+use WP_UnitTestCase;
+use WP_UnitTest_Factory;
+use WordPressdotorg\Pattern_Translations\Pattern as Translations_Pattern;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+
+/**
+ * The twice-daily translation job decides which post is the existing translation of a (pattern, locale) pair.
+ * `post_parent` and `wpop_locale` are both writable by any submitter on their own pattern, so that pair alone
+ * is an attacker-controlled claim; the job would then overwrite the adopted post with the parent's author and
+ * status, forging authorship and bypassing review. Only `wpop_is_translation`, which the job writes and REST
+ * does not expose, actually identifies a pattern the pipeline created.
+ *
+ * @group pattern-translation-lookup
+ */
+class Pattern_Translation_Lookup_Test extends WP_UnitTestCase {
+	/**
+	 * The locale the lookups are performed for.
+	 */
+	const LOCALE = 'fr_FR';
+
+	/**
+	 * The author of the English original.
+	 *
+	 * @var int
+	 */
+	protected static $victim;
+
+	/**
+	 * A directory member with no moderator capability.
+	 *
+	 * @var int
+	 */
+	protected static $member;
+
+	/**
+	 * The published English pattern the translation job walks.
+	 *
+	 * @var int
+	 */
+	protected static $parent_id;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		self::$victim = $factory->user->create( array( 'role' => 'contributor' ) );
+		self::$member = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		self::$parent_id = $factory->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_author' => self::$victim,
+				'post_title'  => 'An English original',
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * Make the test locales resolvable.
+	 *
+	 * `wpop_locale` is sanitized against `get_locales()`, which reads the `wporg_locales` table. That table
+	 * doesn't exist in the test environment, so without this every locale sanitizes to `en_US` and the
+	 * lookups below would find nothing no matter what the code under test did. `get_locales()` caches the
+	 * list, and `WP_UnitTestCase` flushes the object cache per test, so prime it for each one.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		wp_cache_add_global_groups( array( 'locale-associations' ) );
+		wp_cache_set( 'locale-list', array( self::LOCALE, 'de_DE' ), 'locale-associations' );
+	}
+
+	/**
+	 * Clean up shared fixtures.
+	 */
+	public static function tear_down_after_class(): void {
+		wp_delete_post( self::$parent_id, true );
+		wp_delete_user( self::$victim );
+		wp_delete_user( self::$member );
+
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Create a child of the English original.
+	 *
+	 * @param int    $author         The child's author.
+	 * @param string $locale         The child's `wpop_locale`.
+	 * @param bool   $is_translation Whether to mark it as pipeline-created.
+	 * @param string $status         The child's post status.
+	 * @return int The new post ID.
+	 */
+	protected function create_child( int $author, string $locale, bool $is_translation, string $status = 'pending' ): int {
+		$meta = array( 'wpop_locale' => $locale );
+		if ( $is_translation ) {
+			$meta['wpop_is_translation'] = true;
+		}
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_author' => $author,
+				'post_parent' => self::$parent_id,
+				'post_status' => $status,
+				'meta_input'  => $meta,
+			)
+		);
+
+		/*
+		 * Guard the fixture itself: `wpop_locale` silently sanitizes to `en_US` for any locale the site
+		 * doesn't know, which would make every lookup below return null and pass the negative tests for
+		 * entirely the wrong reason.
+		 */
+		$this->assertSame(
+			$locale,
+			get_post_meta( $post_id, 'wpop_locale', true ),
+			'The fixture locale was rejected by the meta sanitizer.'
+		);
+
+		return $post_id;
+	}
+
+	/**
+	 * A member's own submission claiming the same parent and locale is not adopted.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Translations\Pattern::find_existing_translation
+	 */
+	public function test_ignores_a_members_post_claiming_the_parent_and_locale(): void {
+		$this->create_child( self::$member, self::LOCALE, false );
+
+		$found = Translations_Pattern::find_existing_translation( self::$parent_id, self::LOCALE );
+
+		$this->assertNull( $found, 'A post without `wpop_is_translation` must not be adopted.' );
+	}
+
+	/**
+	 * A pattern the pipeline created is still found, so genuine translations keep updating in place.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Translations\Pattern::find_existing_translation
+	 */
+	public function test_finds_a_pipeline_created_translation(): void {
+		$translation_id = $this->create_child( self::$victim, self::LOCALE, true );
+
+		$found = Translations_Pattern::find_existing_translation( self::$parent_id, self::LOCALE );
+
+		$this->assertNotNull( $found );
+		$this->assertSame( $translation_id, $found->ID );
+	}
+
+	/**
+	 * With both present, the pipeline's own translation wins regardless of which was created first.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Translations\Pattern::find_existing_translation
+	 */
+	public function test_prefers_the_pipeline_translation_over_an_impostor(): void {
+		$this->create_child( self::$member, self::LOCALE, false );
+		$translation_id = $this->create_child( self::$victim, self::LOCALE, true );
+
+		$found = Translations_Pattern::find_existing_translation( self::$parent_id, self::LOCALE );
+
+		$this->assertNotNull( $found );
+		$this->assertSame( $translation_id, $found->ID );
+	}
+
+	/**
+	 * A translation for a different locale is not adopted for this one.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Translations\Pattern::find_existing_translation
+	 */
+	public function test_ignores_a_translation_for_another_locale(): void {
+		$this->create_child( self::$victim, 'de_DE', true );
+
+		$found = Translations_Pattern::find_existing_translation( self::$parent_id, self::LOCALE );
+
+		$this->assertNull( $found );
+	}
+
+	/**
+	 * With nothing to adopt the job gets null, which is what makes it insert a fresh translation.
+	 *
+	 * @covers \WordPressdotorg\Pattern_Translations\Pattern::find_existing_translation
+	 */
+	public function test_returns_null_when_no_translation_exists(): void {
+		$found = Translations_Pattern::find_existing_translation( self::$parent_id, self::LOCALE );
+
+		$this->assertNull( $found );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/theme-pattern-actions-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/theme-pattern-actions-test.php
@@ -69,13 +69,22 @@ class Theme_Pattern_Actions_Test extends WP_UnitTestCase {
 	protected $suppress_redirect;
 
 	/**
+	 * The location the theme last tried to redirect to.
+	 *
+	 * @var string
+	 */
+	protected $redirected_to = '';
+
+	/**
 	 * Suppress redirects for the duration of each test.
 	 */
 	public function set_up(): void {
 		parent::set_up();
 
 		// An empty location makes `wp_redirect()` bail before it sends any header.
-		$this->suppress_redirect = function () {
+		$this->redirected_to     = '';
+		$this->suppress_redirect = function ( $location ) {
+			$this->redirected_to = (string) $location;
 			return '';
 		};
 		add_filter( 'wp_redirect', $this->suppress_redirect );
@@ -134,6 +143,11 @@ class Theme_Pattern_Actions_Test extends WP_UnitTestCase {
 		$this->do_draft_action( $pattern_id );
 
 		$this->assertSame( UNLISTED_STATUS, get_post_status( $pattern_id ) );
+		$this->assertStringContainsString(
+			'status=draft-not-allowed',
+			$this->redirected_to,
+			'The author must be told why, not left on a page that silently does nothing.'
+		);
 	}
 
 	/**

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/theme-pattern-actions-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/theme-pattern-actions-test.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Test the theme's front-end pattern actions.
+ */
+
+declare( strict_types = 1 );
+
+namespace WordPressdotorg\Pattern_Directory\Tests;
+
+use WP_UnitTestCase;
+use WP_UnitTest_Factory;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, UNLISTED_STATUS, SPAM_STATUS };
+
+/**
+ * `do_pattern_actions()` drafts a pattern through `wp_update_post()` rather than the REST API, so
+ * `validate_status()` never sees it. Without its own check an author could draft their way out of a
+ * moderator-set status here and then publish the draft over REST.
+ *
+ * @group pattern-status-validation
+ */
+class Theme_Pattern_Actions_Test extends WP_UnitTestCase {
+	/**
+	 * A moderator: holds `edit_others_patterns`.
+	 *
+	 * @var int
+	 */
+	protected static $moderator;
+
+	/**
+	 * The pattern's author: a directory member with no moderator capability.
+	 *
+	 * @var int
+	 */
+	protected static $member;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		self::$moderator = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$member    = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		/*
+		 * The suite loads plugins, not the theme, so pull in the one file under test. Its block and inc
+		 * requires are all `__DIR__`-relative and load standalone.
+		 */
+		if ( ! function_exists( '\WordPressdotorg\Theme\Pattern_Directory_2024\do_pattern_actions' ) ) {
+			require_once dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/themes/wporg-pattern-directory-2024/functions.php';
+		}
+	}
+
+	/**
+	 * Clean up shared fixtures.
+	 */
+	public static function tear_down_after_class(): void {
+		wp_delete_user( self::$moderator );
+		wp_delete_user( self::$member );
+
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Stop `wp_safe_redirect()` reaching `header()`, which PHPUnit's buffered output makes fatal.
+	 *
+	 * @var callable
+	 */
+	protected $suppress_redirect;
+
+	/**
+	 * Suppress redirects for the duration of each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// An empty location makes `wp_redirect()` bail before it sends any header.
+		$this->suppress_redirect = function () {
+			return '';
+		};
+		add_filter( 'wp_redirect', $this->suppress_redirect );
+	}
+
+	/**
+	 * Reset the current user and request state between tests.
+	 */
+	public function tear_down(): void {
+		remove_filter( 'wp_redirect', $this->suppress_redirect );
+		unset( $_REQUEST['action'], $_REQUEST['_wpnonce'] );
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Run the theme's draft action against a pattern, as the current user.
+	 *
+	 * @param int $pattern_id The pattern to act on.
+	 */
+	protected function do_draft_action( int $pattern_id ): void {
+		$this->go_to( get_permalink( $pattern_id ) );
+
+		$_REQUEST['action']   = 'draft';
+		$_REQUEST['_wpnonce'] = wp_create_nonce( 'draft-' . $pattern_id );
+
+		\WordPressdotorg\Theme\Pattern_Directory_2024\do_pattern_actions();
+	}
+
+	/**
+	 * Create a pattern owned by the member.
+	 *
+	 * @param string $status The pattern's status.
+	 * @return int The new pattern ID.
+	 */
+	protected function create_pattern( string $status ): int {
+		return self::factory()->post->create(
+			array(
+				'post_type'   => POST_TYPE,
+				'post_author' => self::$member,
+				'post_status' => $status,
+			)
+		);
+	}
+
+	/**
+	 * An author cannot draft their way out of a moderator's removal.
+	 *
+	 * @covers \WordPressdotorg\Theme\Pattern_Directory_2024\do_pattern_actions
+	 */
+	public function test_member_cannot_draft_an_unlisted_pattern(): void {
+		$pattern_id = $this->create_pattern( UNLISTED_STATUS );
+		wp_set_current_user( self::$member );
+
+		$this->do_draft_action( $pattern_id );
+
+		$this->assertSame( UNLISTED_STATUS, get_post_status( $pattern_id ) );
+	}
+
+	/**
+	 * Nor out of the spam quarantine.
+	 *
+	 * @covers \WordPressdotorg\Theme\Pattern_Directory_2024\do_pattern_actions
+	 */
+	public function test_member_cannot_draft_a_spam_pattern(): void {
+		$pattern_id = $this->create_pattern( SPAM_STATUS );
+		wp_set_current_user( self::$member );
+
+		$this->do_draft_action( $pattern_id );
+
+		$this->assertSame( SPAM_STATUS, get_post_status( $pattern_id ) );
+	}
+
+	/**
+	 * The ordinary case still works: an author can unpublish their own published pattern.
+	 *
+	 * @covers \WordPressdotorg\Theme\Pattern_Directory_2024\do_pattern_actions
+	 */
+	public function test_member_can_draft_own_published_pattern(): void {
+		$pattern_id = $this->create_pattern( 'publish' );
+		wp_set_current_user( self::$member );
+
+		$this->do_draft_action( $pattern_id );
+
+		$this->assertSame( 'draft', get_post_status( $pattern_id ) );
+	}
+
+	/**
+	 * A moderator can still draft an unlisted pattern.
+	 *
+	 * @covers \WordPressdotorg\Theme\Pattern_Directory_2024\do_pattern_actions
+	 */
+	public function test_moderator_can_draft_an_unlisted_pattern(): void {
+		$pattern_id = $this->create_pattern( UNLISTED_STATUS );
+		wp_set_current_user( self::$moderator );
+
+		$this->do_draft_action( $pattern_id );
+
+		$this->assertSame( 'draft', get_post_status( $pattern_id ) );
+	}
+}

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/theme-pattern-actions-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/theme-pattern-actions-test.php
@@ -34,6 +34,13 @@ class Theme_Pattern_Actions_Test extends WP_UnitTestCase {
 	protected static $member;
 
 	/**
+	 * The registered hooks as they were before the theme was loaded, or null if it was already loaded.
+	 *
+	 * @var array|null
+	 */
+	protected static $hooks_before_theme = null;
+
+	/**
 	 * Set up shared fixtures.
 	 *
 	 * @param WP_UnitTest_Factory $factory Test factory.
@@ -43,10 +50,20 @@ class Theme_Pattern_Actions_Test extends WP_UnitTestCase {
 		self::$member    = $factory->user->create( array( 'role' => 'subscriber' ) );
 
 		/*
-		 * The suite loads plugins, not the theme, so pull in the one file under test. Its block and inc
-		 * requires are all `__DIR__`-relative and load standalone.
+		 * The suite loads plugins, not the theme, so pull in the one file under test. Loading it registers the
+		 * theme's hooks -- `pre_get_posts` forces `curation=core` on every main query -- which would silently
+		 * filter results for any later test that runs a pattern query. Snapshot the hooks so they can be put
+		 * back exactly as they were once this class is done.
 		 */
 		if ( ! function_exists( '\WordPressdotorg\Theme\Pattern_Directory_2024\do_pattern_actions' ) ) {
+			// `$wp_filter` holds `WP_Hook` objects, so the array has to be cloned, not just copied.
+			self::$hooks_before_theme = array_map(
+				function ( $hook ) {
+					return clone $hook;
+				},
+				$GLOBALS['wp_filter']
+			);
+
 			require_once dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/themes/wporg-pattern-directory-2024/functions.php';
 		}
 	}
@@ -55,6 +72,13 @@ class Theme_Pattern_Actions_Test extends WP_UnitTestCase {
 	 * Clean up shared fixtures.
 	 */
 	public static function tear_down_after_class(): void {
+		// Put the hooks back, so loading the theme here doesn't change what any later test sees.
+		if ( null !== self::$hooks_before_theme ) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restoring the snapshot taken above.
+			$GLOBALS['wp_filter']     = self::$hooks_before_theme;
+			self::$hooks_before_theme = null;
+		}
+
 		wp_delete_user( self::$moderator );
 		wp_delete_user( self::$member );
 

--- a/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
@@ -91,7 +91,6 @@ class Pattern {
 	 * @return \WP_Post|null The existing translation, or null if this pipeline has not created one.
 	 */
 	public static function find_existing_translation( int $parent_id, string $locale ): ?\WP_Post {
-		// `post_parent => 0` is a real constraint, not an absent one: it would match top-level patterns.
 		if ( $parent_id <= 0 ) {
 			return null;
 		}

--- a/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
@@ -91,6 +91,11 @@ class Pattern {
 	 * @return \WP_Post|null The existing translation, or null if this pipeline has not created one.
 	 */
 	public static function find_existing_translation( int $parent_id, string $locale ): ?\WP_Post {
+		// `post_parent => 0` is a real constraint, not an absent one: it would match top-level patterns.
+		if ( $parent_id <= 0 ) {
+			return null;
+		}
+
 		$children = get_posts( array(
 			'post_parent' => $parent_id,
 			'post_type'   => POST_TYPE,

--- a/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/pattern.php
@@ -68,25 +68,47 @@ class Pattern {
 		// Reset the ID.
 		$translated->ID     = 0;
 
-		// Find the actual post ID of the translated pattern
+		$existing = self::find_existing_translation( (int) $parent->ID, $locale );
+		if ( $existing ) {
+			$translated->ID   = $existing->ID;
+			$translated->name = $existing->post_name; // Preserve the existing translation's slug.
+		}
+
+		return $translated;
+	}
+
+	/**
+	 * Find the pattern this pipeline previously created as the $locale translation of $parent_id.
+	 *
+	 * `post_parent` and `wpop_locale` are both writable by any submitter on their own pattern, so the pair
+	 * alone is an attacker-controlled claim rather than an identification. `wpop_is_translation` is written
+	 * only by `create_or_update_translated_pattern()` and is not exposed over REST, so requiring it keeps the
+	 * job from adopting a user's own post and overwriting it with the parent's author and status.
+	 *
+	 * @param int    $parent_id The English original's post ID.
+	 * @param string $locale    The locale to find the existing translation for.
+	 *
+	 * @return \WP_Post|null The existing translation, or null if this pipeline has not created one.
+	 */
+	public static function find_existing_translation( int $parent_id, string $locale ): ?\WP_Post {
 		$children = get_posts( array(
-			'post_parent' => $parent->ID,
+			'post_parent' => $parent_id,
 			'post_type'   => POST_TYPE,
 			'post_status' => 'any',
 			'meta_query'  => array(
+				'relation' => 'AND',
 				array(
 					'key'   => 'wpop_locale',
 					'value' => $locale,
 				),
+				array(
+					'key'   => 'wpop_is_translation',
+					'value' => 1,
+				),
 			),
 		) );
-		if ( $children ) {
-			$post = array_shift( $children );
-			$translated->ID   = $post->ID;
-			$translated->name = $post->post_name; // ???
-		}
 
-		return $translated;
+		return $children ? array_shift( $children ) : null;
 	}
 
 	/**

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
@@ -83,7 +83,19 @@ function do_pattern_actions() {
 		$is_moderator_status = in_array( get_post_status( $post_id ), array( SPAM_STATUS, UNLISTED_STATUS ), true ) &&
 			! current_user_can( $pattern_type->cap->edit_others_posts );
 
-		if ( wp_verify_nonce( $nonce, 'draft-' . $post_id ) && current_user_can( 'edit_post', $post_id ) && ! $is_moderator_status ) {
+		if ( wp_verify_nonce( $nonce, 'draft-' . $post_id ) && current_user_can( 'edit_post', $post_id ) ) {
+			if ( $is_moderator_status ) {
+				// Tell the author why, rather than reloading the page with the action still in the URL.
+				$url = add_query_arg(
+					array(
+						'status' => 'draft-not-allowed',
+					),
+					get_the_permalink()
+				);
+				wp_safe_redirect( $url );
+				return;
+			}
+
 			// Draft the post.
 			$success = wp_update_post(
 				array(

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
@@ -80,15 +80,10 @@ function do_pattern_actions() {
 		$pattern_type = get_post_type_object( POST_TYPE );
 
 		// `unlisted` and spam are moderator-set, and this path bypasses `validate_status()`.
-		if (
-			in_array( get_post_status( $post_id ), array( SPAM_STATUS, UNLISTED_STATUS ), true ) &&
-			! current_user_can( $pattern_type->cap->edit_others_posts )
-		) {
-			wp_safe_redirect( add_query_arg( array( 'status' => 'draft-failed' ), get_the_permalink() ) );
-			return;
-		}
+		$is_moderator_status = in_array( get_post_status( $post_id ), array( SPAM_STATUS, UNLISTED_STATUS ), true ) &&
+			! current_user_can( $pattern_type->cap->edit_others_posts );
 
-		if ( wp_verify_nonce( $nonce, 'draft-' . $post_id ) && current_user_can( 'edit_post', $post_id ) ) {
+		if ( wp_verify_nonce( $nonce, 'draft-' . $post_id ) && current_user_can( 'edit_post', $post_id ) && ! $is_moderator_status ) {
 			// Draft the post.
 			$success = wp_update_post(
 				array(

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
@@ -4,7 +4,7 @@ namespace WordPressdotorg\Theme\Pattern_Directory_2024;
 
 use function WordPressdotorg\Pattern_Directory\Favorite\{get_favorites, get_favorite_count};
 use function WordPressdotorg\Theme\Pattern_Directory_2024\Block_Config\get_applied_filter_list;
-use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\POST_TYPE;
+use const WordPressdotorg\Pattern_Directory\Pattern_Post_Type\{ POST_TYPE, UNLISTED_STATUS, SPAM_STATUS };
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\POST_TYPE as FLAG_POST_TYPE;
 use const WordPressdotorg\Pattern_Directory\Pattern_Flag_Post_Type\PENDING_STATUS;
 
@@ -77,6 +77,21 @@ function do_pattern_actions() {
 	$post_id = get_the_ID();
 
 	if ( 'draft' === $action ) {
+		$pattern_type = get_post_type_object( POST_TYPE );
+
+		/*
+		 * `unlisted` and spam are moderator-set. This runs through `wp_update_post()` rather than the REST
+		 * API, so `validate_status()` never sees it -- without this check an author could draft their way out
+		 * of a moderator's removal here and then publish the draft over REST.
+		 */
+		if (
+			in_array( get_post_status( $post_id ), array( SPAM_STATUS, UNLISTED_STATUS ), true ) &&
+			! current_user_can( $pattern_type->cap->edit_others_posts )
+		) {
+			wp_safe_redirect( add_query_arg( array( 'status' => 'draft-failed' ), get_the_permalink() ) );
+			return;
+		}
+
 		if ( wp_verify_nonce( $nonce, 'draft-' . $post_id ) && current_user_can( 'edit_post', $post_id ) ) {
 			// Draft the post.
 			$success = wp_update_post(

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
@@ -79,11 +79,7 @@ function do_pattern_actions() {
 	if ( 'draft' === $action ) {
 		$pattern_type = get_post_type_object( POST_TYPE );
 
-		/*
-		 * `unlisted` and spam are moderator-set. This runs through `wp_update_post()` rather than the REST
-		 * API, so `validate_status()` never sees it -- without this check an author could draft their way out
-		 * of a moderator's removal here and then publish the draft over REST.
-		 */
+		// `unlisted` and spam are moderator-set, and this path bypasses `validate_status()`.
 		if (
 			in_array( get_post_status( $post_id ), array( SPAM_STATUS, UNLISTED_STATUS ), true ) &&
 			! current_user_can( $pattern_type->cap->edit_others_posts )

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/functions.php
@@ -86,13 +86,7 @@ function do_pattern_actions() {
 		if ( wp_verify_nonce( $nonce, 'draft-' . $post_id ) && current_user_can( 'edit_post', $post_id ) ) {
 			if ( $is_moderator_status ) {
 				// Tell the author why, rather than reloading the page with the action still in the URL.
-				$url = add_query_arg(
-					array(
-						'status' => 'draft-not-allowed',
-					),
-					get_the_permalink()
-				);
-				wp_safe_redirect( $url );
+				wp_safe_redirect( add_query_arg( array( 'status' => 'draft-not-allowed' ), get_the_permalink() ) );
 				return;
 			}
 

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/single-my-pattern.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/single-my-pattern.php
@@ -27,9 +27,9 @@ if ( 'draft-failed' === $action_status ) {
 		</div>
 	</div>
 	<!-- /wp:wporg/notice -->
-	<?php else : ?>
-	<!-- wp:wporg/status-notice /-->
 	<?php endif; ?>
+
+	<!-- wp:wporg/status-notice /-->
 
 	<!-- wp:post-title {"level":1,"fontSize":"heading-3"} /-->
 

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/single-my-pattern.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/patterns/single-my-pattern.php
@@ -11,6 +11,8 @@ $notice        = '';
 $notice_type   = 'warning';
 if ( 'draft-failed' === $action_status ) {
 	$notice = __( 'Your pattern could not be updated, please try again.', 'wporg-patterns' );
+} elseif ( 'draft-not-allowed' === $action_status ) {
+	$notice = __( 'Only a directory moderator can change the status of this pattern.', 'wporg-patterns' );
 }
 
 ?>


### PR DESCRIPTION
Brings a few REST paths in line with how the rest of the plugin treats moderator-only operations, and makes status resolution on update match what the stored post actually has.

## Changes

**Capability checks**

- `REST_Flags_Controller`: both the collection and single-item routes now check `edit_others_*`, matching the moderator-only intent their error strings already state. The previous `edit_patterns` is granted to every logged-in user by `set_pattern_caps()`, and `edit_post` on the parent is true for the pattern's own author, so neither expressed what the routes meant.
- `wporg-pattern-keyword`: `assign_terms` / `edit_terms` use `edit_others_patterns`. The `core` term feeds Core's remote pattern distribution, so it belongs with the other moderator-managed data. `wporg-pattern-category` is unchanged and stays author-assignable.

**Validation**

- `validate_status()` now considers the status being moved *from*, not only the one being moved to, so `unlisted` and `pending-review` behave consistently as source statuses. This replaces the narrower `pending-review`-only check, and splits the authorization failure out into its own `rest_pattern_cannot_change_status` / 403 rather than reusing the 400 meant for invalid values.
- `validate_against_spam()`: an update that omits `status` now resolves to the post's current status instead of an empty string, so it is classified the same way an equivalent explicit request would be. Drafts are unaffected — they resolve to `draft` and return early as before.
- `validate_parent()` is new. `parent` is written by the translation cron rather than by submitters, so it is restricted to moderators and required to name another pattern.
- `$prepared_post->ID` is guarded where it is absent on create. This also unblocks testing the create path at all, which previously raised an undefined-property warning that `convertWarningsToExceptions` turned into an error.

**Translations**

- An existing locale fork is identified by `wpop_is_translation`, which the sync itself writes, rather than by parent and locale alone.

## Testing

Adds 5 test files covering each of the above (18 new tests). Each change was verified by reverting it individually and confirming the matching tests fail, so none of them pass vacuously.

Note for reviewers of `pattern-translation-lookup-test.php`: `wpop_locale` sanitizes to `en_US` for any locale the site doesn't know, and the `wporg_locales` table doesn't exist under test — so the test primes the locale cache and asserts the fixture landed. Without that the lookups return null regardless of what the code does, and the negative assertions pass for the wrong reason.

```
$ npm run test:php
OK (105 tests, 313 assertions)

$ npm run lint:php
83/83, no errors
```

Rebased on #760; the phpcs config fix and the `pattern-translations` bootstrap require that were originally in this branch both landed there independently and have been dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)