### PR TITLE
Pattern directory: scope front-end pattern capabilities to the creator UI

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-post-type.php
@@ -890,6 +890,10 @@ function get_block_pattern( $post ) {
  * @return array
  */
 function set_pattern_caps( $user_caps ) {
+	if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
+		return $user_caps;
+	}
+
 	// Set corresponding caps for all roles.
 	$cap_args = array(
 		'capability_type' => array( 'pattern', 'patterns' ),


### PR DESCRIPTION
`set_pattern_caps()` grants the front-end pattern capabilities to logged-in network users so the REST-based creator UI works without every user holding a role on the site. Those submissions are validated on `rest_pre_insert_wporg-pattern`.

This scopes the grant to that intended context: for XML-RPC requests the filter now returns the capabilities unchanged, so the front-end caps aren't provisioned outside the creator UI flow. No effect on the REST creator, wp-admin, or CLI paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)