### PR TITLE
Pattern directory: Validate the fields the directory renders

### DIFF
--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -407,7 +407,7 @@ function validate_block_directives( $prepared_post, $request ) {
 		if ( content_has_block_directives( $prepared_post->$field ) ) {
 			return new \WP_Error(
 				'rest_pattern_interactivity_directive',
-				__( 'Pattern content contains interactivity directives, which are not allowed.', 'wporg-patterns' ),
+				__( 'Patterns cannot contain interactivity directives.', 'wporg-patterns' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
+++ b/public_html/wp-content/plugins/pattern-directory/includes/pattern-validation.php
@@ -398,16 +398,19 @@ function validate_block_directives( $prepared_post, $request ) {
 		return $prepared_post;
 	}
 
-	if ( ! isset( $prepared_post->post_content ) ) {
-		return $prepared_post;
-	}
+	// Every field the directory renders, not just the one the pattern editor writes.
+	foreach ( array( 'post_content', 'post_title', 'post_excerpt' ) as $field ) {
+		if ( ! isset( $prepared_post->$field ) ) {
+			continue;
+		}
 
-	if ( content_has_block_directives( $prepared_post->post_content ) ) {
-		return new \WP_Error(
-			'rest_pattern_interactivity_directive',
-			__( 'Pattern content contains interactivity directives, which are not allowed.', 'wporg-patterns' ),
-			array( 'status' => 400 )
-		);
+		if ( content_has_block_directives( $prepared_post->$field ) ) {
+			return new \WP_Error(
+				'rest_pattern_interactivity_directive',
+				__( 'Pattern content contains interactivity directives, which are not allowed.', 'wporg-patterns' ),
+				array( 'status' => 400 )
+			);
+		}
 	}
 
 	return $prepared_post;
@@ -841,6 +844,14 @@ function check_for_spam( $post ) {
  * @return boolean
  */
 function is_title_valid( $title ) {
+	if ( strip_shortcodes( $title ) !== $title || wp_strip_all_tags( $title ) !== $title ) {
+		return false;
+	}
+
+	if ( content_has_block_directives( $title ) ) {
+		return false;
+	}
+
 	// Check title against a list of disallowed words.
 	// Note the space after `test ` to avoid matching "testimonial".
 	$disallow_list = array( 'test ', 'testing', 'my pattern', 'wordpress', 'example' );

--- a/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
+++ b/public_html/wp-content/plugins/pattern-directory/tests/phpunit/pattern-title-validation-test.php
@@ -137,6 +137,18 @@ class Pattern_Title_Validation_Test extends WP_UnitTestCase {
 				'rest_pattern_invalid_title',
 				array_merge( $defaults, array( 'title' => 'Test' ) ),
 			),
+			array(
+				'rest_pattern_invalid_title',
+				array_merge( $defaults, array( 'title' => 'Quote [caption width="1" caption="x"]y[/caption]' ) ),
+			),
+			array(
+				'rest_pattern_invalid_title',
+				array_merge( $defaults, array( 'title' => 'Quote <span>markup</span>' ) ),
+			),
+			array(
+				'rest_pattern_interactivity_directive',
+				array_merge( $defaults, array( 'title' => 'Quote <span data-wp-interactive="x">y</span>' ) ),
+			),
 		);
 	}
 


### PR DESCRIPTION
`validate_block_directives()` scans `post_content` for Interactivity API attributes, and its docblock explains why kses cannot do that job. The field to scan is hard-coded, so the title and excerpt — which the directory renders the same way — are never checked.

`is_title_valid()` has the matching gap on the other side: it compares the title against a five-word disallow list, which says nothing about what the title contains.

- Scan `post_title` and `post_excerpt` for directives alongside `post_content`.
- Require a title to survive `strip_shortcodes()` and `wp_strip_all_tags()` unchanged, and to carry no directives, before the disallow list sees it.

The new checks run ahead of the disallow list, so the existing rejections keep their error codes.

## Testing steps

1. Submit a pattern titled `Example [caption width="1" caption="x"]y[/caption]`. It is rejected; on `trunk` it is accepted and stored intact.
2. Submit one titled `<span data-wp-interactive="x">Hi</span>`. Rejected.
3. `Default Paragraph`, `Testimonial` and `Stylized Quote and Citation` are still accepted; `Testing`, `My Pattern` and `Test` are still rejected with `rest_pattern_invalid_title`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
