### PR TITLE
Pattern directory: tidy output escaping and query handling

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-flags.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-flags.php
@@ -171,7 +171,7 @@ function flag_list_table_row_actions( $actions, $post ) {
 
 	$actions['review'] = sprintf(
 		'<a href="%s" aria-label="%s">%s</a>',
-		esc_attr( $pattern_url ),
+		esc_url( $pattern_url ),
 		/* translators: %s: Post title. */
 		esc_attr( sprintf( __( 'Review &#8220;%s&#8221;', 'wporg-patterns' ), $pattern_title ) ),
 		__( 'Review Pattern', 'wporg-patterns' )
@@ -188,7 +188,7 @@ function flag_list_table_row_actions( $actions, $post ) {
 
 		$actions['resolve'] = sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
-			esc_attr( $resolve_url ),
+			esc_url( $resolve_url ),
 			esc_attr( __( 'Mark this flag as resolved', 'wporg-patterns' ) ),
 			__( 'Resolve', 'wporg-patterns' )
 		);
@@ -205,7 +205,7 @@ function flag_list_table_row_actions( $actions, $post ) {
 
 		$actions['unresolve'] = sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
-			esc_attr( $unresolve_url ),
+			esc_url( $unresolve_url ),
 			esc_attr( __( 'Mark this flag as pending', 'wporg-patterns' ) ),
 			__( 'Unresolve', 'wporg-patterns' )
 		);
@@ -225,7 +225,7 @@ function flag_list_table_row_actions( $actions, $post ) {
 
 		$actions['view-all'] = sprintf(
 			'<br /><a href="%s" aria-label="%s">%s</a>',
-			esc_attr( $view_all_url ),
+			esc_url( $view_all_url ),
 			/* translators: %s: Post title. */
 			esc_attr( sprintf( __( 'View all flags for &#8220;%s&#8221;', 'wporg-patterns' ), $pattern_title ) ),
 			__( 'View All Flags For This Pattern', 'wporg-patterns' )

--- a/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/admin-patterns.php
@@ -436,7 +436,7 @@ function add_row_actions( $actions, $post ) {
 
 		$actions['publish'] = sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
-			$publish_url,
+			esc_url( $publish_url ),
 			/* translators: %s: Post title. */
 			esc_attr( sprintf( __( 'Publish &#8220;%s&#8221;', 'wporg-patterns' ), $title ) ),
 			_x( 'Publish', 'verb', 'wporg-patterns' )
@@ -454,7 +454,7 @@ function add_row_actions( $actions, $post ) {
 
 		$actions['unlist'] = sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
-			$unlist_url,
+			esc_url( $unlist_url ),
 			/* translators: %s: Post title. */
 			esc_attr( sprintf( __( 'Remove &#8220;%s&#8221; from the directory', 'wporg-patterns' ), $title ) ),
 			_x( 'Unlist', 'verb', 'wporg-patterns' )
@@ -472,7 +472,7 @@ function add_row_actions( $actions, $post ) {
 
 		$actions['spam'] = sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
-			$spam_url,
+			esc_url( $spam_url ),
 			/* translators: %s: Post title. */
 			esc_attr( sprintf( __( 'Mark &#8220;%s&#8221; as spam', 'wporg-patterns' ), $title ) ),
 			_x( 'Spam', 'verb', 'wporg-patterns' )

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -186,24 +186,28 @@ function get_pattern_ids_with_pending_flags( $args = array() ) {
 	$pattern = PATTERN;
 	$flag    = POST_TYPE;
 
-	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-	$pattern_ids = $wpdb->get_col(
-		$wpdb->prepare(
-			"
-			SELECT DISTINCT patterns.ID
-			FROM {$wpdb->posts} patterns
-				JOIN {$wpdb->posts} flags ON patterns.ID = flags.post_parent
-					AND flags.post_type = '{$flag}'
-				    AND flags.post_status = 'pending'
-			WHERE patterns.post_type = '{$pattern}'
-			ORDER BY %s %s
-			",
-			$args['orderby'],
-			$args['order']
-		)
+	// Allowlist orderby/order; these are a column and a keyword, which can't be bound as placeholders.
+	$orderby_columns = array(
+		'date'  => 'patterns.post_date',
+		'title' => 'patterns.post_title',
+		'id'    => 'patterns.ID',
 	);
-	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$orderby = $orderby_columns[ strtolower( (string) $args['orderby'] ) ] ?? 'patterns.post_date';
+	$order   = 'asc' === strtolower( (string) $args['order'] ) ? 'ASC' : 'DESC';
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+	$pattern_ids = $wpdb->get_col(
+		"
+		SELECT DISTINCT patterns.ID
+		FROM {$wpdb->posts} patterns
+			JOIN {$wpdb->posts} flags ON patterns.ID = flags.post_parent
+				AND flags.post_type = '{$flag}'
+			    AND flags.post_status = 'pending'
+		WHERE patterns.post_type = '{$pattern}'
+		ORDER BY {$orderby} {$order}
+		"
+	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
 
 	return $pattern_ids;
 }

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-flag-post-type.php
@@ -192,8 +192,9 @@ function get_pattern_ids_with_pending_flags( $args = array() ) {
 		'title' => 'patterns.post_title',
 		'id'    => 'patterns.ID',
 	);
-	$orderby = $orderby_columns[ strtolower( (string) $args['orderby'] ) ] ?? 'patterns.post_date';
-	$order   = 'asc' === strtolower( (string) $args['order'] ) ? 'ASC' : 'DESC';
+	$orderby_key = is_string( $args['orderby'] ) ? strtolower( $args['orderby'] ) : '';
+	$orderby     = $orderby_columns[ $orderby_key ] ?? 'patterns.post_date';
+	$order       = ( is_string( $args['order'] ) && 'asc' === strtolower( $args['order'] ) ) ? 'ASC' : 'DESC';
 
 	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
 	$pattern_ids = $wpdb->get_col(

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -797,12 +797,17 @@ function filter_patterns_rest_query( $args, $request ) {
 			}
 		);
 
-		// Only return patterns whose blocks are all allowed; an all-invalid list matches nothing, so it still narrows.
-		$args['meta_query']['allowed_blocks'] = array(
-			'key'     => 'wpop_contains_block_types',
-			'compare' => 'REGEXP',
-			'value'   => '^((' . implode( '|', $allowed_blocks ) . '),?)+$',
-		);
+		if ( $allowed_blocks ) {
+			// Only return patterns whose blocks are all in the allowed list.
+			$args['meta_query']['allowed_blocks'] = array(
+				'key'     => 'wpop_contains_block_types',
+				'compare' => 'REGEXP',
+				'value'   => '^((' . implode( '|', $allowed_blocks ) . '),?)+$',
+			);
+		} else {
+			// Every requested block name was invalid; match no patterns.
+			$args['post__in'] = array( 0 );
+		}
 	}
 
 	return $args;

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -789,6 +789,15 @@ function filter_patterns_rest_query( $args, $request ) {
 
 	$allowed_blocks = $request->get_param( 'allowed_blocks' );
 	if ( $allowed_blocks ) {
+		// Restrict to valid block names so arbitrary regex can't be injected into the REGEXP compare below.
+		$allowed_blocks = array_filter(
+			(array) $allowed_blocks,
+			function ( $block_name ) {
+				return is_string( $block_name ) && preg_match( '#^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$#', $block_name );
+			}
+		);
+	}
+	if ( ! empty( $allowed_blocks ) ) {
 		// Only return a pattern if all contained blocks are in the allowed blocks list.
 		$args['meta_query']['allowed_blocks'] = array(
 			'key'     => 'wpop_contains_block_types',

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -793,12 +793,11 @@ function filter_patterns_rest_query( $args, $request ) {
 		$allowed_blocks = array_filter(
 			(array) $allowed_blocks,
 			function ( $block_name ) {
-				return is_string( $block_name ) && preg_match( '#^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$#', $block_name );
+				return is_string( $block_name ) && preg_match( '#^[a-z0-9-]+/[a-z0-9-]+$#', $block_name );
 			}
 		);
-	}
-	if ( ! empty( $allowed_blocks ) ) {
-		// Only return a pattern if all contained blocks are in the allowed blocks list.
+
+		// Only return patterns whose blocks are all allowed; an all-invalid list matches nothing, so it still narrows.
 		$args['meta_query']['allowed_blocks'] = array(
 			'key'     => 'wpop_contains_block_types',
 			'compare' => 'REGEXP',

--- a/public_html/wp-content/plugins/pattern-translations/includes/parsers/BasicText.php
+++ b/public_html/wp-content/plugins/pattern-translations/includes/parsers/BasicText.php
@@ -46,7 +46,7 @@ class BasicText implements BlockParser {
 				foreach ( $text_nodes as $text ) {
 					if ( trim( $text->nodeValue ) && isset( $replacements[ $text->nodeValue ] ) ) {
 						$regex = '#(<([^>]*)>)?' . preg_quote( $text->nodeValue, '/' ) . '(<([^>]*)>)?#is';
-						$inner_content = preg_replace( $regex, '${1}' . $replacements[ $text->nodeValue ] . '${3}', $inner_content );
+						$inner_content = preg_replace( $regex, '${1}' . addcslashes( $replacements[ $text->nodeValue ], '\\$' ) . '${3}', $inner_content );
 					}
 				}
 			}

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/block-config.php
@@ -469,7 +469,9 @@ function update_archive_title( $block_content, $block, $instance ) {
 			$title = __( 'Search results', 'wporg-patterns' );
 		}
 
+		$allowed_tags       = array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' );
 		$tag_name           = isset( $attributes['level'] ) ? 'h' . (int) $attributes['level'] : 'h1';
+		$tag_name           = in_array( $tag_name, $allowed_tags, true ) ? $tag_name : 'h1';
 		$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
 		// Required to prevent `block_to_render` from being null in `get_block_wrapper_attributes`.
@@ -482,7 +484,7 @@ function update_archive_title( $block_content, $block, $instance ) {
 			'<%1$s %2$s>%3$s</%1$s>',
 			$tag_name,
 			$wrapper_attributes,
-			$title
+			esc_html( $title )
 		);
 	}
 	return $block_content;

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/shortcodes.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/inc/shortcodes.php
@@ -12,7 +12,7 @@ add_shortcode(
 	'pattern_edit_link',
 	function () {
 		$post_id = get_the_ID();
-		return site_url( "pattern/$post_id/edit/" );
+		return esc_url( site_url( "pattern/$post_id/edit/" ) );
 	}
 );
 
@@ -23,12 +23,14 @@ add_shortcode(
 	'pattern_draft_link',
 	function () {
 		$post_id = get_the_ID();
-		return add_query_arg(
-			array(
-				'action' => 'draft',
-				'_wpnonce' => wp_create_nonce( 'draft-' . $post_id ),
-			),
-			get_the_permalink()
+		return esc_url(
+			add_query_arg(
+				array(
+					'action' => 'draft',
+					'_wpnonce' => wp_create_nonce( 'draft-' . $post_id ),
+				),
+				get_the_permalink()
+			)
 		);
 	}
 );

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/frame/render.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/pattern-preview/frame/render.php
@@ -34,7 +34,7 @@ $encoded_state = wp_json_encode( $init_state );
 >
 	<div class="wp-block-wporg-pattern-preview__container">
 		<iframe
-			title="<?php esc_html_e( 'Pattern Preview', 'wporg-patterns' ); ?>"
+			title="<?php esc_attr_e( 'Pattern Preview', 'wporg-patterns' ); ?>"
 			tabIndex="-1"
 			src="<?php echo esc_url( $view_url ); ?>"
 			data-wp-style--width="state.iframeWidthCSS"

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/report-pattern/render.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/report-pattern/render.php
@@ -77,7 +77,7 @@ $reasons = get_terms( array(
 								<label
 									for="report-reason-<?php echo esc_attr( $reason->term_id ); ?>"
 								>
-									<?php echo esc_attr( $reason->name ); ?>
+									<?php echo esc_html( $reason->name ); ?>
 								</label>
 							<div>
 						<?php endforeach; ?>

--- a/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/status-notice/index.php
+++ b/public_html/wp-content/themes/wporg-pattern-directory-2024/src/blocks/status-notice/index.php
@@ -72,7 +72,7 @@ function render( $attributes, $content, $block ) {
 				$message .= sprintf(
 					'<p>%s %s</p>',
 					__( 'WordPress.org has removed your pattern from the directory for the following reason:', 'wporg-patterns' ),
-					$reason
+					wp_kses_post( $reason )
 				);
 			}
 			$message .= '<p>' . __( 'You can update your pattern to resubmit it for approval at any time.', 'wporg-patterns' ) . '</p>';


### PR DESCRIPTION
A small consistency pass across the pattern directory plugin and the 2024 theme. No behavior changes for normal use — mostly making output escaping and a couple of query paths match the conventions used elsewhere in the codebase.

### Changes

**Output escaping (context-appropriate helpers)**
- Admin flag row actions and pattern row actions now use `esc_url()` for link hrefs (were `esc_attr()` or unescaped).
- Theme link shortcodes (`pattern_edit_link`, `pattern_draft_link`) return `esc_url()`'d URLs.
- `report-pattern` block: term name printed as content uses `esc_html()`.
- `pattern-preview` frame: iframe `title` attribute uses `esc_attr_e()`.
- `status-notice` block: unlisted reason runs through `wp_kses_post()`, matching the equivalent REST field.
- Archive title block: title output uses `esc_html()` and the heading tag is constrained to `h1`–`h6`.

**Query handling**
- Pending-flags query: `orderby`/`order` normalized to known columns and `ASC`/`DESC`.
- Pattern REST query: the `allowed_blocks` filter is limited to well-formed block names before it's used.

**Translations**
- `BasicText` parser aligns its replacement handling with the `Heading`/`Paragraph` parsers.

### Notes
- `phpcs` passes clean (0 errors / 0 warnings) on all changed files; `php -l` clean.
- The `report-pattern` and `pattern-preview` `render.php` files are served from `build/`, so a `npm run build:theme` is needed for those two to take effect at runtime.