### PR TITLE
CI: speed up workflows — run tests and linters directly on the runner

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -1,0 +1,25 @@
+name: "Setup Node dependencies"
+description: "Install Node and restore node_modules from cache, running npm ci only on a cache miss."
+
+runs:
+    using: "composite"
+    steps:
+        - name: Install Node
+          uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+          with:
+              node-version-file: ".nvmrc"
+
+        - name: Cache node_modules
+          id: node-modules-cache
+          uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+          with:
+              path: |
+                  node_modules
+                  public_html/wp-content/plugins/*/node_modules
+                  public_html/wp-content/themes/*/node_modules
+              key: node-modules-${{ runner.os }}-${{ hashFiles('.nvmrc', 'package-lock.json') }}
+
+        - name: Install dependencies
+          if: steps.node-modules-cache.outputs.cache-hit != 'true'
+          shell: bash
+          run: npm ci

--- a/.github/workflows/build-blocks.yml
+++ b/.github/workflows/build-blocks.yml
@@ -15,13 +15,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-            - name: Setup
-              uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
-              with:
-                packageManager: "npm"
-                token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Setup Node dependencies
+              uses: ./.github/actions/setup-node-deps
+
+            - name: Build
+              run: npm run build --workspaces --if-present
 
             - name: Remove build artifacts
               run: |

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,22 +5,43 @@ on:
     push:
         branches: [trunk]
     pull_request:
+    # Enable manually running action if necessary.
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-    check:
-        name: All
+    php:
+        name: PHP
 
         runs-on: ubuntu-latest
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-            - name: Setup
-              uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
-              with:
-                packageManager: "npm"
-                token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Install Composer dependencies
+              uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
 
-            - name: Lint
-              uses: WordPress/wporg-repo-tools/.github/actions/lint@trunk
+            - name: Lint PHP
+              run: composer run lint
+
+    js-css:
+        name: JS & CSS
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+            - name: Setup Node dependencies
+              uses: ./.github/actions/setup-node-deps
+
+            - name: Lint CSS
+              run: npm run lint:css --workspaces --if-present
+
+            - name: Lint JS
+              run: npm run lint:js --workspaces --if-present

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,7 +6,8 @@ on:
         paths:
             - public_html/**
             - .github/workflows/unit-tests.yml
-            - .wp-env.test.json
+            - .github/actions/**
+            - .github/wp-tests-config.php
             - composer.json
             - composer.lock
             - package.json
@@ -16,7 +17,8 @@ on:
         paths:
             - public_html/**
             - .github/workflows/unit-tests.yml
-            - .wp-env.test.json
+            - .github/actions/**
+            - .github/wp-tests-config.php
             - composer.json
             - composer.lock
             - package.json
@@ -24,32 +26,65 @@ on:
     # Enable manually running action if necessary.
     workflow_dispatch:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     unit-php:
         name: PHP
 
         runs-on: ubuntu-latest
 
+        env:
+            WP_CORE_DIR: /tmp/wordpress
+            WP_TESTS_DIR: /tmp/wordpress-develop/tests/phpunit
+
         steps:
             - name: Checkout repository
-              uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-            - name: Setup
-              uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
+            - name: Setup PHP
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
               with:
-                packageManager: "npm"
-                token: ${{ secrets.GITHUB_TOKEN }}
+                  php-version: "8.4"
+                  coverage: none
+
+            - name: Install Composer dependencies
+              uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
+
+            - name: Get date
+              id: date
+              run: echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+            # The test library must match the core build under test, so both come
+            # from current trunk: the nightly build as the install, and a sparse
+            # checkout of wordpress-develop for the PHPUnit library.
+            - name: Cache WordPress
+              id: wordpress-cache
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: |
+                      /tmp/wordpress
+                      /tmp/wordpress-develop
+                  key: wordpress-nightly-${{ steps.date.outputs.date }}
 
             - name: Install WordPress
+              if: steps.wordpress-cache.outputs.cache-hit != 'true'
               run: |
-                  chmod -R 767 ./ # TODO: Possibly integrate in wp-env
-                  npm run test:env -- start --update
-                  npm run test:env -- run cli wp core version
-                  npm run test:env -- run cli wp plugin list
+                  (curl -sSL https://wordpress.org/nightly-builds/wordpress-latest.zip -o /tmp/wordpress.zip && unzip -q /tmp/wordpress.zip -d /tmp) &
+                  (git clone --quiet --depth=1 --filter=blob:none --sparse https://github.com/WordPress/wordpress-develop /tmp/wordpress-develop && git -C /tmp/wordpress-develop sparse-checkout set tests/phpunit/includes tests/phpunit/data) &
+                  wait
+
+            - name: Start database
+              run: |
+                  sudo systemctl start mysql
+                  mysql -uroot -proot -h127.0.0.1 -e "CREATE DATABASE wordpress_test;"
 
             - name: Running multisite unit tests
-              run: npm run test:php
-              if: ${{ success() || failure() }}
+              env:
+                  WP_TESTS_CONFIG_FILE_PATH: ${{ github.workspace }}/.github/wp-tests-config.php
+              run: vendor/bin/phpunit -c public_html/wp-content/tests/phpunit/phpunit.xml
 
     unit-js:
         name: JS
@@ -58,13 +93,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-            - name: Setup
-              uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
-              with:
-                packageManager: "npm"
-                token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Setup Node dependencies
+              uses: ./.github/actions/setup-node-deps
 
             - name: Run unit tests on the pattern creator
-              run: npm run test:unit --workspace=wporg-pattern-creator 
+              run: npm run test:unit --workspace=wporg-pattern-creator

--- a/.github/wp-tests-config.php
+++ b/.github/wp-tests-config.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * WordPress test-suite configuration for CI.
+ *
+ * Used by the unit-tests workflow, which runs PHPUnit directly on the runner
+ * against a downloaded WordPress core build and the runner's MySQL service.
+ * Locations come from the environment so the workflow stays the single source
+ * of truth for paths.
+ *
+ * @package pattern-directory
+ */
+
+declare( strict_types = 1 );
+
+define( 'ABSPATH', rtrim( (string) getenv( 'WP_CORE_DIR' ), '/' ) . '/' );
+
+define( 'DB_NAME', (string) ( getenv( 'WP_DB_NAME' ) ?: 'wordpress_test' ) );
+define( 'DB_USER', (string) ( getenv( 'WP_DB_USER' ) ?: 'root' ) );
+define( 'DB_PASSWORD', (string) ( getenv( 'WP_DB_PASSWORD' ) ?: 'root' ) );
+define( 'DB_HOST', (string) ( getenv( 'WP_DB_HOST' ) ?: '127.0.0.1' ) );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+$table_prefix = 'wptests_'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+
+define( 'WP_PHP_BINARY', 'php' );
+define( 'WP_DEBUG', true );

--- a/public_html/wp-content/tests/phpunit/bootstrap.php
+++ b/public_html/wp-content/tests/phpunit/bootstrap.php
@@ -3,8 +3,17 @@
  * PHPUnit bootstrap file
  */
 
-// Require composer dependencies.
-require_once '/var/www/html/vendor/autoload.php';
+// Require composer dependencies: wp-env maps the repo's vendor dir to /var/www/html; on a plain host checkout it lives at the repo root.
+$_autoload_candidates = array(
+	'/var/www/html/vendor/autoload.php',
+	dirname( __DIR__, 4 ) . '/vendor/autoload.php',
+);
+foreach ( $_autoload_candidates as $_autoload ) {
+	if ( file_exists( $_autoload ) ) {
+		require_once $_autoload;
+		break;
+	}
+}
 
 // If we're running in WP's build directory, ensure that WP knows that, too.
 if ( 'build' === getenv( 'LOCAL_DIR' ) ) {
@@ -32,6 +41,11 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
+// The test library reads the config path from a constant; bridge the env var CI sets (wp-phpunit does the same).
+if ( getenv( 'WP_TESTS_CONFIG_FILE_PATH' ) && ! defined( 'WP_TESTS_CONFIG_FILE_PATH' ) ) {
+	define( 'WP_TESTS_CONFIG_FILE_PATH', getenv( 'WP_TESTS_CONFIG_FILE_PATH' ) );
+}
+
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 
@@ -39,6 +53,12 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugins() {
+	// The locale stand-in loads as an mu-plugin under wp-env; on a plain host checkout load it directly (its definitions are function_exists-guarded).
+	$_locales = dirname( __DIR__, 4 ) . '/.wp-env/wporg-locales.php';
+	if ( file_exists( $_locales ) ) {
+		require_once $_locales;
+	}
+
 	require dirname( dirname( __DIR__ ) ) . '/plugins/pattern-directory/bootstrap.php';
 	require dirname( dirname( __DIR__ ) ) . '/plugins/pattern-creator/pattern-creator.php';
 	require dirname( dirname( __DIR__ ) ) . '/plugins/pattern-translations/pattern-translations.php';


### PR DESCRIPTION
Nearly all CI time is setup, not work: on recent runs the JS test job spent ~4m05s installing to run 6s of Jest, and the PHP test job spent ~5m50s (repo-tools setup + a full wp-env Docker boot) to run 7s of PHPUnit. Inspired by WordPress/wporg-mu-plugins#756, this restructures the workflows so each job sets up only what its seconds of real work need.

## Changes

- **PHPUnit runs directly on the runner** — no wp-env, no Docker. The job downloads the nightly core build and a matching sparse, blob-filtered checkout of `wordpress-develop`'s test library (both cached with a daily key, ~20s cold and parallelized), starts the runner's bundled MySQL, and runs the multisite suite via a checked-in `.github/wp-tests-config.php`. Composer is cached via `ramsey/composer-install`.
  - The tests bootstrap now resolves the vendor autoloader on plain host checkouts (wp-env's `/var/www/html` mapping still wins in the container), loads the `.wp-env/wporg-locales.php` stand-in when it isn't mapped in as an mu-plugin, and bridges the `WP_TESTS_CONFIG_FILE_PATH` env var to the constant the test library reads — the same shim wp-phpunit provides. `npm run test:php` against the local wp-env test environment is unchanged and still passes (verified: 139 tests both ways).
- **`node_modules` is cached whole**, keyed on `package-lock.json` + `.nvmrc`, with `npm ci` only on a miss — via a new local composite action (`.github/actions/setup-node-deps`) shared by the JS test, JS/CSS lint, and build-blocks jobs. This retires the `wporg-repo-tools` setup action, which installed svn, ran cold `composer install` + `npm install`, and **built all three workspaces** even for jobs that never touch build output.
- **Linting split into parallel jobs**: PHP (Composer only — no Node at all) and JS/CSS (Node only — no Composer), instead of one job that installed everything.
- **PR concurrency cancellation**: pushing a fixup cancels the superseded run.
- **Actions pinned to current releases**, replacing the deprecated node16-era `actions/checkout` v3 pins.

## Measured impact (runs on this PR)

| Job | Before | Cold caches | Warm caches |
|---|---|---|---|
| Unit tests / PHP | ~5m58s | 40s | **43s** |
| Unit tests / JS | ~4m15s | 4m18s | **43s** |
| Lint / PHP | ~4m30s | 18s | **16s** |
| Lint / JS & CSS | ~4m30s | 4m21s | **44s** |

Cold runs only pay `npm ci` again when the lock file changes, plus the first daily WordPress-nightly download (~20s); every following run reuses the caches. The PHP jobs are fast even cold since they never install Node dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)